### PR TITLE
Applied Persistable interface to OutboxMessage to prevent select before insert.

### DIFF
--- a/backend/outbox/build.gradle
+++ b/backend/outbox/build.gradle
@@ -36,7 +36,7 @@ dockerCompose {
 dependencies {
     /* DO NOT ADD DEPENDENCIES TO OTHER VALTIMO MODULES */
     implementation "org.springframework.boot:spring-boot-starter"
-    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    api "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation("org.springframework.security:spring-security-core")
 
     implementation "org.liquibase:liquibase-core:${liquibaseVersion}"

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxMessage.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxMessage.kt
@@ -19,9 +19,13 @@ package com.ritense.outbox
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
+import jakarta.persistence.PostLoad
+import jakarta.persistence.PostPersist
 import jakarta.persistence.Table
+import org.springframework.data.domain.Persistable
 import java.time.LocalDateTime
 import java.util.UUID
+
 
 @Entity
 @Table(name = "outbox_message")
@@ -29,11 +33,26 @@ class OutboxMessage(
 
     @Id
     @Column(name = "id")
-    val id: UUID = UUID.randomUUID(),
+    private val id: UUID = UUID.randomUUID(),
 
     @Column(name = "message")
     val message: String,
 
     @Column(name = "created_on")
     val createdOn: LocalDateTime = LocalDateTime.now()
-)
+): Persistable<UUID> {
+    @Transient
+    private var isNew = true
+
+    override fun getId(): UUID {
+        return id
+    }
+
+    override fun isNew() = isNew
+
+    @PostPersist
+    @PostLoad
+    fun markNotNew() {
+        this.isNew = false
+    }
+}


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue:
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/368
<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Specify the documents branch location:
Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
