### PR TITLE
Fix frontend snapshot versioning: set gradle.properties to 13.5.0

### DIFF
--- a/frontend/gradle.properties
+++ b/frontend/gradle.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-projectVersion=13.0.1
+projectVersion=13.5.0


### PR DESCRIPTION
Frontend snapshots published to S3 currently have the wrong version