### PR TITLE
ZGW Zaken api create zaak additional properties

### DIFF
--- a/.github/workflows/cicd_frontend.yml
+++ b/.github/workflows/cicd_frontend.yml
@@ -77,9 +77,9 @@ jobs:
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
           # replace special characters with -
-          SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/+|<>,;]/-/g' | tr '[:upper:]' '[:lower:]')
+          SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/+|<>,;_]/-/g' | tr '[:upper:]' '[:lower:]')
 
-          PROJECT_VERSION=$(cat gradle.properties | grep 'projectVersion=' | cut -d '=' -f 2)     
+          PROJECT_VERSION=$(cat gradle.properties | grep 'projectVersion=' | cut -d '=' -f 2)
           if [[ "$BRANCH_NAME" == rc-* ]]; then
               PROJECT_VERSION="${PROJECT_VERSION}-${SAFE_BRANCH_NAME}.${BUILD_NUMBER}"
           elif [[ "$BRANCH_NAME" == "next-minor" ]]; then

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -190,11 +190,11 @@ class ZakenApiPlugin(
         @PluginActionProperty plannedEndDate: String? = null,
         @PluginActionProperty finalDeliveryDate: String? = null,
         @PluginActionProperty explanation: String? = null,
-        @PluginActionProperty communicationChannel: URI? = null,
+        @PluginActionProperty communicationChannel: String? = null,
         @PluginActionProperty paymentIndication: String? = null,
         @PluginActionProperty caseGeometryType: String? = null,
         @PluginActionProperty caseGeometryCoordinates: String? = null,
-        @PluginActionProperty mainCase: URI? = null
+        @PluginActionProperty mainCase: String? = null
     ) {
         withLoggingContext(
             CATALOGI_API.ZAAKTYPE to zaaktypeUrl.toString()
@@ -210,10 +210,10 @@ class ZakenApiPlugin(
                 plannedEndDate = plannedEndDate?.let { LocalDate.parse(it) },
                 finalDeliveryDate = finalDeliveryDate?.let { LocalDate.parse(it) },
                 explanation = explanation,
-                communicationChannel = communicationChannel,
+                communicationChannel = communicationChannel?.let { URI.create(it) },
                 paymentIndication = paymentIndication?.let { Betalingsindicatie.create(it) },
                 caseGeometry = caseGeometry,
-                mainCase = mainCase
+                mainCase = mainCase?.let { URI.create(it) }
             )
 
             logger.info { "Zaak of zaaktype with URL '$zaaktypeUrl' created for document with id '$documentId'" }
@@ -385,7 +385,7 @@ class ZakenApiPlugin(
     ): Geometry? =
         if (geometryType != null && geometryCoordinates != null) {
             Geometry(
-                type = GeometryType.entries.find { it.key.uppercase() == geometryType.uppercase() }!!,
+                type = GeometryType.entries.find { it.key.equals(geometryType, ignoreCase = true) }!!,
                 coordinates = pluginService.getObjectMapper().readValue(geometryCoordinates)
             )
         } else {
@@ -1211,10 +1211,12 @@ class ZakenApiPlugin(
 
     companion object {
         private val logger = KotlinLogging.logger {}
+
         const val PLUGIN_KEY = "zakenapi"
         const val URL_PROPERTY = "url"
         const val RESOURCE_ID_PROCESS_VAR = "resourceId"
         const val DOCUMENT_URL_PROCESS_VAR = "documentUrl"
+
         fun findConfigurationByUrl(url: URI) = { properties: JsonNode ->
             url.toString().startsWith(properties[URL_PROPERTY].textValue())
         }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -189,19 +189,31 @@ class ZakenApiPlugin(
         @PluginActionProperty description: String? = null,
         @PluginActionProperty plannedEndDate: String? = null,
         @PluginActionProperty finalDeliveryDate: String? = null,
+        @PluginActionProperty explanation: String? = null,
+        @PluginActionProperty communicationChannel: URI? = null,
+        @PluginActionProperty paymentIndication: String? = null,
+        @PluginActionProperty caseGeometryType: String? = null,
+        @PluginActionProperty caseGeometryCoordinates: String? = null,
+        @PluginActionProperty mainCase: URI? = null
     ) {
         withLoggingContext(
             CATALOGI_API.ZAAKTYPE to zaaktypeUrl.toString()
         ) {
             val documentId = UUID.fromString(execution.businessKey)
+            val caseGeometry = geometryOrNullFrom(caseGeometryType , caseGeometryCoordinates)
 
             createZaak(
-                documentId,
-                rsin,
-                zaaktypeUrl,
-                description,
-                plannedEndDate?.let { LocalDate.parse(it) },
-                finalDeliveryDate?.let { LocalDate.parse(it) },
+                documentId = documentId,
+                rsin = rsin,
+                zaaktypeUrl = zaaktypeUrl,
+                description = description,
+                plannedEndDate = plannedEndDate?.let { LocalDate.parse(it) },
+                finalDeliveryDate = finalDeliveryDate?.let { LocalDate.parse(it) },
+                explanation = explanation,
+                communicationChannel = communicationChannel,
+                paymentIndication = paymentIndication?.let { Betalingsindicatie.create(it) },
+                caseGeometry = caseGeometry,
+                mainCase = mainCase
             )
 
             logger.info { "Zaak of zaaktype with URL '$zaaktypeUrl' created for document with id '$documentId'" }
@@ -215,6 +227,11 @@ class ZakenApiPlugin(
         description: String? = null,
         plannedEndDate: LocalDate? = null,
         finalDeliveryDate: LocalDate? = null,
+        explanation: String? = null,
+        communicationChannel: URI? = null,
+        paymentIndication: Betalingsindicatie? = null,
+        caseGeometry: Geometry? = null,
+        mainCase: URI? = null
     ) {
         withLoggingContext(
             CATALOGI_API.ZAAKTYPE to zaaktypeUrl.toString(),
@@ -238,11 +255,16 @@ class ZakenApiPlugin(
                 CreateZaakRequest(
                     bronorganisatie = rsin,
                     zaaktype = zaaktypeUrl,
+                    omschrijving = description,
                     verantwoordelijkeOrganisatie = rsin,
                     startdatum = startdatum,
                     uiterlijkeEinddatumAfdoening = uiterlijkeEinddatumAfdoening,
-                    omschrijving = description,
                     einddatumGepland = plannedEndDate,
+                    toelichting = explanation,
+                    communicatiekanaal = communicationChannel,
+                    betalingsindicatie = paymentIndication,
+                    zaakgeometrie = caseGeometry,
+                    hoofdzaak = mainCase
                 )
             )
 
@@ -284,14 +306,7 @@ class ZakenApiPlugin(
         @PluginActionProperty startDateRetentionPeriod: String? = null
     ) {
         val documentId = UUID.fromString(execution.businessKey)
-        val caseGeometry: Geometry? = if (caseGeometryType != null && caseGeometryCoordinates != null) {
-            Geometry(
-                type = GeometryType.entries.find { it.key.uppercase() == caseGeometryType.uppercase() }!!,
-                coordinates = pluginService.getObjectMapper().readValue(caseGeometryCoordinates)
-            )
-        } else {
-            null
-        }
+        val caseGeometry = geometryOrNullFrom(caseGeometryType , caseGeometryCoordinates)
 
         patchZaak(
             documentId = documentId,
@@ -363,6 +378,19 @@ class ZakenApiPlugin(
             logger.info { "Zaak with URL '${zaak.url}' patched successfully for document with id '$documentId''" }
         }
     }
+
+    private fun geometryOrNullFrom(
+        geometryType: String?,
+        geometryCoordinates: String?
+    ): Geometry? =
+        if (geometryType != null && geometryCoordinates != null) {
+            Geometry(
+                type = GeometryType.entries.find { it.key.uppercase() == geometryType.uppercase() }!!,
+                coordinates = pluginService.getObjectMapper().readValue(geometryCoordinates)
+            )
+        } else {
+            null
+        }
 
     @PluginAction(
         key = "create-natuurlijk-persoon-zaak-rol",

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/config/ZakenApiAutoConfiguration.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/config/ZakenApiAutoConfiguration.kt
@@ -21,14 +21,12 @@ import com.ritense.authorization.AuthorizationService
 import com.ritense.case_.listener.ZaakTypeLinkCaseEventListener
 import com.ritense.catalogiapi.service.CatalogiService
 import com.ritense.catalogiapi.service.ZaaktypeUrlProvider
-import com.ritense.document.service.DocumentService
 import com.ritense.documentenapi.service.DocumentenApiService
 import com.ritense.documentenapi.service.DocumentenApiVersionService
 import com.ritense.outbox.OutboxService
 import com.ritense.plugin.service.PluginService
 import com.ritense.processdocument.importer.ZaakTypeLinkImporter
 import com.ritense.processdocument.service.ProcessDefinitionCaseDefinitionService
-import com.ritense.processdocument.service.ProcessDocumentAssociationService
 import com.ritense.processdocument.service.ProcessDocumentService
 import com.ritense.resource.service.TemporaryResourceStorageService
 import com.ritense.temporaryresource.repository.ResourceStorageMetadataRepository
@@ -63,7 +61,6 @@ import com.ritense.zakenapi.service.ZakenApiEventListener
 import com.ritense.zakenapi.service.ZakenDocumentDeleteHandler
 import com.ritense.zakenapi.web.rest.DefaultZaakTypeLinkResource
 import com.ritense.zakenapi.web.rest.ZaakDocumentResource
-import kotlin.contracts.ExperimentalContracts
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -75,6 +72,7 @@ import org.springframework.core.annotation.Order
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.web.client.RestClient
+import kotlin.contracts.ExperimentalContracts
 
 @AutoConfiguration
 @EnableJpaRepositories(basePackages = ["com.ritense.zakenapi.repository"])
@@ -103,7 +101,7 @@ class ZakenApiAutoConfiguration {
     fun zakenApiPluginFactory(
         pluginService: PluginService,
         zakenApiClient: ZakenApiClient,
-        urlProvider: ZaakUrlProvider,
+        zaakUrlProvider: ZaakUrlProvider,
         storageService: TemporaryResourceStorageService,
         zaakInstanceLinkRepository: ZaakInstanceLinkRepository,
         zaakHersteltermijnRepository: ZaakHersteltermijnRepository,
@@ -113,7 +111,7 @@ class ZakenApiAutoConfiguration {
     ) = ZakenApiPluginFactory(
         pluginService,
         zakenApiClient,
-        urlProvider,
+        zaakUrlProvider,
         storageService,
         zaakInstanceLinkRepository,
         zaakHersteltermijnRepository,

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginFactoryTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginFactoryTest.kt
@@ -18,13 +18,11 @@ package com.ritense.zakenapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.ritense.document.service.DocumentService
 import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.domain.PluginDefinition
 import com.ritense.plugin.domain.PluginProperty
 import com.ritense.plugin.service.PluginService
-import com.ritense.processdocument.service.ProcessDocumentAssociationService
 import com.ritense.resource.service.TemporaryResourceStorageService
 import com.ritense.valtimo.contract.json.MapperSingleton
 import com.ritense.valueresolver.ValueResolverService

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -627,7 +627,7 @@ internal class ZakenApiPluginTest {
         val communicationChannel = communicationChannel()
         val paymentIndication = Betalingsindicatie.GEDEELTELIJK.key
         val caseGeometryType = GeometryType.POINT.key
-        val caseGeometryCoordinates = "[52.370216, 4.895168]"
+        val caseGeometryCoordinates = "[4.932921, 52.370085]"
         val mainCase = zaakUrl("123")
 
         whenever(executionMock.businessKey)

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -17,9 +17,7 @@
 package com.ritense.zakenapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ritense.document.service.DocumentService
 import com.ritense.plugin.service.PluginService
-import com.ritense.processdocument.service.ProcessDocumentAssociationService
 import com.ritense.resource.service.TemporaryResourceStorageService
 import com.ritense.valtimo.contract.json.MapperSingleton
 import com.ritense.valueresolver.ValueResolverService
@@ -40,7 +38,6 @@ import com.ritense.zakenapi.domain.UpdateZaakeigenschapRequest
 import com.ritense.zakenapi.domain.ZaakHersteltermijn
 import com.ritense.zakenapi.domain.ZaakInstanceLink
 import com.ritense.zakenapi.domain.ZaakObject
-import com.ritense.zakenapi.domain.zaakobjectrequest.ZaakObjectRequest
 import com.ritense.zakenapi.domain.ZaakResponse
 import com.ritense.zakenapi.domain.ZaakeigenschapResponse
 import com.ritense.zakenapi.domain.ZaakopschortingRequest
@@ -50,6 +47,7 @@ import com.ritense.zakenapi.domain.rol.RolNatuurlijkPersoon
 import com.ritense.zakenapi.domain.rol.RolNietNatuurlijkPersoon
 import com.ritense.zakenapi.domain.rol.RolOrganisatorischeEenheid
 import com.ritense.zakenapi.domain.rol.RolVestiging
+import com.ritense.zakenapi.domain.zaakobjectrequest.ZaakObjectRequest
 import com.ritense.zakenapi.repository.ZaakHersteltermijnRepository
 import com.ritense.zakenapi.repository.ZaakInstanceLinkRepository
 import com.ritense.zgw.Page
@@ -554,7 +552,67 @@ internal class ZakenApiPluginTest {
     }
 
     @Test
-    fun `should create zaak`() {
+    fun `should create zaak with required properties only`() {
+        val zakenApiClient: ZakenApiClient = mock()
+        val executionMock = mock<DelegateExecution>()
+        val authenticationMock = mock<ZakenApiAuthentication>()
+
+        val documentId = UUID.randomUUID()
+        val rsin = Rsin("051845623")
+        val zaaktypeUrl = zaaktypeUri()
+
+        whenever(executionMock.businessKey)
+            .thenReturn(documentId.toString())
+
+        whenever(
+            zakenApiClient.createZaak(
+                authentication = eq(authenticationMock),
+                baseUrl = eq(zakenApiUri()),
+                request = any()
+            )
+        ).thenReturn(
+            ZaakResponse(
+                url = zaakUri(),
+                uuid = UUID.randomUUID(),
+                zaaktype = zaaktypeUrl,
+                bronorganisatie = rsin,
+                startdatum = LocalDate.now(),
+                verantwoordelijkeOrganisatie = rsin,
+            )
+        )
+
+        val plugin = zakenApiPlugin(
+            zakenApiClient = zakenApiClient,
+            authenticationMock = authenticationMock,
+            pluginService = pluginServiceMock()
+        )
+
+        plugin.createZaak(
+            execution = executionMock,
+            rsin = rsin,
+            zaaktypeUrl = zaaktypeUrl
+        )
+
+        val captor = argumentCaptor<CreateZaakRequest>()
+        verify(zakenApiClient).createZaak(any(), any(), captor.capture())
+
+        val request = captor.firstValue
+        assertThat(request.bronorganisatie).isEqualTo(rsin)
+        assertThat(request.zaaktype).isEqualTo(zaaktypeUrl)
+        assertThat(request.verantwoordelijkeOrganisatie).isEqualTo(rsin)
+        assertThat(request.startdatum).isNotNull()
+        assertThat(request.omschrijving).isNull()
+        assertThat(request.einddatumGepland).isNull()
+        assertThat(request.toelichting).isNull()
+        assertThat(request.uiterlijkeEinddatumAfdoening).isNull()
+        assertThat(request.communicatiekanaal).isNull()
+        assertThat(request.betalingsindicatie).isNull()
+        assertThat(request.zaakgeometrie).isNull()
+        assertThat(request.hoofdzaak).isNull()
+    }
+
+    @Test
+    fun `should create zaak with additional properties`() {
         val zakenApiClient: ZakenApiClient = mock()
         val executionMock = mock<DelegateExecution>()
         val authenticationMock = mock<ZakenApiAuthentication>()

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -564,13 +565,21 @@ internal class ZakenApiPluginTest {
         val description = "Omschrijving"
         val plannedEndDate = LocalDate.now().plusDays(10)
         val finalDeliveryDate = null
+        val explanation = "Toelichting"
+        val communicationChannel = communicationChannel()
+        val paymentIndication = Betalingsindicatie.GEDEELTELIJK.key
+        val caseGeometryType = GeometryType.POINT.key
+        val caseGeometryCoordinates = "[52.370216, 4.895168]"
+        val mainCase = zaakUrl("123")
 
-        whenever(executionMock.businessKey).thenReturn(documentId.toString())
+        whenever(executionMock.businessKey)
+            .thenReturn(documentId.toString())
+
         whenever(
             zakenApiClient.createZaak(
-                eq(authenticationMock),
-                eq(zakenApiUri()),
-                any()
+                authentication = eq(authenticationMock),
+                baseUrl = eq(zakenApiUri()),
+                request = any()
             )
         ).thenReturn(
             ZaakResponse(
@@ -585,28 +594,41 @@ internal class ZakenApiPluginTest {
 
         val plugin = zakenApiPlugin(
             zakenApiClient = zakenApiClient,
-            authenticationMock = authenticationMock
+            authenticationMock = authenticationMock,
+            pluginService = pluginServiceMock()
         )
 
         plugin.createZaak(
-            executionMock,
-            rsin,
-            zaaktypeUrl,
-            description,
-            plannedEndDate.toString(),
-            finalDeliveryDate
+            execution = executionMock,
+            rsin = rsin,
+            zaaktypeUrl = zaaktypeUrl,
+            description = description,
+            plannedEndDate = plannedEndDate.toString(),
+            finalDeliveryDate = finalDeliveryDate,
+            explanation = explanation,
+            communicationChannel = communicationChannel,
+            paymentIndication = paymentIndication,
+            caseGeometryType = caseGeometryType,
+            caseGeometryCoordinates = caseGeometryCoordinates,
+            mainCase = mainCase
         )
 
         val captor = argumentCaptor<CreateZaakRequest>()
         verify(zakenApiClient).createZaak(any(), any(), captor.capture())
 
         val request = captor.firstValue
-        assertEquals(rsin, request.bronorganisatie)
-        assertEquals(zaaktypeUrl, request.zaaktype)
-        assertEquals(rsin, request.verantwoordelijkeOrganisatie)
-        assertNotNull(request.startdatum)
-        assertEquals(description, request.omschrijving)
-        assertEquals(plannedEndDate, request.einddatumGepland)
+        assertThat(request.bronorganisatie).isEqualTo(rsin)
+        assertThat(request.zaaktype).isEqualTo(zaaktypeUrl)
+        assertThat(request.verantwoordelijkeOrganisatie).isEqualTo(rsin)
+        assertThat(request.startdatum).isNotNull()
+        assertThat(request.omschrijving).isEqualTo(description)
+        assertThat(request.einddatumGepland).isEqualTo(plannedEndDate)
+        assertThat(request.toelichting).isEqualTo(explanation)
+        assertThat(request.uiterlijkeEinddatumAfdoening).isNull()
+        assertThat(request.communicatiekanaal).isEqualTo(URI.create(communicationChannel))
+        assertThat(request.betalingsindicatie).isEqualTo(Betalingsindicatie.GEDEELTELIJK)
+        assertThat(request.zaakgeometrie).isEqualTo(Geometry(GeometryType.POINT, listOf(52.370216F, 4.895168F)))
+        assertThat(request.hoofdzaak).isEqualTo(URI.create(mainCase))
     }
 
     @Test
@@ -615,10 +637,6 @@ internal class ZakenApiPluginTest {
         val zaakInstanceLinkRepository: ZaakInstanceLinkRepository = mock()
         val executionMock: DelegateExecution = mock()
         val authenticationMock: ZakenApiAuthentication = mock()
-        val pluginService: PluginService = mock()
-
-        whenever(pluginService.getObjectMapper())
-            .thenReturn(MapperSingleton.get())
 
         val documentId = UUID.fromString("dff80fb1-e24e-4287-b168-7bb199be5d58")
         val zaakId = "f18146df-4b26-4a32-8e52-122cfa4475bd"
@@ -628,7 +646,7 @@ internal class ZakenApiPluginTest {
 
         val description = "Omschrijving"
         val explantation = "Toelichting"
-        val communicationChannel = "https://example.com/comminicatiekanaal/example"
+        val communicationChannel = communicationChannel()
         val communicationChannelName = "Communicatiekanaal Naam"
         val nowDate = LocalDate.parse("2025-07-23")
         val plannedEndDate = nowDate.plusMonths(10).toString()
@@ -666,7 +684,7 @@ internal class ZakenApiPluginTest {
             zakenApiClient = zakenApiClient,
             zaakInstanceLinkRepository = zaakInstanceLinkRepository,
             authenticationMock = authenticationMock,
-            pluginService = pluginService
+            pluginService = pluginServiceMock()
         )
 
         plugin.patchZaak(
@@ -1208,6 +1226,10 @@ internal class ZakenApiPluginTest {
         }
     }
 
+    private fun pluginServiceMock(): PluginService = mock {
+        on { this.getObjectMapper()  } doReturn MapperSingleton.get()
+    }
+
     private fun zakenApiUrl() = "https://zaken.plugin.url"
     private fun zakenApiUri() = URI(zakenApiUrl())
 
@@ -1233,4 +1255,6 @@ internal class ZakenApiPluginTest {
     private fun objectUri() = URI(objectUrl())
 
     private fun documentUrl() = "https://document.url"
+
+    private fun communicationChannel() = "https://example.com/comminicatiekanaal/example"
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZakenApiEventListenerTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZakenApiEventListenerTest.kt
@@ -61,72 +61,115 @@ class ZakenApiEventListenerTest {
     fun `should create zaak on DocumentCreatedEvent when zakenApiPluginConfigurationId is set`() {
         val pluginId = PluginConfigurationId.existingId(UUID.randomUUID())
         val zaakTypeLink = ZaakTypeLink(
-            ZaakTypeLinkId.newId(UUID.randomUUID()),
-            caseDefinitionId,
-            URI("http://some-url"),
-            true,
-            pluginId.id,
-            mock()
+            zaakTypeLinkId = ZaakTypeLinkId.newId(UUID.randomUUID()),
+            caseDefinitionId = caseDefinitionId,
+            zaakTypeUrl = URI("http://some-url"),
+            createWithDossier = true,
+            zakenApiPluginConfigurationId = pluginId.id,
+            rsin = mock()
         )
 
         val event = setupDocumentCreatedRequest()
         val zakenApiPlugin = mock<ZakenApiPlugin>()
         val documentId = mock<Document.Id>()
 
-        whenever(zaakTypeLinkService.get(any())).thenReturn(zaakTypeLink)
-        whenever(pluginService.createInstance<ZakenApiPlugin>(any<UUID>())).thenReturn(zakenApiPlugin)
-        whenever(event.documentId()).thenReturn(documentId)
-        whenever(documentId.id).thenReturn(UUID.randomUUID())
+        whenever(zaakTypeLinkService.get(any()))
+            .thenReturn(zaakTypeLink)
+        whenever(pluginService.createInstance<ZakenApiPlugin>(any<UUID>()))
+            .thenReturn(zakenApiPlugin)
+        whenever(event.documentId())
+            .thenReturn(documentId)
+        whenever(documentId.id)
+            .thenReturn(UUID.randomUUID())
 
         zakenApiEventListener.handle(event)
 
-        verify(zakenApiPlugin).createZaak(any<UUID>(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
+        verify(zakenApiPlugin).createZaak(
+            documentId = any<UUID>(),
+            rsin = any(),
+            zaaktypeUrl = any(),
+            description = anyOrNull(),
+            plannedEndDate = anyOrNull(),
+            finalDeliveryDate = anyOrNull(),
+            explanation = anyOrNull(),
+            communicationChannel = anyOrNull(),
+            paymentIndication = anyOrNull(),
+            caseGeometry = anyOrNull(),
+            mainCase = anyOrNull()
+        )
     }
 
     @Test
     fun `should not create zaak on DocumentCreatedEvent when zakenApiPluginConfigurationId is null`() {
-        val pluginId = PluginConfigurationId.existingId(UUID.randomUUID())
         val zaakTypeLink = ZaakTypeLink(
-            ZaakTypeLinkId.newId(UUID.randomUUID()),
-            caseDefinitionId,
-            URI("http://some-url"),
-            true,
-            null,
-            mock()
+            zaakTypeLinkId = ZaakTypeLinkId.newId(UUID.randomUUID()),
+            caseDefinitionId = caseDefinitionId,
+            zaakTypeUrl = URI("http://some-url"),
+            createWithDossier = true,
+            zakenApiPluginConfigurationId = null,
+            rsin = mock()
         )
 
         val event = setupDocumentCreatedRequest()
         val zakenApiPlugin = mock<ZakenApiPlugin>()
 
-        whenever(zaakTypeLinkService.get(any())).thenReturn(zaakTypeLink)
-        whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(zakenApiPlugin)
+        whenever(zaakTypeLinkService.get(any()))
+            .thenReturn(zaakTypeLink)
+        whenever(pluginService.createInstance(any<PluginConfigurationId>()))
+            .thenReturn(zakenApiPlugin)
 
         zakenApiEventListener.handle(event)
 
-        verify(zakenApiPlugin, never()).createZaak(any<UUID>(), any(), any(), any(), any(), any())
+        verify(zakenApiPlugin, never()).createZaak(
+            documentId = any<UUID>(),
+            rsin = any(),
+            zaaktypeUrl = any(),
+            description = anyOrNull(),
+            plannedEndDate = anyOrNull(),
+            finalDeliveryDate = anyOrNull(),
+            explanation = anyOrNull(),
+            communicationChannel = anyOrNull(),
+            paymentIndication = anyOrNull(),
+            caseGeometry = anyOrNull(),
+            mainCase = anyOrNull()
+        )
     }
 
     @Test
     fun `should not create zaak on DocumentCreatedEvent when createWithDossier is false`() {
         val pluginId = PluginConfigurationId.existingId(UUID.randomUUID())
         val zaakTypeLink = ZaakTypeLink(
-            ZaakTypeLinkId.newId(UUID.randomUUID()),
-            caseDefinitionId,
-            URI("http://some-url"),
-            false,
-            pluginId.id,
-            mock()
+            zaakTypeLinkId = ZaakTypeLinkId.newId(UUID.randomUUID()),
+            caseDefinitionId = caseDefinitionId,
+            zaakTypeUrl = URI("http://some-url"),
+            createWithDossier = false,
+            zakenApiPluginConfigurationId = pluginId.id,
+            rsin = mock()
         )
 
         val event = setupDocumentCreatedRequest()
         val zakenApiPlugin = mock<ZakenApiPlugin>()
 
-        whenever(zaakTypeLinkService.get(any())).thenReturn(zaakTypeLink)
-        whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(zakenApiPlugin)
+        whenever(zaakTypeLinkService.get(any()))
+            .thenReturn(zaakTypeLink)
+        whenever(pluginService.createInstance(any<PluginConfigurationId>()))
+            .thenReturn(zakenApiPlugin)
 
         zakenApiEventListener.handle(event)
 
-        verify(zakenApiPlugin, never()).createZaak(any<UUID>(), any(), any(), any(), any(), any())
+        verify(zakenApiPlugin, never()).createZaak(
+            documentId = any<UUID>(),
+            rsin = any(),
+            zaaktypeUrl = any(),
+            description = anyOrNull(),
+            plannedEndDate = anyOrNull(),
+            finalDeliveryDate = anyOrNull(),
+            explanation = anyOrNull(),
+            communicationChannel = anyOrNull(),
+            paymentIndication = anyOrNull(),
+            caseGeometry = anyOrNull(),
+            mainCase = anyOrNull()
+        )
     }
 
     @EventListener(DocumentCreatedEvent::class)
@@ -149,15 +192,16 @@ class ZakenApiEventListenerTest {
         val zaakTypeLinkCaptor = argumentCaptor<ZaakTypeLink>()
 
         val zaakTypeLink = ZaakTypeLink(
-            ZaakTypeLinkId.newId(UUID.randomUUID()),
-            caseDefinitionId,
-            URI("http://some-url"),
-            true,
-            pluginId.id,
-            mock()
+            zaakTypeLinkId = ZaakTypeLinkId.newId(UUID.randomUUID()),
+            caseDefinitionId = caseDefinitionId,
+            zaakTypeUrl = URI("http://some-url"),
+            createWithDossier = true,
+            zakenApiPluginConfigurationId = pluginId.id,
+            rsin = mock()
         )
 
-        whenever(zaakTypeLinkService.getByPluginConfigurationId(any())).thenReturn(listOf(zaakTypeLink))
+        whenever(zaakTypeLinkService.getByPluginConfigurationId(any()))
+            .thenReturn(listOf(zaakTypeLink))
 
         zakenApiEventListener.handle(event)
 
@@ -184,7 +228,8 @@ class ZakenApiEventListenerTest {
             mock()
         )
 
-        whenever(zaakTypeLinkService.getByPluginConfigurationId(any())).thenReturn(listOf(zaakTypeLink))
+        whenever(zaakTypeLinkService.getByPluginConfigurationId(any()))
+            .thenReturn(listOf(zaakTypeLink))
 
         zakenApiEventListener.handle(event)
 
@@ -197,10 +242,14 @@ class ZakenApiEventListenerTest {
     private fun setupDocumentCreatedRequest(): DocumentCreatedEvent {
         val event = mock<DocumentCreatedEvent>()
         val idMock = mock<DocumentDefinition.Id>()
-        whenever(event.definitionId()).thenReturn(idMock)
-        whenever(idMock.caseDefinitionId()).thenReturn(caseDefinitionId)
-        whenever(idMock.name()).thenReturn("test")
-        whenever(idMock.caseDefinitionId()).thenReturn(caseDefinitionId)
+        whenever(event.definitionId())
+            .thenReturn(idMock)
+        whenever(idMock.caseDefinitionId())
+            .thenReturn(caseDefinitionId)
+        whenever(idMock.name())
+            .thenReturn("test")
+        whenever(idMock.caseDefinitionId())
+            .thenReturn(caseDefinitionId)
         return event
     }
 }

--- a/frontend/projects/valtimo/components/src/lib/components/input/input.component.html
+++ b/frontend/projects/valtimo/components/src/lib/components/input/input.component.html
@@ -185,8 +185,9 @@
     }"
     class="v-input--preset-options">
     <span>{{ presetsTitle }}:</span>
-    @for (preset of presetOptions; track $index; let isFirst = $first) {
-      @if (!isFirst) { | }
+
+    @for (preset of presetOptions; track $index) {
+      @if (!$first) { | }
       <a (click)="presetWithValue(preset)" class="v-input--preset-option">{{ preset }}</a>
     }
   </div>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -16,30 +16,29 @@
 
 <ng-container
   *ngIf="{
-    disabled: disabled$ | async,
-    prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
-    pluginId: pluginId$ | async,
-    selectedInputOption: selectedInputOption$ | async,
-    zaakTypeSelectItems: zaakTypeItems$ | async,
-    loading: loading$ | async,
     context: context$ | async,
+    disabled: disabled$ | async,
+    loading: loading$ | async,
+    prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
+    selectedInputOption: selectedInputOption$ | async,
+    zaakTypeSelectItems: zaakTypeItems$ | async
   } as obs"
 >
   <ng-container *ngIf="obs.loading === false; else loading">
     <v-paragraph [margin]="true" [italic]="true">
-      {{ 'createZaakInformation' | pluginTranslate: obs.pluginId | async }}
+      {{ 'createZaakInformation' | pluginTranslate: pluginId | async }}
     </v-paragraph>
 
     <v-form (valueChange)="onFormValueChanged($event)">
       <v-input
         name="rsin"
-        [title]="'rsin' | pluginTranslate: obs.pluginId | async"
-        [tooltip]="'rsinTooltip' | pluginTranslate: obs.pluginId | async"
+        [title]="'rsin' | pluginTranslate: pluginId | async"
+        [tooltip]="'rsinTooltip' | pluginTranslate: pluginId | async"
         [defaultValue]="obs.prefill?.rsin"
-        [margin]="true"
+        [disabled]="obs.disabled"
         [required]="true"
         [trim]="true"
-        [disabled]="obs.disabled"
+        [margin]="true"
         [widthPx]="350"
       >
       </v-input>
@@ -47,61 +46,61 @@
       <v-radio
         *ngIf="obs?.context?.[0] === 'case'"
         name="inputTypeZaakTypeToggle"
-        [disabled]="obs.disabled"
-        [title]="'inputTypeZaakTypeToggle' | pluginTranslate: obs.pluginId | async"
+        [title]="'inputTypeZaakTypeToggle' | pluginTranslate: pluginId | async"
         [defaultValue]="selectedInputOption$ | async"
-        [margin]="true"
         [radioValues]="inputTypeOptions$ | async"
+        [disabled]="obs.disabled"
+        [margin]="true"
       >
       </v-radio>
 
       <v-input
         *ngIf="obs.selectedInputOption === 'text'"
         name="zaaktypeUrl"
-        [title]="'zaakTypeUrl' | pluginTranslate: obs.pluginId | async"
-        [tooltip]="'zaakTypeTooltip' | pluginTranslate: obs.pluginId | async"
+        [title]="'zaakTypeUrl' | pluginTranslate: pluginId | async"
+        [tooltip]="'zaakTypeTooltip' | pluginTranslate: pluginId | async"
         [defaultValue]="obs.prefill?.zaaktypeUrl"
         [disabled]="obs.disabled || obs.selectedInputOption === 'selection'"
-        [margin]="true"
         [required]="true"
         [trim]="true"
-        [fullWidth]="true"
+        [margin]="true"
+        [widthPx]="700"
       >
       </v-input>
 
-      <ng-container *ngIf="obs.selectedInputOption === 'selection'">
-        <v-select
-          name="zaaktypeUrl"
-          [title]="'zaakType' | pluginTranslate: obs.pluginId | async"
-          [tooltip]="'zaakTypeSelectTooltip' | pluginTranslate: obs.pluginId | async"
-          [margin]="true"
-          [required]="true"
-          [items]="obs.zaakTypeSelectItems"
-          [widthInPx]="350"
-          [disabled]="
-            obs.disabled ||
-            obs.selectedInputOption === 'text' ||
-            oneSelectItem(obs.zaakTypeSelectItems)
-          "
-          [defaultSelectionId]="
-            (selectItemsIncludeId(obs.zaakTypeSelectItems, obs.prefill?.zaaktypeUrl) &&
-              obs.prefill?.zaaktypeUrl) ||
-            (oneSelectItem(obs.zaakTypeSelectItems) && obs.zaakTypeSelectItems[0].id)
-          "
-          [loading]="!obs.zaakTypeSelectItems"
-        ></v-select>
-      </ng-container>
+      <v-select
+        *ngIf="obs.selectedInputOption === 'selection'"
+        name="zaaktypeUrl"
+        [title]="'zaakType' | pluginTranslate: pluginId | async"
+        [tooltip]="'zaakTypeSelectTooltip' | pluginTranslate: pluginId | async"
+        [required]="true"
+        [items]="obs.zaakTypeSelectItems"
+        [loading]="!obs.zaakTypeSelectItems"
+        [disabled]="
+          obs.disabled ||
+          obs.selectedInputOption === 'text' ||
+          oneSelectItem(obs.zaakTypeSelectItems)
+        "
+        [margin]="true"
+        [defaultSelectionId]="
+          (selectItemsIncludeId(obs.zaakTypeSelectItems, obs.prefill?.zaaktypeUrl) && obs.prefill?.zaaktypeUrl)
+          ||
+          (oneSelectItem(obs.zaakTypeSelectItems) && obs.zaakTypeSelectItems[0].id)
+        "
+        [widthInPx]="350"
+      ></v-select>
 
       <div class="row">
         <div class="col-12">
           <button
             cdsButton="primary"
+            class="add-button"
             [size]="'md'"
             [cdsOverflowMenu]="addCasePropertyList"
             [customPane]="true"
             placement="bottom"
           >
-            {{ 'addZaakProperty' | pluginTranslate: obs.pluginId | async }}
+            {{ 'addZaakProperty' | pluginTranslate: pluginId | async }}
             <svg class="cds--btn__icon" cdsIcon="add" size="16"></svg>
           </button>
         </div>
@@ -114,58 +113,60 @@
               <v-input
                 [name]="CASE_GEOMETRY_TYPE"
                 [title]="translationKeyFor(CASE_GEOMETRY_TYPE) | pluginTranslate: pluginId | async"
-                [required]="true"
                 [defaultValue]="prefillValueFor(CASE_GEOMETRY_TYPE, obs.prefill)"
-                [margin]="false"
                 (valueChange)="onPropertyChanged(CASE_GEOMETRY_TYPE, $event)"
                 [dataTestId]="dataTestIdFor(CASE_GEOMETRY_TYPE)"
+                [required]="true"
+                [margin]="false"
               />
-              <div class="presets">
-                  <span>Presets:</span>
-                  <ng-template ngFor let-preset [ngForOf]="geometryTypes" let-isFirst="first">
-                      <ng-template [ngIf]="!isFirst"> | </ng-template><a (click)="presetPropertyWithValue(CASE_GEOMETRY_TYPE, preset)" class="preset">{{ preset }}</a>
-                  </ng-template>
-              </div>
+              <ng-container
+                [ngTemplateOutlet]="presets"
+                [ngTemplateOutletContext]="{
+                  property: CASE_GEOMETRY_TYPE,
+                  presetOptions: geometryTypes
+                }">
+              </ng-container>
             } @else if (property === CASE_GEOMETRY_COORDINATES) {
               <v-input
                 [name]="CASE_GEOMETRY_COORDINATES"
                 [title]="translationKeyFor(CASE_GEOMETRY_COORDINATES) | pluginTranslate: pluginId | async"
                 [tooltip]="translationKeyFor(`${CASE_GEOMETRY_COORDINATES}Tooltip`) | pluginTranslate: pluginId | async"
-                [required]="true"
                 [defaultValue]="prefillValueFor(CASE_GEOMETRY_COORDINATES, obs.prefill)"
-                [margin]="true"
                 (valueChange)="onPropertyChanged(CASE_GEOMETRY_COORDINATES, $event)"
+                [required]="true"
+                [margin]="true"
               />
             } @else if (property.includes('Date')) {
               <v-input
                 [name]="property"
                 [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
                 [tooltip]="'dateformatTooltip' | pluginTranslate: pluginId | async"
-                [required]="true"
                 [defaultValue]="prefillValueFor(property, obs.prefill)"
-                [margin]="true"
-                [trim]="true"
                 (valueChange)="onPropertyChanged(property, $event)"
                 [dataTestId]="dataTestIdFor(property)"
+                [required]="true"
+                [margin]="true"
+                [trim]="true"
               ></v-input>
             } @else {
               <v-input
                 [name]="property"
                 [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
-                [required]="true"
                 [defaultValue]="prefillValueFor(property, obs.prefill)"
-                [margin]="(property !== PAYMENT_INDICATION_TYPE)"
-                [trim]="true"
                 (valueChange)="onPropertyChanged(property, $event)"
                 [dataTestId]="dataTestIdFor(property)"
+                [required]="true"
+                [margin]="(property !== PAYMENT_INDICATION_TYPE)"
+                [trim]="true"
               />
               @if (property === PAYMENT_INDICATION_TYPE) {
-                <div class="presets">
-                  <span>Presets:</span>
-                  <ng-template ngFor let-preset [ngForOf]="paymentIndicationTypes" let-isFirst="first">
-                      <ng-template [ngIf]="!isFirst"> | </ng-template><a (click)="presetPropertyWithValue(PAYMENT_INDICATION_TYPE, preset)" class="preset">{{ preset }}</a>
-                  </ng-template>
-                </div>
+                <ng-container
+                  [ngTemplateOutlet]="presets"
+                  [ngTemplateOutletContext]="{
+                    property: PAYMENT_INDICATION_TYPE,
+                    presetOptions: paymentIndicationTypes
+                  }">
+                </ng-container>
               }
             }
           </div>
@@ -192,11 +193,23 @@
 
 <ng-template #addCasePropertyList>
   @for (propertyOption of propertyOptions; track propertyOption) {
-    <cds-overflow-menu-option
-      *ngIf="!hasPropertyBeenAdded(propertyOption)"
-      (click)="addProperty(propertyOption)"
-    >
-      {{ translationKeyForPropertyList(propertyOption) | pluginTranslate: (pluginId$ | async) | async }}
-    </cds-overflow-menu-option>
+    @if (propertyOption !== CASE_GEOMETRY_COORDINATES) {
+      <cds-overflow-menu-option
+        *ngIf="!hasPropertyBeenAdded(propertyOption)"
+        (click)="addProperty(propertyOption)"
+      >
+        {{ translationKeyForPropertyList(propertyOption) | pluginTranslate: pluginId | async }}
+      </cds-overflow-menu-option>
+    }
   }
+</ng-template>
+
+<ng-template #presets let-property="property" let-presetOptions="presetOptions">
+  <div class="presets">
+      <span>Presets:</span>
+      @for (preset of presetOptions; track $index; let isFirst = $first) {
+        @if (!isFirst) { | }
+        <a (click)="presetPropertyWithValue(property, preset)" class="preset">{{ preset }}</a>
+      }
+  </div>
 </ng-template>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -109,48 +109,42 @@
       @for (property of propertyList; track property) {
         <div class="row">
           <div class="col-11">
-            @if (property === CASE_GEOMETRY_TYPE) {
-              <v-input
-                [name]="CASE_GEOMETRY_TYPE"
-                [title]="translationKeyFor(CASE_GEOMETRY_TYPE) | pluginTranslate: pluginId | async"
-                [defaultValue]="prefillValueFor(CASE_GEOMETRY_TYPE, obs.prefill)"
-                (valueChange)="onPropertyChanged(CASE_GEOMETRY_TYPE, $event)"
-                [required]="true"
-                [margin]="true"
-                [presetOptions]="geometryTypes"
-              />
-            } @else if (property === CASE_GEOMETRY_COORDINATES) {
-              <v-input
-                [name]="CASE_GEOMETRY_COORDINATES"
-                [title]="translationKeyFor(CASE_GEOMETRY_COORDINATES) | pluginTranslate: pluginId | async"
-                [tooltip]="translationKeyFor(`${CASE_GEOMETRY_COORDINATES}Tooltip`) | pluginTranslate: pluginId | async"
-                [defaultValue]="prefillValueFor(CASE_GEOMETRY_COORDINATES, obs.prefill)"
-                (valueChange)="onPropertyChanged(CASE_GEOMETRY_COORDINATES, $event)"
-                [required]="true"
-                [margin]="true"
-              />
-            } @else if (property.includes('Date')) {
-              <v-input
-                [name]="property"
-                [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
-                [tooltip]="'dateformatTooltip' | pluginTranslate: pluginId | async"
-                [defaultValue]="prefillValueFor(property, obs.prefill)"
-                (valueChange)="onPropertyChanged(property, $event)"
-                [required]="true"
-                [margin]="true"
-                [trim]="true"
-              ></v-input>
-            } @else {
-              <v-input
-                [name]="property"
-                [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
-                [defaultValue]="prefillValueFor(property, obs.prefill)"
-                (valueChange)="onPropertyChanged(property, $event)"
-                [required]="true"
-                [margin]="true"
-                [trim]="true"
-                [presetOptions]="property === PAYMENT_INDICATION_TYPE ? paymentIndicationTypes : []"
-              />
+            @switch (property) {
+              @case (CASE_GEOMETRY_TYPE) {
+                <v-input
+                  [name]="CASE_GEOMETRY_TYPE"
+                  [title]="translationKeyFor(CASE_GEOMETRY_TYPE) | pluginTranslate: pluginId | async"
+                  [defaultValue]="prefillValueFor(CASE_GEOMETRY_TYPE, obs.prefill)"
+                  (valueChange)="onPropertyChanged(CASE_GEOMETRY_TYPE, $event)"
+                  [required]="true"
+                  [margin]="true"
+                  [presetOptions]="geometryTypes"
+                />
+              }
+              @case (CASE_GEOMETRY_COORDINATES) {
+                <v-input
+                  [name]="CASE_GEOMETRY_COORDINATES"
+                  [title]="translationKeyFor(CASE_GEOMETRY_COORDINATES) | pluginTranslate: pluginId | async"
+                  [tooltip]="translationKeyFor(`${CASE_GEOMETRY_COORDINATES}Tooltip`) | pluginTranslate: pluginId | async"
+                  [defaultValue]="prefillValueFor(CASE_GEOMETRY_COORDINATES, obs.prefill)"
+                  (valueChange)="onPropertyChanged(CASE_GEOMETRY_COORDINATES, $event)"
+                  [required]="true"
+                  [margin]="true"
+                />
+              }
+              @default {
+                <v-input
+                  [name]="property"
+                  [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
+                  [tooltip]="property.includes('Date') ? ('dateformatTooltip' | pluginTranslate: pluginId | async) : null"
+                  [defaultValue]="prefillValueFor(property, obs.prefill)"
+                  (valueChange)="onPropertyChanged(property, $event)"
+                  [required]="true"
+                  [margin]="true"
+                  [trim]="true"
+                  [presetOptions]="property === PAYMENT_INDICATION_TYPE ? paymentIndicationTypes : []"
+                />
+              }
             }
           </div>
           <div class="col-1">

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -115,17 +115,10 @@
                 [title]="translationKeyFor(CASE_GEOMETRY_TYPE) | pluginTranslate: pluginId | async"
                 [defaultValue]="prefillValueFor(CASE_GEOMETRY_TYPE, obs.prefill)"
                 (valueChange)="onPropertyChanged(CASE_GEOMETRY_TYPE, $event)"
-                [dataTestId]="dataTestIdFor(CASE_GEOMETRY_TYPE)"
                 [required]="true"
-                [margin]="false"
+                [margin]="true"
+                [presetOptions]="geometryTypes"
               />
-              <ng-container
-                [ngTemplateOutlet]="presets"
-                [ngTemplateOutletContext]="{
-                  property: CASE_GEOMETRY_TYPE,
-                  presetOptions: geometryTypes
-                }">
-              </ng-container>
             } @else if (property === CASE_GEOMETRY_COORDINATES) {
               <v-input
                 [name]="CASE_GEOMETRY_COORDINATES"
@@ -143,7 +136,6 @@
                 [tooltip]="'dateformatTooltip' | pluginTranslate: pluginId | async"
                 [defaultValue]="prefillValueFor(property, obs.prefill)"
                 (valueChange)="onPropertyChanged(property, $event)"
-                [dataTestId]="dataTestIdFor(property)"
                 [required]="true"
                 [margin]="true"
                 [trim]="true"
@@ -154,20 +146,11 @@
                 [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
                 [defaultValue]="prefillValueFor(property, obs.prefill)"
                 (valueChange)="onPropertyChanged(property, $event)"
-                [dataTestId]="dataTestIdFor(property)"
                 [required]="true"
-                [margin]="(property !== PAYMENT_INDICATION_TYPE)"
+                [margin]="true"
                 [trim]="true"
+                [presetOptions]="property === PAYMENT_INDICATION_TYPE ? paymentIndicationTypes : []"
               />
-              @if (property === PAYMENT_INDICATION_TYPE) {
-                <ng-container
-                  [ngTemplateOutlet]="presets"
-                  [ngTemplateOutletContext]="{
-                    property: PAYMENT_INDICATION_TYPE,
-                    presetOptions: paymentIndicationTypes
-                  }">
-                </ng-container>
-              }
             }
           </div>
           <div class="col-1">
@@ -202,14 +185,4 @@
       </cds-overflow-menu-option>
     }
   }
-</ng-template>
-
-<ng-template #presets let-property="property" let-presetOptions="presetOptions">
-  <div class="presets">
-      <span>Presets:</span>
-      @for (preset of presetOptions; track $index; let isFirst = $first) {
-        @if (!isFirst) { | }
-        <a (click)="presetPropertyWithValue(property, preset)" class="preset">{{ preset }}</a>
-      }
-  </div>
 </ng-template>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -30,7 +30,7 @@
       {{ 'createZaakInformation' | pluginTranslate: obs.pluginId | async }}
     </v-paragraph>
 
-    <v-form (valueChange)="formValueChange($event)">
+    <v-form (valueChange)="onFormValueChanged($event)">
       <v-input
         name="rsin"
         [title]="'rsin' | pluginTranslate: obs.pluginId | async"
@@ -93,62 +93,44 @@
       </ng-container>
 
       @for (property of propertyList; track property) {
-        @if (property === 'description') {
-          <div class="property-input">
-            <v-input
-              name="description"
-              [title]="'beschrijving' | pluginTranslate: obs.pluginId | async"
-              [margin]="true"
-              [defaultValue]="obs.prefill?.description"
-              [required]="true"
-              (valueChange)="onPropertyChanged('description', $event)"
-            />
-
-            <button class="btn btn-space delete-button" (click)="removeCaseProperty('description')">
-              <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
-            </button>
-          </div>
-        } @else if (property === 'plannedEndDate') {
-          <div class="property-input">
-            <v-input
-              name="plannedEndDate"
-              [title]="'plannedEndDate' | pluginTranslate: obs.pluginId | async"
-              [margin]="true"
-              [defaultValue]="obs.prefill?.plannedEndDate"
-              [required]="true"
-              [trim]="true"
-              [tooltip]="'dateformatTooltip' | pluginTranslate: obs.pluginId | async"
-              (valueChange)="onPropertyChanged('plannedEndDate', $event)"
-            ></v-input>
-
-            <button
-              class="btn btn-space delete-button"
-              (click)="removeCaseProperty('plannedEndDate')"
-            >
-              <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
-            </button>
-          </div>
-        } @else if (property === 'finalDeliveryDate') {
-          <div class="property-input">
-            <v-input
-              name="finalDeliveryDate"
-              [title]="'finalDeliveryDate' | pluginTranslate: obs.pluginId | async"
-              [margin]="true"
-              [defaultValue]="obs.prefill?.finalDeliveryDate"
-              [required]="true"
-              [trim]="true"
-              [tooltip]="'dateformatTooltip' | pluginTranslate: obs.pluginId | async"
-              (valueChange)="onPropertyChanged('finalDeliveryDate', $event)"
-            ></v-input>
-
-            <button
-              class="btn btn-space delete-button"
-              (click)="removeCaseProperty('finalDeliveryDate')"
-            >
-              <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
-            </button>
-          </div>
-        }
+        <div class="property-input">
+          @if (property === 'description') {
+              <v-input
+                [name]="property"
+                [title]="translationKeyFor(property) | pluginTranslate: obs.pluginId | async"
+                [required]="true"
+                [defaultValue]="obs.prefill[property]"
+                [margin]="true"
+                (valueChange)="onPropertyChanged(property, $event)"
+              />
+          } @else if (property === 'plannedEndDate' || property === 'finalDeliveryDate') {
+              <v-input
+                [name]="property"
+                [title]="translationKeyFor(property) | pluginTranslate: obs.pluginId | async"
+                [required]="true"
+                [defaultValue]="obs.prefill[property]"
+                [margin]="true"
+                [trim]="true"
+                [tooltip]="'dateformatTooltip' | pluginTranslate: obs.pluginId | async"
+                (valueChange)="onPropertyChanged(property, $event)"
+              ></v-input>
+          } @else {
+              <v-input
+                [name]="property"
+                [title]="translationKeyFor(property) | pluginTranslate: obs.pluginId | async"
+                [required]="true"
+                [defaultValue]="obs.prefill[property]"
+                [margin]="true"
+                [trim]="true"
+                (valueChange)="onPropertyChanged(property, $event)"
+              />
+          }
+          <button
+            class="btn btn-space delete-button"
+            (click)="removeCaseProperty(property)">
+            <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
+          </button>
+        </div>
       }
 
       <button
@@ -173,24 +155,12 @@
 </ng-template>
 
 <ng-template #addCasePropertyList>
-  <cds-overflow-menu-option
-    (click)="addCaseProperty('description')"
-    *ngIf="!hasPropertyBeenAdded('description')"
-  >
-    {{ 'beschrijving' | pluginTranslate: (pluginId$ | async) | async }}
-  </cds-overflow-menu-option>
-
-  <cds-overflow-menu-option
-    (click)="addCaseProperty('plannedEndDate')"
-    *ngIf="!hasPropertyBeenAdded('plannedEndDate')"
-  >
-    {{ 'plannedEndDate' | pluginTranslate: (pluginId$ | async) | async }}
-  </cds-overflow-menu-option>
-
-  <cds-overflow-menu-option
-    (click)="addCaseProperty('finalDeliveryDate')"
-    *ngIf="!hasPropertyBeenAdded('finalDeliveryDate')"
-  >
-    {{ 'finalDeliveryDate' | pluginTranslate: (pluginId$ | async) | async }}
-  </cds-overflow-menu-option>
+  @for (propertyOption of extraPropertiesOptions; track propertyOption) {
+    <cds-overflow-menu-option
+      *ngIf="!hasPropertyBeenAdded(propertyOption)"
+      (click)="addCaseProperty(propertyOption)"
+    >
+      {{ translationKeyFor(propertyOption) | pluginTranslate: (pluginId$ | async) | async }}
+    </cds-overflow-menu-option>
+  }
 </ng-template>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -21,10 +21,12 @@
     loading: loading$ | async,
     prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
     selectedInputOption: selectedInputOption$ | async,
-    zaakTypeSelectItems: zaakTypeItems$ | async
+    zaakTypeSelectItems: zaakTypeItems$ | async,
   } as obs"
 >
-  <ng-container *ngIf="obs.loading === false; else loading">
+  @if (obs.loading) {
+    <cds-loading></cds-loading>
+  } @else {
     <v-paragraph [margin]="true" [italic]="true">
       {{ 'createZaakInformation' | pluginTranslate: pluginId | async }}
     </v-paragraph>
@@ -83,8 +85,8 @@
         "
         [margin]="true"
         [defaultSelectionId]="
-          (selectItemsIncludeId(obs.zaakTypeSelectItems, obs.prefill?.zaaktypeUrl) && obs.prefill?.zaaktypeUrl)
-          ||
+          (selectItemsIncludeId(obs.zaakTypeSelectItems, obs.prefill?.zaaktypeUrl) &&
+            obs.prefill?.zaaktypeUrl) ||
           (oneSelectItem(obs.zaakTypeSelectItems) && obs.zaakTypeSelectItems[0].id)
         "
         [widthInPx]="350"
@@ -98,9 +100,10 @@
             [size]="'md'"
             [cdsOverflowMenu]="addCasePropertyList"
             [customPane]="true"
-            placement="bottom"
+            placement="bottom,top"
           >
             {{ 'addZaakProperty' | pluginTranslate: pluginId | async }}
+
             <svg class="cds--btn__icon" cdsIcon="add" size="16"></svg>
           </button>
         </div>
@@ -113,7 +116,9 @@
               @case (CASE_GEOMETRY_TYPE) {
                 <v-input
                   [name]="CASE_GEOMETRY_TYPE"
-                  [title]="translationKeyFor(CASE_GEOMETRY_TYPE) | pluginTranslate: pluginId | async"
+                  [title]="
+                    translationKeyFor(CASE_GEOMETRY_TYPE) | pluginTranslate: pluginId | async
+                  "
                   [defaultValue]="prefillValueFor(CASE_GEOMETRY_TYPE, obs.prefill)"
                   (valueChange)="onPropertyChanged(CASE_GEOMETRY_TYPE, $event)"
                   [required]="true"
@@ -124,7 +129,9 @@
               @case (CASE_GEOMETRY_COORDINATES) {
                 <v-input
                   [name]="CASE_GEOMETRY_COORDINATES"
-                  [title]="translationKeyFor(CASE_GEOMETRY_COORDINATES) | pluginTranslate: pluginId | async"
+                  [title]="
+                    translationKeyFor(CASE_GEOMETRY_COORDINATES) | pluginTranslate: pluginId | async
+                  "
                   [tooltip]="translationKeyFor(`${CASE_GEOMETRY_COORDINATES}Tooltip`) | pluginTranslate: pluginId | async"
                   [defaultValue]="prefillValueFor(CASE_GEOMETRY_COORDINATES, obs.prefill)"
                   (valueChange)="onPropertyChanged(CASE_GEOMETRY_COORDINATES, $event)"
@@ -136,22 +143,27 @@
                 <v-input
                   [name]="property"
                   [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
-                  [tooltip]="property.includes('Date') ? ('dateformatTooltip' | pluginTranslate: pluginId | async) : null"
+                  [tooltip]="
+                    property.includes('Date')
+                      ? ('dateformatTooltip' | pluginTranslate: pluginId | async)
+                      : null
+                  "
                   [defaultValue]="prefillValueFor(property, obs.prefill)"
                   (valueChange)="onPropertyChanged(property, $event)"
                   [required]="true"
                   [margin]="true"
                   [trim]="true"
-                  [presetOptions]="property === PAYMENT_INDICATION_TYPE ? paymentIndicationTypes : []"
+                  [presetOptions]="
+                    property === PAYMENT_INDICATION_TYPE ? paymentIndicationTypes : []
+                  "
                 />
               }
             }
           </div>
+
           <div class="property-delete-col">
             @if (property !== CASE_GEOMETRY_COORDINATES) {
-              <button
-                class="btn btn-space delete-button"
-                (click)="removeProperty(property)">
+              <button class="btn btn-space delete-button" (click)="removeProperty(property)">
                 <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
               </button>
             }
@@ -159,22 +171,13 @@
         </div>
       }
     </v-form>
-  </ng-container>
+  }
 </ng-container>
-
-<ng-template #loading>
-  <div class="loading-container">
-    <cds-loading></cds-loading>
-  </div>
-</ng-template>
 
 <ng-template #addCasePropertyList>
   @for (propertyOption of propertyOptions; track propertyOption) {
-    @if (propertyOption !== CASE_GEOMETRY_COORDINATES) {
-      <cds-overflow-menu-option
-        *ngIf="!hasPropertyBeenAdded(propertyOption)"
-        (click)="addProperty(propertyOption)"
-      >
+    @if (propertyOption !== CASE_GEOMETRY_COORDINATES && !hasPropertyBeenAdded(propertyOption)) {
+      <cds-overflow-menu-option (click)="addProperty(propertyOption)">
         {{ translationKeyForPropertyList(propertyOption) | pluginTranslate: pluginId | async }}
       </cds-overflow-menu-option>
     }

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -34,12 +34,12 @@
       <v-input
         name="rsin"
         [title]="'rsin' | pluginTranslate: obs.pluginId | async"
-        [margin]="true"
+        [tooltip]="'rsinTooltip' | pluginTranslate: obs.pluginId | async"
         [defaultValue]="obs.prefill?.rsin"
-        [disabled]="obs.disabled"
+        [margin]="true"
         [required]="true"
         [trim]="true"
-        [tooltip]="'rsinTooltip' | pluginTranslate: obs.pluginId | async"
+        [disabled]="obs.disabled"
         [widthPx]="350"
       >
       </v-input>
@@ -49,9 +49,9 @@
         name="inputTypeZaakTypeToggle"
         [disabled]="obs.disabled"
         [title]="'inputTypeZaakTypeToggle' | pluginTranslate: obs.pluginId | async"
-        [radioValues]="inputTypeOptions$ | async"
         [defaultValue]="selectedInputOption$ | async"
         [margin]="true"
+        [radioValues]="inputTypeOptions$ | async"
       >
       </v-radio>
 
@@ -59,23 +59,25 @@
         *ngIf="obs.selectedInputOption === 'text'"
         name="zaaktypeUrl"
         [title]="'zaakTypeUrl' | pluginTranslate: obs.pluginId | async"
-        [margin]="true"
+        [tooltip]="'zaakTypeTooltip' | pluginTranslate: obs.pluginId | async"
         [defaultValue]="obs.prefill?.zaaktypeUrl"
         [disabled]="obs.disabled || obs.selectedInputOption === 'selection'"
+        [margin]="true"
         [required]="true"
         [trim]="true"
-        [tooltip]="'zaakTypeTooltip' | pluginTranslate: obs.pluginId | async"
         [fullWidth]="true"
       >
       </v-input>
 
       <ng-container *ngIf="obs.selectedInputOption === 'selection'">
         <v-select
-          [items]="obs.zaakTypeSelectItems"
-          [margin]="true"
-          [widthInPx]="350"
           name="zaaktypeUrl"
           [title]="'zaakType' | pluginTranslate: obs.pluginId | async"
+          [tooltip]="'zaakTypeSelectTooltip' | pluginTranslate: obs.pluginId | async"
+          [margin]="true"
+          [required]="true"
+          [items]="obs.zaakTypeSelectItems"
+          [widthInPx]="350"
           [disabled]="
             obs.disabled ||
             obs.selectedInputOption === 'text' ||
@@ -86,64 +88,98 @@
               obs.prefill?.zaaktypeUrl) ||
             (oneSelectItem(obs.zaakTypeSelectItems) && obs.zaakTypeSelectItems[0].id)
           "
-          [required]="true"
           [loading]="!obs.zaakTypeSelectItems"
-          [tooltip]="'zaakTypeSelectTooltip' | pluginTranslate: obs.pluginId | async"
         ></v-select>
       </ng-container>
 
-      @for (property of propertyList; track property) {
-        <div class="property-input">
-          @if (property === 'description') {
-              <v-input
-                [name]="property"
-                [title]="translationKeyFor(property) | pluginTranslate: obs.pluginId | async"
-                [required]="true"
-                [defaultValue]="obs.prefill[property]"
-                [margin]="true"
-                (valueChange)="onPropertyChanged(property, $event)"
-              />
-          } @else if (property === 'plannedEndDate' || property === 'finalDeliveryDate') {
-              <v-input
-                [name]="property"
-                [title]="translationKeyFor(property) | pluginTranslate: obs.pluginId | async"
-                [required]="true"
-                [defaultValue]="obs.prefill[property]"
-                [margin]="true"
-                [trim]="true"
-                [tooltip]="'dateformatTooltip' | pluginTranslate: obs.pluginId | async"
-                (valueChange)="onPropertyChanged(property, $event)"
-              ></v-input>
-          } @else {
-              <v-input
-                [name]="property"
-                [title]="translationKeyFor(property) | pluginTranslate: obs.pluginId | async"
-                [required]="true"
-                [defaultValue]="obs.prefill[property]"
-                [margin]="true"
-                [trim]="true"
-                (valueChange)="onPropertyChanged(property, $event)"
-              />
-          }
+      <div class="row">
+        <div class="col-12">
           <button
-            class="btn btn-space delete-button"
-            (click)="removeCaseProperty(property)">
-            <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
+            cdsButton="primary"
+            [size]="'md'"
+            [cdsOverflowMenu]="addCasePropertyList"
+            [customPane]="true"
+            placement="bottom"
+          >
+            {{ 'addZaakProperty' | pluginTranslate: obs.pluginId | async }}
+            <svg class="cds--btn__icon" cdsIcon="add" size="16"></svg>
           </button>
         </div>
+      </div>
+
+      @for (property of propertyList; track property) {
+        <div class="row">
+          <div class="col-11">
+            @if (property === CASE_GEOMETRY_TYPE) {
+              <v-input
+                [name]="CASE_GEOMETRY_TYPE"
+                [title]="translationKeyFor(CASE_GEOMETRY_TYPE) | pluginTranslate: pluginId | async"
+                [required]="true"
+                [defaultValue]="prefillValueFor(CASE_GEOMETRY_TYPE, obs.prefill)"
+                [margin]="false"
+                (valueChange)="onPropertyChanged(CASE_GEOMETRY_TYPE, $event)"
+                [dataTestId]="dataTestIdFor(CASE_GEOMETRY_TYPE)"
+              />
+              <div class="presets">
+                  <span>Presets:</span>
+                  <ng-template ngFor let-preset [ngForOf]="geometryTypes" let-isFirst="first">
+                      <ng-template [ngIf]="!isFirst"> | </ng-template><a (click)="presetPropertyWithValue(CASE_GEOMETRY_TYPE, preset)" class="preset">{{ preset }}</a>
+                  </ng-template>
+              </div>
+            } @else if (property === CASE_GEOMETRY_COORDINATES) {
+              <v-input
+                [name]="CASE_GEOMETRY_COORDINATES"
+                [title]="translationKeyFor(CASE_GEOMETRY_COORDINATES) | pluginTranslate: pluginId | async"
+                [tooltip]="translationKeyFor(`${CASE_GEOMETRY_COORDINATES}Tooltip`) | pluginTranslate: pluginId | async"
+                [required]="true"
+                [defaultValue]="prefillValueFor(CASE_GEOMETRY_COORDINATES, obs.prefill)"
+                [margin]="true"
+                (valueChange)="onPropertyChanged(CASE_GEOMETRY_COORDINATES, $event)"
+              />
+            } @else if (property.includes('Date')) {
+              <v-input
+                [name]="property"
+                [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
+                [tooltip]="'dateformatTooltip' | pluginTranslate: pluginId | async"
+                [required]="true"
+                [defaultValue]="prefillValueFor(property, obs.prefill)"
+                [margin]="true"
+                [trim]="true"
+                (valueChange)="onPropertyChanged(property, $event)"
+                [dataTestId]="dataTestIdFor(property)"
+              ></v-input>
+            } @else {
+              <v-input
+                [name]="property"
+                [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
+                [required]="true"
+                [defaultValue]="prefillValueFor(property, obs.prefill)"
+                [margin]="(property !== PAYMENT_INDICATION_TYPE)"
+                [trim]="true"
+                (valueChange)="onPropertyChanged(property, $event)"
+                [dataTestId]="dataTestIdFor(property)"
+              />
+              @if (property === PAYMENT_INDICATION_TYPE) {
+                <div class="presets">
+                  <span>Presets:</span>
+                  <ng-template ngFor let-preset [ngForOf]="paymentIndicationTypes" let-isFirst="first">
+                      <ng-template [ngIf]="!isFirst"> | </ng-template><a (click)="presetPropertyWithValue(PAYMENT_INDICATION_TYPE, preset)" class="preset">{{ preset }}</a>
+                  </ng-template>
+                </div>
+              }
+            }
+          </div>
+          <div class="col-1">
+            @if (property !== CASE_GEOMETRY_COORDINATES) {
+              <button
+                class="btn btn-space delete-button"
+                (click)="removeProperty(property)">
+                <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
+              </button>
+            }
+          </div>
+        </div>
       }
-
-      <button
-        cdsButton="primary"
-        [size]="'md'"
-        [cdsOverflowMenu]="addCasePropertyList"
-        [customPane]="true"
-        placement="bottom"
-      >
-        {{ 'addZaakProperty' | pluginTranslate: obs.pluginId | async }}
-
-        <svg class="cds--btn__icon" cdsIcon="add" size="16"></svg>
-      </button>
     </v-form>
   </ng-container>
 </ng-container>
@@ -158,7 +194,7 @@
   @for (propertyOption of propertyOptions; track propertyOption) {
     <cds-overflow-menu-option
       *ngIf="!hasPropertyBeenAdded(propertyOption)"
-      (click)="addCaseProperty(propertyOption)"
+      (click)="addProperty(propertyOption)"
     >
       {{ translationKeyForPropertyList(propertyOption) | pluginTranslate: (pluginId$ | async) | async }}
     </cds-overflow-menu-option>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -155,12 +155,12 @@
 </ng-template>
 
 <ng-template #addCasePropertyList>
-  @for (propertyOption of extraPropertiesOptions; track propertyOption) {
+  @for (propertyOption of propertyOptions; track propertyOption) {
     <cds-overflow-menu-option
       *ngIf="!hasPropertyBeenAdded(propertyOption)"
       (click)="addCaseProperty(propertyOption)"
     >
-      {{ translationKeyFor(propertyOption) | pluginTranslate: (pluginId$ | async) | async }}
+      {{ translationKeyForPropertyList(propertyOption) | pluginTranslate: (pluginId$ | async) | async }}
     </cds-overflow-menu-option>
   }
 </ng-template>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.html
@@ -90,8 +90,8 @@
         [widthInPx]="350"
       ></v-select>
 
-      <div class="row">
-        <div class="col-12">
+      <div class="property-row">
+        <div class="property-input-col">
           <button
             cdsButton="primary"
             class="add-button"
@@ -107,8 +107,8 @@
       </div>
 
       @for (property of propertyList; track property) {
-        <div class="row">
-          <div class="col-11">
+        <div class="property-row">
+          <div class="property-input-col">
             @switch (property) {
               @case (CASE_GEOMETRY_TYPE) {
                 <v-input
@@ -147,7 +147,7 @@
               }
             }
           </div>
-          <div class="col-1">
+          <div class="property-delete-col">
             @if (property !== CASE_GEOMETRY_COORDINATES) {
               <button
                 class="btn btn-space delete-button"

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
@@ -23,6 +23,35 @@
   align-items: center;
 }
 
+div.presets {
+  margin-top: 0.2em;
+  margin-block-end: var(--v-input-margin);
+  font-size: var(--v-font-size-smaller);
+
+  span:first-child {
+    padding-right: 0.3em;
+  }
+
+  a.preset {
+    cursor: pointer;
+    font-style: italic;
+  }
+}
+
+button.delete-button {
+  height: 46px;
+  width: 46px;
+  margin-top: 20px;
+}
+
+button.delete-button:hover {
+  background-color: #e12717;
+}
+
+button.add-button {
+  margin-block-end: var(--v-input-margin);
+}
+
 ::ng-deep .cds--overflow-menu-options {
   z-index: 10000 !important;
   width: 230px;
@@ -41,8 +70,4 @@
     width: 46px;
     margin: 16px;
   }
-}
-
-.delete-button:hover {
-  background-color: #e12717;
 }

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
@@ -23,21 +23,6 @@
   align-items: center;
 }
 
-div.presets {
-  margin-top: 0.2em;
-  margin-block-end: var(--v-input-margin);
-  font-size: var(--v-font-size-smaller);
-
-  span:first-child {
-    padding-right: 0.3em;
-  }
-
-  a.preset {
-    cursor: pointer;
-    font-style: italic;
-  }
-}
-
 button.delete-button {
   height: 46px;
   width: 46px;

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
@@ -56,3 +56,17 @@ button.add-button {
     margin: 16px;
   }
 }
+
+div.property-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 92% 8%; /* precise 95/5 split */
+}
+div.property-row > * {
+  box-sizing: border-box; /* keeps borders/padding inside the column width */
+  min-width: 0;           /* prevents overflow from long content */
+}
+div.property-input-col  { }
+div.property-delete-col {
+  margin-left: auto;
+}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.scss
@@ -64,9 +64,8 @@ div.property-row {
 }
 div.property-row > * {
   box-sizing: border-box; /* keeps borders/padding inside the column width */
-  min-width: 0;           /* prevents overflow from long content */
+  min-width: 0; /* prevents overflow from long content */
 }
-div.property-input-col  { }
 div.property-delete-col {
   margin-left: auto;
 }

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
@@ -60,10 +60,10 @@ export class CreateZaakConfigurationComponent
 
   public readonly propertyList: Array<CreateZaakExtraProperties> = [];
 
-  readonly pluginId$ = new BehaviorSubject<string>('');
-  readonly selectedInputOption$ = new BehaviorSubject<InputOption>('selection');
-
-  readonly inputTypeOptions$: Observable<Array<RadioValue>> = this.pluginId$.pipe(
+  public readonly pluginId$ = new BehaviorSubject<string>('');
+  public readonly selectedInputOption$ = new BehaviorSubject<InputOption>('selection');
+  public readonly loading$ = new BehaviorSubject<boolean>(true);
+  public readonly inputTypeOptions$: Observable<Array<RadioValue>> = this.pluginId$.pipe(
     filter(pluginId => !!pluginId),
     switchMap(pluginId =>
       combineLatest([
@@ -76,16 +76,7 @@ export class CreateZaakConfigurationComponent
       {value: 'text', title: textTranslation},
     ])
   );
-
-  private saveSubscription!: Subscription;
-
-  private readonly formValue$ = new BehaviorSubject<CreateZaakConfig | null>(null);
-  private readonly valid$ = new BehaviorSubject<boolean>(false);
-  private readonly _properties = new Map<CreateZaakExtraProperties, string>();
-
-  readonly loading$ = new BehaviorSubject<boolean>(true);
-
-  readonly zaakTypeItems$: Observable<Array<SelectItem>> = this.modalService.modalData$.pipe(
+  public readonly zaakTypeItems$: Observable<Array<SelectItem>> = this.modalService.modalData$.pipe(
     switchMap(() => this.context$),
     tap(([context]) => {
       if (context === 'independent') {
@@ -135,9 +126,13 @@ export class CreateZaakConfigurationComponent
     })
   );
 
+  private readonly _formValue$ = new BehaviorSubject<CreateZaakConfig | null>(null);
+  private readonly _properties = new Map<CreateZaakExtraProperties, string>();
+  private saveSubscription!: Subscription;
+  private readonly _valid$ = new BehaviorSubject<boolean>(false);
+
   constructor(
     private readonly openZaakService: OpenZaakService,
-    private readonly documentService: DocumentService,
     private readonly modalService: ModalService,
     private readonly pluginTranslatePipe: PluginTranslatePipe,
     private readonly iconService: IconService
@@ -145,25 +140,24 @@ export class CreateZaakConfigurationComponent
     this.iconService.registerAll([Add16, TrashCan16]);
   }
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.openSaveSubscription();
 
     this.prefillConfiguration$.pipe(take(1)).subscribe(prefill => {
-      CreateZaakExtraPropertyOptions.filter(property => prefill && !!prefill[property]).forEach(property =>
-        this.addCaseProperty(property)
-      );
+      CreateZaakExtraPropertyOptions.filter(property => prefill && !!prefill[property])
+        .forEach(property => this.addCaseProperty(property));
     });
   }
 
-  ngOnDestroy() {
+  public ngOnDestroy(): void {
     this.saveSubscription?.unsubscribe();
   }
 
-  formValueChange(formValue: CreateZaakConfig): void {
+  public onFormValueChanged(formValue: CreateZaakConfig): void {
     this._properties.forEach((value, key) => (formValue[key] = value));
 
     const inputTypeZaakTypeToggle = formValue.inputTypeZaakTypeToggle;
-    this.formValue$.next(formValue);
+    this._formValue$.next(formValue);
     this.handleValid(formValue);
 
     if (inputTypeZaakTypeToggle) {
@@ -171,7 +165,7 @@ export class CreateZaakConfigurationComponent
     }
   }
 
-  oneSelectItem(selectItems: Array<SelectItem>): boolean {
+  public oneSelectItem(selectItems: Array<SelectItem>): boolean {
     if (Array.isArray(selectItems)) {
       return selectItems.length === 1;
     }
@@ -179,7 +173,7 @@ export class CreateZaakConfigurationComponent
     return false;
   }
 
-  selectItemsIncludeId(selectItems: Array<SelectItem>, id: string): boolean {
+  public selectItemsIncludeId(selectItems: Array<SelectItem>, id: string): boolean {
     if (Array.isArray(selectItems)) {
       return !!selectItems.find(item => item.id === id);
     }
@@ -187,17 +181,52 @@ export class CreateZaakConfigurationComponent
     return false;
   }
 
+  public translationKeyFor(property: string): string {
+    return (property === 'description' ? 'beschrijving' : property);
+  }
+
+  public addCaseProperty(property: CreateZaakExtraProperties): void {
+    // only add the property to the list if it is not in the list
+    if (this.propertyList.indexOf(property) == -1) {
+      this.propertyList.push(property);
+    }
+  }
+
+  public removeCaseProperty(property: CreateZaakExtraProperties): void {
+    // only remove the property from the list if it is in the list
+    if (this.propertyList.indexOf(property) != -1) {
+      this.propertyList.splice(this.propertyList.indexOf(property), 1);
+      this.onPropertyChanged(property, undefined);
+    }
+  }
+
+  public hasPropertyBeenAdded(property: CreateZaakExtraProperties): boolean {
+    return this.propertyList.indexOf(property) !== -1;
+  }
+
+  public onPropertyChanged(property: CreateZaakExtraProperties, value: any): void {
+    this._properties.set(property, value);
+    this._formValue$
+      .pipe(
+        filter(formValue => formValue !== null),
+        take(1)
+      )
+      .subscribe(formValue => {
+        this.onFormValueChanged(formValue);
+      });
+  }
+
   private handleValid(formValue: CreateZaakConfig): void {
     const isPropertyInvalid = this.propertyList.some(property => !!!formValue[property]);
     const valid = !!(formValue.rsin && formValue.zaaktypeUrl) && !isPropertyInvalid;
 
-    this.valid$.next(valid);
+    this._valid$.next(valid);
     this.valid.emit(valid);
   }
 
   private openSaveSubscription(): void {
     this.saveSubscription = this.save$?.subscribe(save => {
-      combineLatest([this.formValue$, this.valid$])
+      combineLatest([this._formValue$, this._valid$])
         .pipe(take(1))
         .subscribe(([formValue, valid]) => {
           if (valid) {
@@ -211,31 +240,5 @@ export class CreateZaakConfigurationComponent
           }
         });
     });
-  }
-
-  public addCaseProperty(property: CreateZaakExtraProperties): void {
-    this.propertyList.push(property);
-  }
-
-  public removeCaseProperty(property: CreateZaakExtraProperties): void {
-    this.propertyList.splice(this.propertyList.indexOf(property), 1);
-    this._properties.delete(property);
-    this.onPropertyChanged(property, undefined);
-  }
-
-  public hasPropertyBeenAdded(property: CreateZaakExtraProperties): boolean {
-    return this.propertyList.indexOf(property) !== -1;
-  }
-
-  public onPropertyChanged(property: CreateZaakExtraProperties, value: any): void {
-    this._properties.set(property, value);
-    this.formValue$
-      .pipe(
-        filter(formValue => formValue !== null),
-        take(1)
-      )
-      .subscribe(formValue => {
-        this.formValueChange(formValue);
-      });
   }
 }

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
@@ -29,7 +29,6 @@ import {
 } from 'rxjs';
 import {CreateZaakConfig, InputOption} from '../../models';
 import {OpenZaakService, ZaakType, ZaakTypeLink} from '@valtimo/resource';
-import {DocumentService} from '@valtimo/document';
 import {ModalService, RadioValue, SelectItem} from '@valtimo/components';
 import {PluginTranslatePipe} from '../../../../pipes';
 import {Add16, TrashCan16} from '@carbon/icons';
@@ -58,6 +57,7 @@ export class CreateZaakConfigurationComponent
   @Output() valid: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() configuration: EventEmitter<CreateZaakConfig> = new EventEmitter<CreateZaakConfig>();
 
+  public readonly propertyOptions: string[] = Object.values(CreateZaakExtraPropertyOptions);
   public readonly propertyList: Array<CreateZaakExtraProperties> = [];
 
   public readonly pluginId$ = new BehaviorSubject<string>('');
@@ -126,6 +126,10 @@ export class CreateZaakConfigurationComponent
     })
   );
 
+  protected readonly CASE_GEOMETRY_TYPE: string = 'caseGeometryType';
+  protected readonly CASE_GEOMETRY_COORDINATES: string = 'caseGeometryCoordinates';
+  protected readonly PAYMENT_INDICATION_TYPE: string = 'paymentIndication';
+
   private readonly _formValue$ = new BehaviorSubject<CreateZaakConfig | null>(null);
   private readonly _properties = new Map<CreateZaakExtraProperties, string>();
   private saveSubscription!: Subscription;
@@ -183,6 +187,10 @@ export class CreateZaakConfigurationComponent
 
   public translationKeyFor(property: string): string {
     return (property === 'description' ? 'beschrijving' : property);
+  }
+
+  public translationKeyForPropertyList(property: string): string {
+    return (property === this.CASE_GEOMETRY_TYPE ? 'caseGeometry' : this.translationKeyFor(property));
   }
 
   public addCaseProperty(property: CreateZaakExtraProperties): void {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
@@ -122,7 +122,7 @@ export class CreateZaakConfigurationComponent
   protected readonly PAYMENT_INDICATION_TYPE: string = 'paymentIndication';
 
   private readonly DATA_TEST_ID_PREFIX: string = 'create-zaak-property_';
-  private readonly _formValue$ = new BehaviorSubject<CreateZaakConfig | null>(null);
+  private readonly _formValue$ = new BehaviorSubject<CreateZaakConfig>(null);
   private readonly _properties = new Map<CreateZaakExtraProperties, string>();
   private saveSubscription!: Subscription;
   private readonly _valid$ = new BehaviorSubject<boolean>(false);
@@ -150,9 +150,8 @@ export class CreateZaakConfigurationComponent
   }
 
   public onFormValueChanged(formValue: CreateZaakConfig): void {
+    const inputTypeZaakTypeToggle = formValue?.inputTypeZaakTypeToggle;
     this._properties.forEach((value, key) => (formValue[key] = value));
-
-    const inputTypeZaakTypeToggle = formValue.inputTypeZaakTypeToggle;
     this._formValue$.next(formValue);
     this.handleValid(formValue);
 
@@ -165,7 +164,6 @@ export class CreateZaakConfigurationComponent
     if (Array.isArray(selectItems)) {
       return selectItems.length === 1;
     }
-
     return false;
   }
 
@@ -173,7 +171,6 @@ export class CreateZaakConfigurationComponent
     if (Array.isArray(selectItems)) {
       return !!selectItems.find(item => item.id === id);
     }
-
     return false;
   }
 
@@ -194,6 +191,9 @@ export class CreateZaakConfigurationComponent
     if (this.propertyList.indexOf(property) == -1) {
       this.propertyList.push(property);
     }
+    if (property === this.CASE_GEOMETRY_TYPE) {
+      this.addProperty(this.CASE_GEOMETRY_COORDINATES as CreateZaakExtraProperties);
+    }
   }
 
   public removeProperty(property: CreateZaakExtraProperties): void {
@@ -201,6 +201,9 @@ export class CreateZaakConfigurationComponent
     if (this.propertyList.indexOf(property) != -1) {
       this.propertyList.splice(this.propertyList.indexOf(property), 1);
       this.onPropertyChanged(property, undefined);
+    }
+    if (property === this.CASE_GEOMETRY_TYPE) {
+      this.removeProperty(this.CASE_GEOMETRY_COORDINATES as CreateZaakExtraProperties);
     }
   }
 
@@ -210,11 +213,7 @@ export class CreateZaakConfigurationComponent
 
   public onPropertyChanged(property: CreateZaakExtraProperties, value: any): void {
     this._properties.set(property, value);
-    this._formValue$
-      .pipe(
-        filter(formValue => formValue !== null),
-        take(1)
-      )
+    this._formValue$.pipe(filter(formValue => formValue !== null), take(1))
       .subscribe(formValue => {
         this.onFormValueChanged(formValue);
       });
@@ -235,14 +234,17 @@ export class CreateZaakConfigurationComponent
 
   private handleValid(formValue: CreateZaakConfig): void {
     const isPropertyInvalid = this.propertyList.some(property => !!!formValue[property]);
-    const valid = !!(formValue.rsin && formValue.zaaktypeUrl) && !isPropertyInvalid;
+    const valid = !!(
+      formValue.rsin &&
+      formValue.zaaktypeUrl
+    ) && !isPropertyInvalid;
 
     this._valid$.next(valid);
     this.valid.emit(valid);
   }
 
   private openSaveSubscription(): void {
-    this.saveSubscription = this.save$?.subscribe(save => {
+    this.saveSubscription = this.save$?.subscribe(() => {
       combineLatest([this._formValue$, this._valid$])
         .pipe(take(1))
         .subscribe(([formValue, valid]) => {
@@ -250,7 +252,7 @@ export class CreateZaakConfigurationComponent
             const payload: CreateZaakConfig = {
               rsin: formValue.rsin,
               zaaktypeUrl: formValue.zaaktypeUrl,
-              manualZaakTypeUrl: formValue.manualZaakTypeUrl,
+              manualZaakTypeUrl: formValue.manualZaakTypeUrl
             };
             this.propertyList.forEach(property => (payload[property] = formValue[property]));
             this.configuration.emit(payload);

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
@@ -16,7 +16,17 @@
 
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {FunctionConfigurationComponent} from '../../../../models';
-import {BehaviorSubject, combineLatest, filter, map, Observable, Subscription, switchMap, take, tap,} from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  filter,
+  map,
+  Observable,
+  Subscription,
+  switchMap,
+  take,
+  tap,
+} from 'rxjs';
 import {CreateZaakConfig, InputOption} from '../../models';
 import {OpenZaakService, ZaakType, ZaakTypeLink} from '@valtimo/resource';
 import {ModalService, RadioValue, SelectItem} from '@valtimo/components';
@@ -24,7 +34,10 @@ import {CaseManagementParams, ManagementContext} from '@valtimo/shared';
 import {PluginTranslatePipe} from '../../../../pipes';
 import {Add16, TrashCan16} from '@carbon/icons';
 import {IconService} from 'carbon-components-angular';
-import {CreateZaakExtraProperties, CreateZaakExtraPropertyOptions} from '../../models/create-zaak-properties';
+import {
+  CreateZaakExtraProperties,
+  CreateZaakExtraPropertyOptions,
+} from '../../models/create-zaak-properties';
 import {GEOMETRY_TYPES} from '../../models/geometry-types';
 import {PAYMENT_INDICATION_TYPES} from '../../models/payment-indication-types';
 
@@ -139,8 +152,9 @@ export class CreateZaakConfigurationComponent
     this.openSaveSubscription();
 
     this.prefillConfiguration$.pipe(take(1)).subscribe(prefill => {
-      CreateZaakExtraPropertyOptions.filter(property => prefill && !!prefill[property])
-        .forEach(property => this.addProperty(property));
+      CreateZaakExtraPropertyOptions.filter(property => prefill && !!prefill[property]).forEach(
+        property => this.addProperty(property)
+      );
     });
   }
 
@@ -174,15 +188,15 @@ export class CreateZaakConfigurationComponent
   }
 
   public prefillValueFor(property: string, prefill: CreateZaakConfig): string | null {
-    return (prefill !== null) ? prefill[property] : null;
+    return prefill !== null ? (prefill?.[property] ?? null) : null;
   }
 
   public translationKeyFor(property: string): string {
-    return (property === 'description' ? 'beschrijving' : property);
+    return property === 'description' ? 'beschrijving' : property;
   }
 
   public translationKeyForPropertyList(property: string): string {
-    return (property === this.CASE_GEOMETRY_TYPE ? 'caseGeometry' : this.translationKeyFor(property));
+    return property === this.CASE_GEOMETRY_TYPE ? 'caseGeometry' : this.translationKeyFor(property);
   }
 
   public addProperty(property: CreateZaakExtraProperties): void {
@@ -212,7 +226,11 @@ export class CreateZaakConfigurationComponent
 
   public onPropertyChanged(property: CreateZaakExtraProperties, value: any): void {
     this._properties.set(property, value);
-    this._formValue$.pipe(filter(formValue => formValue !== null), take(1))
+    this._formValue$
+      .pipe(
+        filter(formValue => formValue !== null),
+        take(1)
+      )
       .subscribe(formValue => {
         this.onFormValueChanged(formValue);
       });
@@ -220,10 +238,7 @@ export class CreateZaakConfigurationComponent
 
   private handleValid(formValue: CreateZaakConfig): void {
     const isPropertyInvalid = this.propertyList.some(property => !!!formValue[property]);
-    const valid = !!(
-      formValue.rsin &&
-      formValue.zaaktypeUrl
-    ) && !isPropertyInvalid;
+    const valid = !!(formValue.rsin && formValue.zaaktypeUrl) && !isPropertyInvalid;
 
     this._valid$.next(valid);
     this.valid.emit(valid);
@@ -238,7 +253,7 @@ export class CreateZaakConfigurationComponent
             const payload: CreateZaakConfig = {
               rsin: formValue.rsin,
               zaaktypeUrl: formValue.zaaktypeUrl,
-              manualZaakTypeUrl: formValue.manualZaakTypeUrl
+              manualZaakTypeUrl: formValue.manualZaakTypeUrl,
             };
             this.propertyList.forEach(property => (payload[property] = formValue[property]));
             this.configuration.emit(payload);

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
@@ -121,7 +121,6 @@ export class CreateZaakConfigurationComponent
   protected readonly CASE_GEOMETRY_COORDINATES: string = 'caseGeometryCoordinates';
   protected readonly PAYMENT_INDICATION_TYPE: string = 'paymentIndication';
 
-  private readonly DATA_TEST_ID_PREFIX: string = 'create-zaak-property_';
   private readonly _formValue$ = new BehaviorSubject<CreateZaakConfig>(null);
   private readonly _properties = new Map<CreateZaakExtraProperties, string>();
   private saveSubscription!: Subscription;
@@ -217,19 +216,6 @@ export class CreateZaakConfigurationComponent
       .subscribe(formValue => {
         this.onFormValueChanged(formValue);
       });
-  }
-
-  public dataTestIdFor(property: CreateZaakExtraProperties): string {
-    return this.DATA_TEST_ID_PREFIX + property
-  }
-
-  public presetPropertyWithValue(property: CreateZaakExtraProperties, value: string): void {
-    const input =
-      document.querySelector<HTMLInputElement>(`[data-testid="${this.DATA_TEST_ID_PREFIX + property}"]`);
-    if (input) {
-      input.value = value;
-      input.dispatchEvent(new Event('input'));
-    }
   }
 
   private handleValid(formValue: CreateZaakConfig): void {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
@@ -174,7 +174,7 @@ export class CreateZaakConfigurationComponent
   }
 
   public prefillValueFor(property: string, prefill: CreateZaakConfig): string | null {
-    return (prefill != null) ? prefill[property] : null;
+    return (prefill !== null) ? prefill[property] : null;
   }
 
   public translationKeyFor(property: string): string {
@@ -187,7 +187,7 @@ export class CreateZaakConfigurationComponent
 
   public addProperty(property: CreateZaakExtraProperties): void {
     // only add the property to the list if it is not in the list
-    if (this.propertyList.indexOf(property) == -1) {
+    if (this.propertyList.indexOf(property) === -1) {
       this.propertyList.push(property);
     }
     if (property === this.CASE_GEOMETRY_TYPE) {
@@ -197,7 +197,7 @@ export class CreateZaakConfigurationComponent
 
   public removeProperty(property: CreateZaakExtraProperties): void {
     // only remove the property from the list if it is in the list
-    if (this.propertyList.indexOf(property) != -1) {
+    if (this.propertyList.indexOf(property) !== -1) {
       this.propertyList.splice(this.propertyList.indexOf(property), 1);
       this.onPropertyChanged(property, undefined);
     }

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/create-zaak/create-zaak-configuration.component.ts
@@ -16,25 +16,17 @@
 
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {FunctionConfigurationComponent} from '../../../../models';
-import {
-  BehaviorSubject,
-  combineLatest,
-  filter,
-  map,
-  Observable,
-  Subscription,
-  switchMap,
-  take,
-  tap,
-} from 'rxjs';
+import {BehaviorSubject, combineLatest, filter, map, Observable, Subscription, switchMap, take, tap,} from 'rxjs';
 import {CreateZaakConfig, InputOption} from '../../models';
 import {OpenZaakService, ZaakType, ZaakTypeLink} from '@valtimo/resource';
 import {ModalService, RadioValue, SelectItem} from '@valtimo/components';
+import {CaseManagementParams, ManagementContext} from '@valtimo/shared';
 import {PluginTranslatePipe} from '../../../../pipes';
 import {Add16, TrashCan16} from '@carbon/icons';
 import {IconService} from 'carbon-components-angular';
 import {CreateZaakExtraProperties, CreateZaakExtraPropertyOptions} from '../../models/create-zaak-properties';
-import {CaseManagementParams, ManagementContext} from '@valtimo/shared';
+import {GEOMETRY_TYPES} from '../../models/geometry-types';
+import {PAYMENT_INDICATION_TYPES} from '../../models/payment-indication-types';
 
 @Component({
   standalone: false,
@@ -46,19 +38,18 @@ import {CaseManagementParams, ManagementContext} from '@valtimo/shared';
 export class CreateZaakConfigurationComponent
   implements FunctionConfigurationComponent, OnInit, OnDestroy
 {
-  @Input() save$: Observable<void>;
-  @Input() disabled$: Observable<boolean>;
-  @Input() set pluginId(value: string) {
-    this.pluginId$.next(value);
-  }
   @Input() context$: Observable<[ManagementContext, CaseManagementParams]>;
-
+  @Input() disabled$: Observable<boolean>;
+  @Input() pluginId: string;
+  @Input() save$: Observable<void>;
   @Input() prefillConfiguration$: Observable<CreateZaakConfig>;
   @Output() valid: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() configuration: EventEmitter<CreateZaakConfig> = new EventEmitter<CreateZaakConfig>();
 
   public readonly propertyOptions: string[] = Object.values(CreateZaakExtraPropertyOptions);
   public readonly propertyList: Array<CreateZaakExtraProperties> = [];
+  public readonly geometryTypes: string[] = GEOMETRY_TYPES;
+  public readonly paymentIndicationTypes: string[] = PAYMENT_INDICATION_TYPES;
 
   public readonly pluginId$ = new BehaviorSubject<string>('');
   public readonly selectedInputOption$ = new BehaviorSubject<InputOption>('selection');
@@ -130,6 +121,7 @@ export class CreateZaakConfigurationComponent
   protected readonly CASE_GEOMETRY_COORDINATES: string = 'caseGeometryCoordinates';
   protected readonly PAYMENT_INDICATION_TYPE: string = 'paymentIndication';
 
+  private readonly DATA_TEST_ID_PREFIX: string = 'create-zaak-property_';
   private readonly _formValue$ = new BehaviorSubject<CreateZaakConfig | null>(null);
   private readonly _properties = new Map<CreateZaakExtraProperties, string>();
   private saveSubscription!: Subscription;
@@ -149,7 +141,7 @@ export class CreateZaakConfigurationComponent
 
     this.prefillConfiguration$.pipe(take(1)).subscribe(prefill => {
       CreateZaakExtraPropertyOptions.filter(property => prefill && !!prefill[property])
-        .forEach(property => this.addCaseProperty(property));
+        .forEach(property => this.addProperty(property));
     });
   }
 
@@ -185,6 +177,10 @@ export class CreateZaakConfigurationComponent
     return false;
   }
 
+  public prefillValueFor(property: string, prefill: CreateZaakConfig): string | null {
+    return (prefill != null) ? prefill[property] : null;
+  }
+
   public translationKeyFor(property: string): string {
     return (property === 'description' ? 'beschrijving' : property);
   }
@@ -193,14 +189,14 @@ export class CreateZaakConfigurationComponent
     return (property === this.CASE_GEOMETRY_TYPE ? 'caseGeometry' : this.translationKeyFor(property));
   }
 
-  public addCaseProperty(property: CreateZaakExtraProperties): void {
+  public addProperty(property: CreateZaakExtraProperties): void {
     // only add the property to the list if it is not in the list
     if (this.propertyList.indexOf(property) == -1) {
       this.propertyList.push(property);
     }
   }
 
-  public removeCaseProperty(property: CreateZaakExtraProperties): void {
+  public removeProperty(property: CreateZaakExtraProperties): void {
     // only remove the property from the list if it is in the list
     if (this.propertyList.indexOf(property) != -1) {
       this.propertyList.splice(this.propertyList.indexOf(property), 1);
@@ -222,6 +218,19 @@ export class CreateZaakConfigurationComponent
       .subscribe(formValue => {
         this.onFormValueChanged(formValue);
       });
+  }
+
+  public dataTestIdFor(property: CreateZaakExtraProperties): string {
+    return this.DATA_TEST_ID_PREFIX + property
+  }
+
+  public presetPropertyWithValue(property: CreateZaakExtraProperties, value: string): void {
+    const input =
+      document.querySelector<HTMLInputElement>(`[data-testid="${this.DATA_TEST_ID_PREFIX + property}"]`);
+    if (input) {
+      input.value = value;
+      input.dispatchEvent(new Event('input'));
+    }
   }
 
   private handleValid(formValue: CreateZaakConfig): void {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/patch-zaak/patch-zaak-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/patch-zaak/patch-zaak-configuration.component.ts
@@ -21,6 +21,8 @@ import {PatchZaakConfig} from '../../models';
 import {IconService} from 'carbon-components-angular';
 import {Add16, TrashCan16} from '@carbon/icons';
 import {PatchZaakProperties, PatchZaakPropertyOptions} from '../../models/patch-zaak-properties';
+import {GEOMETRY_TYPES} from '../../models/geometry-types';
+import {PAYMENT_INDICATION_TYPES} from '../../models/payment-indication-types';
 
 @Component({
   standalone: false,
@@ -38,9 +40,8 @@ export class PatchZaakConfigurationComponent implements FunctionConfigurationCom
 
   public readonly propertyOptions: string[] = Object.values(PatchZaakPropertyOptions);
   public readonly propertyList: Array<PatchZaakProperties> = [];
-  public readonly geometryTypes: string[] =
-    ['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'GeometryCollection', 'MultiPolygon'];
-  public readonly paymentIndicationTypes: string[] = ['nvt', 'nog_niet', 'gedeeltelijk', 'geheel'];
+  public readonly geometryTypes: string[] = GEOMETRY_TYPES;
+  public readonly paymentIndicationTypes: string[] = PAYMENT_INDICATION_TYPES;
 
   protected readonly CASE_GEOMETRY_TYPE: string = 'caseGeometryType';
   protected readonly CASE_GEOMETRY_COORDINATES: string = 'caseGeometryCoordinates';

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
@@ -92,8 +92,14 @@ interface CreateZaakConfig {
   zaaktypeUrl: string;
   inputTypeZaakTypeToggle?: InputOption;
   description?: string;
+  explanation?: string;
   plannedEndDate?: string;
   finalDeliveryDate?: string;
+  communicationChannel?: string;
+  paymentIndication?: string;
+  caseGeometryType?: string;
+  caseGeometryCoordinates?: string,
+  mainCase?: string;
 }
 
 interface SetZaakopschortingConfig {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/create-zaak-properties.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/create-zaak-properties.ts
@@ -18,5 +18,11 @@ export const CreateZaakExtraPropertyOptions = [
   'description',
   'plannedEndDate',
   'finalDeliveryDate',
+  'explanation',
+  'communicationChannel',
+  'paymentIndication',
+  'caseGeometry',
+  'mainCase',
+  'relevantOtherCases'
 ] as const;
 export type CreateZaakExtraProperties = (typeof CreateZaakExtraPropertyOptions)[number];

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/create-zaak-properties.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/create-zaak-properties.ts
@@ -16,13 +16,13 @@
 
 export const CreateZaakExtraPropertyOptions = [
   'description',
+  'explanation',
   'plannedEndDate',
   'finalDeliveryDate',
-  'explanation',
   'communicationChannel',
   'paymentIndication',
-  'caseGeometry',
-  'mainCase',
-  'relevantOtherCases'
+  'caseGeometryType',
+  'caseGeometryCoordinates',
+  'mainCase'
 ] as const;
 export type CreateZaakExtraProperties = (typeof CreateZaakExtraPropertyOptions)[number];

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/geometry-types.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/geometry-types.ts
@@ -1,0 +1,9 @@
+export const GEOMETRY_TYPES: string[] = [
+  'Point',
+  'MultiPoint',
+  'LineString',
+  'MultiLineString',
+  'Polygon',
+  'GeometryCollection',
+  'MultiPolygon',
+];

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/payment-indication-types.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/payment-indication-types.ts
@@ -1,0 +1,1 @@
+export const PAYMENT_INDICATION_TYPES: string[] = ['nvt', 'nog_niet', 'gedeeltelijk', 'geheel'];


### PR DESCRIPTION
Describe the changes

Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/153

Added additional properties to the create-zaak plugin action:

    explanation (defaults to null)
    communicationChannel (defaults to null)
    paymentIndication (defaults to null)
    caseGeometryType (defaults to null)
    caseGeometryCoordinates (defaults to null)
    mainCase (defaults to null)

See original PR: https://github.com/valtimo-platform/valtimo-backend-libraries/pull/1964