### PR TITLE
GH-345: verzoekProperty is null

### DIFF
--- a/backend/case/src/main/resources/config/liquibase/changelog/20250827-widget-tab-conditions.xml
+++ b/backend/case/src/main/resources/config/liquibase/changelog/20250827-widget-tab-conditions.xml
@@ -32,6 +32,7 @@
     </changeSet>
 
     <changeSet id="3" author="Ritense">
+        <validCheckSum>9:d8671936cda57a7b491cac541b49a4a4</validCheckSum>
         <addNotNullConstraint tableName="case_widget_tab_widget" columnName="display_conditions" columnDataType="${jsonType}"/>
     </changeSet>
 

--- a/backend/case/src/main/resources/config/liquibase/changelog/20250827-widget-tab-conditions.xml
+++ b/backend/case/src/main/resources/config/liquibase/changelog/20250827-widget-tab-conditions.xml
@@ -32,7 +32,7 @@
     </changeSet>
 
     <changeSet id="3" author="Ritense">
-        <addNotNullConstraint tableName="case_widget_tab_widget" columnName="display_conditions"/>
+        <addNotNullConstraint tableName="case_widget_tab_widget" columnName="display_conditions" columnDataType="${jsonType}"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/backend/zgw/verzoek/src/main/resources/config/liquibase/changelog/20250926-rename-to-case-definition-key.xml
+++ b/backend/zgw/verzoek/src/main/resources/config/liquibase/changelog/20250926-rename-to-case-definition-key.xml
@@ -20,6 +20,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
     <changeSet id="1" author="Ritense">
+        <validCheckSum>9:1674218d038e85ab14a6617879d4902b</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <dbms type="postgresql"/>
         </preConditions>
@@ -30,12 +31,17 @@
                                properties::jsonb,
                                '{verzoekProperties}',
                                jsonb_agg(
-                                       jsonb_set(
-                                               elem - 'caseDefinitionName',
-                                               '{caseDefinitionKey}',
-                                               elem->'caseDefinitionName',
-                                               true
-                                       )
+                                       CASE
+                                           WHEN elem ? 'caseDefinitionName' THEN
+                                               jsonb_set(
+                                                       elem - 'caseDefinitionName',
+                                                       '{caseDefinitionKey}',
+                                                       elem->'caseDefinitionName',
+                                                       true
+                                               )
+                                           ELSE
+                                               elem
+                                           END
                                )
                        )::json
                 FROM jsonb_array_elements((plugin_configuration.properties::jsonb)->'verzoekProperties') elem
@@ -45,6 +51,7 @@
     </changeSet>
 
     <changeSet id="2" author="Ritense">
+        <validCheckSum>9:e086b386761efcf5b997b87606fb9ca8</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <dbms type="mysql"/>
             <sqlCheck expectedResult="1">
@@ -59,7 +66,9 @@
                 c.properties,
                 '$.verzoekProperties',
                 JSON_ARRAYAGG(
-                JSON_REMOVE(
+                CASE
+                WHEN JSON_CONTAINS_PATH(vp.verzoek_property, 'one', '$.caseDefinitionName')
+                THEN JSON_REMOVE(
                 JSON_SET(
                 vp.verzoek_property,
                 '$.caseDefinitionKey',
@@ -67,6 +76,8 @@
                 ),
                 '$.caseDefinitionName'
                 )
+                ELSE vp.verzoek_property
+                END
                 )
                 ) AS new_props
                 FROM plugin_configuration c,

--- a/backend/zgw/verzoek/src/main/resources/config/liquibase/changelog/20250926-rename-to-case-definition-key.xml
+++ b/backend/zgw/verzoek/src/main/resources/config/liquibase/changelog/20250926-rename-to-case-definition-key.xml
@@ -32,7 +32,7 @@
                                '{verzoekProperties}',
                                jsonb_agg(
                                        CASE
-                                           WHEN elem ? 'caseDefinitionName' THEN
+                                           WHEN jsonb_exists(elem, 'caseDefinitionName') THEN
                                                jsonb_set(
                                                        elem - 'caseDefinitionName',
                                                        '{caseDefinitionKey}',


### PR DESCRIPTION
The liquibase script would set the `verzoekProperties` array in database to `[null]` when the migration was already done manually before the upgrade.


https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/345