### PR TITLE
Simplify filename sanitization logic in DocumentenApiMetadataModal component

### DIFF
--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
@@ -76,7 +76,7 @@ import {
   TagModule,
   TooltipModule,
 } from 'carbon-components-angular';
-import {DocumentenApiTagService} from '../../services/documenten-api-tag.service';
+import {DocumentenApiTagService} from '../../services';
 import moment from 'moment';
 import {DocumentenApiUploadFieldDefaultValues} from '../../models/documenten-api-upload-field.model';
 import {DocumentenApiVersionService} from '../../services';
@@ -606,7 +606,7 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
       return null;
     }
 
-    filename = filename.replace(/\.[^/.]+$/, '').replace(/[^a-zA-Z0-9]+/g, ' ');
+    filename = filename.replace(/\.[^/.]+$/, '').replace(/[._]/g, ' ');
     return filename.charAt(0).toUpperCase() + filename.slice(1);
   }
 


### PR DESCRIPTION
### Describe the changes
Sanitization is simplified, so we no longer remove all symbols from the document title.
File extension is removed and then all underscores and dots are replaced by spaces.
All other symbols will be kept in the title.

This makes sure that dates in the filename (2025-11-11) will remain formatted correctly in the file title.

Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/417

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
