### PR TITLE
story: 145785 backport patch besluit in V12.

### DIFF
--- a/backend/app/gzac/src/main/resources/bpmn/vastleggen-besluit.bpmn
+++ b/backend/app/gzac/src/main/resources/bpmn/vastleggen-besluit.bpmn
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.1">
+  <bpmn:collaboration id="Collaboration_1jayd0m" isClosed="false">
+    <bpmn:participant id="PatchBesluitParticipant" name="Vastleggen besluit" processRef="vastleggen-besluit" />
+  </bpmn:collaboration>
+  <bpmn:process id="vastleggen-besluit" name="Vastleggen besluit" processType="None" isClosed="false" isExecutable="true" operaton:versionTag="CD:bezwaar:1.0.1">
+    <bpmn:startEvent id="startEventPatchBesluit">
+      <bpmn:outgoing>Flow_1aqi6ks</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="LinkDocumentAanBesluitTask" name="Link besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
+      <bpmn:incoming>Flow_0bm9i67</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z587ap</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="GetBesluitDocumentUrlTask" name="Get besluit document url" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${resourceStorageDelegate.getMetadata(tempFileId,&#34;documentUrl&#34;)}" camunda:resultVariable="besluitDocumentUrl">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="tempFileId">${besluitDocumenten[0].id}</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1aqi6ks</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ej4yoc</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_0cpeutm">
+      <bpmn:incoming>Flow_1qap1ym</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="PatchBesluitTask" name="Patch besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
+      <bpmn:incoming>Flow_0mava74</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qap1ym</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:userTask id="PatchBesluitUserTask" name="Patch besluit" camunda:candidateGroups="ROLE_ADMIN">
+      <bpmn:incoming>Flow_0z587ap</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mava74</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1aqi6ks" sourceRef="startEventPatchBesluit" targetRef="GetBesluitDocumentUrlTask" />
+    <bpmn:sequenceFlow id="Flow_1ej4yoc" sourceRef="GetBesluitDocumentUrlTask" targetRef="CreateBesluitTask" />
+    <bpmn:sequenceFlow id="Flow_0bm9i67" sourceRef="CreateBesluitTask" targetRef="LinkDocumentAanBesluitTask" />
+    <bpmn:sequenceFlow id="Flow_0z587ap" sourceRef="LinkDocumentAanBesluitTask" targetRef="PatchBesluitUserTask" />
+    <bpmn:sequenceFlow id="Flow_1qap1ym" sourceRef="PatchBesluitTask" targetRef="Event_0cpeutm" />
+    <bpmn:sequenceFlow id="Flow_0mava74" sourceRef="PatchBesluitUserTask" targetRef="PatchBesluitTask" />
+    <bpmn:serviceTask id="CreateBesluitTask" name="Create besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
+      <bpmn:incoming>Flow_1ej4yoc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bm9i67</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1jayd0m">
+      <bpmndi:BPMNShape id="Participant_0t1hozn_di" bpmnElement="PatchBesluitParticipant" isHorizontal="true">
+        <dc:Bounds x="160" y="70" width="990" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEventPatchBesluit">
+        <dc:Bounds x="210" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0kvdccs" bpmnElement="LinkDocumentAanBesluitTask">
+        <dc:Bounds x="600" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0mwf0oq" bpmnElement="GetBesluitDocumentUrlTask">
+        <dc:Bounds x="280" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cpeutm_di" bpmnElement="Event_0cpeutm">
+        <dc:Bounds x="1059" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tb6jh7" bpmnElement="PatchBesluitTask">
+        <dc:Bounds x="907" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xjbg3r_di" bpmnElement="PatchBesluitUserTask">
+        <dc:Bounds x="760" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02iquzq_di" bpmnElement="CreateBesluitTask">
+        <dc:Bounds x="440" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1aqi6ks_di" bpmnElement="Flow_1aqi6ks">
+        <di:waypoint x="246" y="200" />
+        <di:waypoint x="280" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ej4yoc_di" bpmnElement="Flow_1ej4yoc">
+        <di:waypoint x="380" y="200" />
+        <di:waypoint x="440" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bm9i67_di" bpmnElement="Flow_0bm9i67">
+        <di:waypoint x="540" y="200" />
+        <di:waypoint x="600" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z587ap_di" bpmnElement="Flow_0z587ap">
+        <di:waypoint x="700" y="200" />
+        <di:waypoint x="760" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qap1ym_di" bpmnElement="Flow_1qap1ym">
+        <di:waypoint x="1007" y="200" />
+        <di:waypoint x="1059" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mava74_di" bpmnElement="Flow_0mava74">
+        <di:waypoint x="860" y="200" />
+        <di:waypoint x="907" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.patch-besluit.json
+++ b/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.patch-besluit.json
@@ -1,0 +1,68 @@
+{
+    "display": "form",
+    "components": [
+        {
+            "label": "Beslisdatum",
+            "format": "yyyy-MM-dd hh:mm",
+            "tableView": false,
+            "datePicker": {
+                "disableWeekends": false,
+                "disableWeekdays": false
+            },
+            "defaultDate": "moment()",
+            "enableMinDateInput": false,
+            "enableMaxDateInput": false,
+            "validateWhenHidden": false,
+            "key": "pv.beslisdatum",
+            "type": "datetime",
+            "input": true,
+            "widget": {
+                "type": "calendar",
+                "displayInTimezone": "viewer",
+                "locale": "en",
+                "useLocaleSettings": false,
+                "allowInput": true,
+                "mode": "single",
+                "enableTime": true,
+                "noCalendar": false,
+                "format": "yyyy-MM-dd hh:mm",
+                "hourIncrement": 1,
+                "minuteIncrement": 1,
+                "time_24hr": false,
+                "minDate": null,
+                "disableWeekends": false,
+                "disableWeekdays": false,
+                "maxDate": null
+            }
+        },
+        {
+            "key": "pv.vervaldatum",
+            "type": "textfield",
+            "input": true,
+            "label": "Vervaldatum",
+            "defaultValue": "2025-11-14"
+        },
+        {
+            "key": "pv.vervalreden",
+            "type": "textfield",
+            "input": true,
+            "label": "Vervalreden",
+            "defaultValue": "ingetrokken_overheid"
+        },
+        {
+            "key": "pv.toelichting",
+            "type": "textfield",
+            "input": true,
+            "label": "Toelichting",
+            "defaultValue": "Toelichting-2"
+        },
+        {
+            "key": "submit",
+            "type": "button",
+            "input": true,
+            "label": "Submit",
+            "tableView": false,
+            "showValidations": false
+        }
+    ]
+}

--- a/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.upload-besluit-document.json
+++ b/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.upload-besluit-document.json
@@ -1,0 +1,47 @@
+{
+    "display": "form",
+    "components": [
+        {
+            "key": "pv.besluitDocumenten",
+            "type": "documenten-api-file",
+            "input": true,
+            "label": "Upload hieronder de besluit",
+            "tableView": false,
+            "attributes": {
+                "data-testid": "vastleggen-besluit-pv.besluitDocument"
+            },
+            "customOptions": {
+                "title": "",
+                "author": "",
+                "camera": false,
+                "status": "definitief",
+                "filename": "",
+                "language": "nld",
+                "subtitle": "",
+                "hideTitle": false,
+                "description": "Besluit",
+                "maxFileSize": 1,
+                "documentType": "test",
+                "disableAuthor": false,
+                "disableStatus": false,
+                "documentTitle": "Besluit",
+                "disableFilename": false,
+                "disableLanguage": false,
+                "hideMaxFileSize": false,
+                "disableDescription": false,
+                "disableDocumentType": false,
+                "confidentialityLevel": "zaakvertrouwelijk",
+                "disableDocumentTitle": false,
+                "disableConfidentialityLevel": false
+            }
+        },
+        {
+            "key": "submit",
+            "type": "button",
+            "input": true,
+            "label": "Submit",
+            "tableView": false,
+            "showValidations": false
+        }
+    ]
+}

--- a/backend/app/gzac/src/main/resources/config/process-document-link/bezwaar.json
+++ b/backend/app/gzac/src/main/resources/config/process-document-link/bezwaar.json
@@ -3,5 +3,10 @@
         "processDefinitionKey": "bezwaar",
         "canInitializeDocument": true,
         "startableByUser": true
+    },
+    {
+        "processDefinitionKey": "vastleggen-besluit",
+        "canInitializeDocument": false,
+        "startableByUser": true
     }
 ]

--- a/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
+++ b/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
@@ -12,7 +12,7 @@
         "pluginConfigurationId": "857d4312-c420-4a22-979b-625818d97ed5",
         "pluginActionDefinitionKey": "create-besluit",
         "actionProperties": {
-            "besluittypeUrl": "http://localhost:8001/catalogi/api/v1/besluittypen/239b9760-cce2-4ae1-a3b7-4337ce51c83a",
+            "besluittypeUrl": "Fill in the besluitTypeUrl here",
             "toelichting": "Besluit",
             "bestuursorgaan": "Bestuursorgaan",
             "ingangsdatum": "2025-11-11",

--- a/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
+++ b/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
@@ -1,0 +1,62 @@
+[
+    {
+        "activityId": "startEventPatchBesluit",
+        "activityType": "bpmn:StartEvent:start",
+        "processLinkType": "form",
+        "formDefinitionName": "vastleggen-besluit.upload-besluit-document"
+    },
+    {
+        "activityId": "CreateBesluitTask",
+        "activityType": "bpmn:ServiceTask:start",
+        "processLinkType": "plugin",
+        "pluginConfigurationId": "857d4312-c420-4a22-979b-625818d97ed5",
+        "pluginActionDefinitionKey": "create-besluit",
+        "actionProperties": {
+            "besluittypeUrl": "http://localhost:8001/catalogi/api/v1/besluittypen/239b9760-cce2-4ae1-a3b7-4337ce51c83a",
+            "toelichting": "Besluit",
+            "bestuursorgaan": "Bestuursorgaan",
+            "ingangsdatum": "2025-11-11",
+            "createdBesluitUrl": "besluitUrl",
+            "vervalreden": "tijdelijk",
+            "vervaldatum": null,
+            "publicatiedatum": null,
+            "verzenddatum": null,
+            "uiterlijkeReactieDatum": null,
+            "inputTypeBesluitToggle": "text",
+            "inputTypeStartingDateToggle": "text",
+            "inputTypeExpirationDateToggle": "selection"
+        }
+    },
+    {
+        "activityId": "LinkDocumentAanBesluitTask",
+        "activityType": "bpmn:ServiceTask:start",
+        "processLinkType": "plugin",
+        "pluginConfigurationId": "857d4312-c420-4a22-979b-625818d97ed5",
+        "pluginActionDefinitionKey": "link-document-to-besluit",
+        "actionProperties": {
+            "besluitUrl": "pv:besluitUrl",
+            "documentUrl": "pv:besluitDocumentUrl"
+        }
+    },
+    {
+        "activityId": "PatchBesluitUserTask",
+        "activityType": "bpmn:UserTask:create",
+        "processLinkType": "form",
+        "formDefinitionName": "vastleggen-besluit.patch-besluit"
+    },
+    {
+        "activityId": "PatchBesluitTask",
+        "activityType": "bpmn:ServiceTask:start",
+        "processLinkType": "plugin",
+        "pluginConfigurationId": "857d4312-c420-4a22-979b-625818d97ed5",
+        "pluginActionDefinitionKey": "patch-besluit",
+        "actionProperties": {
+            "besluitUrl": "pv:besluitUrl",
+            "beslisdatum": "pv:beslisdatum",
+            "vervaldatum": "pv:vervaldatum",
+            "vervalreden": "pv:vervalreden",
+            "toelichting": "pv:toelichting"
+
+        }
+    }
+]

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiPlugin.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiPlugin.kt
@@ -16,11 +16,11 @@
 
 package com.ritense.besluitenapi
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.ritense.besluitenapi.client.Besluit
 import com.ritense.besluitenapi.client.BesluitenApiClient
 import com.ritense.besluitenapi.client.CreateBesluitInformatieObject
 import com.ritense.besluitenapi.client.CreateBesluitRequest
+import com.ritense.besluitenapi.client.PatchBesluitRequest
 import com.ritense.besluitenapi.client.Vervalreden
 import com.ritense.logging.withLoggingContext
 import com.ritense.plugin.annotation.Plugin
@@ -128,6 +128,75 @@ class BesluitenApiPlugin(
         }
     }
 
+    @PluginAction(
+        key = "patch-besluit",
+        title = "Patch besluit",
+        description = "Patches a besluit in the Besluiten API",
+        activityTypes = [ActivityTypeWithEventName.SERVICE_TASK_START]
+    )
+    fun patchBesluit(
+        execution: DelegateExecution,
+        @PluginActionProperty besluitUrl: String,
+        @PluginActionProperty beslisdatum: String? = null,
+        @PluginActionProperty toelichting: String? = null,
+        @PluginActionProperty bestuursorgaan: String? = null,
+        @PluginActionProperty ingangsdatum: String? = null,
+        @PluginActionProperty vervaldatum: String? = null,
+        @PluginActionProperty vervalreden: Vervalreden? = null,
+        @PluginActionProperty publicatiedatum: String? = null,
+        @PluginActionProperty verzenddatum: String? = null,
+        @PluginActionProperty uiterlijkeReactieDatum: String? = null
+    ) {
+        val documentId = UUID.fromString(execution.businessKey)
+        withLoggingContext(
+            "com.ritense.document.domain.impl.JsonSchemaDocument" to documentId.toString()
+        ) {
+            patchBesluit(
+                besluitUrl = URI(besluitUrl),
+                beslisdatum = beslisdatum?.let { toLocalDate(it) },
+                toelichting = toelichting,
+                bestuursorgaan = bestuursorgaan,
+                ingangsdatum = ingangsdatum?.let { toLocalDate(it) },
+                vervaldatum = vervaldatum?.let { toLocalDate(it) },
+                vervalreden = vervalreden,
+                publicatiedatum = publicatiedatum?.let { toLocalDate(it) },
+                verzenddatum = verzenddatum?.let { toLocalDate(it) },
+                uiterlijkeReactieDatum = uiterlijkeReactieDatum?.let { toLocalDate(it) }
+            )
+        }
+    }
+
+    fun patchBesluit(
+        besluitUrl: URI,
+        beslisdatum: LocalDate? = null,
+        toelichting: String? = null,
+        bestuursorgaan: String? = null,
+        ingangsdatum: LocalDate? = null,
+        vervaldatum: LocalDate? = null,
+        vervalreden: Vervalreden? = null,
+        publicatiedatum: LocalDate? = null,
+        verzenddatum: LocalDate? = null,
+        uiterlijkeReactieDatum: LocalDate? = null,
+    ): Besluit {
+        val request = PatchBesluitRequest(
+            datum = beslisdatum,
+            toelichting = toelichting,
+            bestuursorgaan = bestuursorgaan,
+            ingangsdatum = ingangsdatum,
+            vervaldatum = vervaldatum,
+            vervalreden = vervalreden,
+            publicatiedatum = publicatiedatum,
+            verzenddatum = verzenddatum,
+            uiterlijkeReactiedatum = uiterlijkeReactieDatum
+        )
+
+        return besluitenApiClient.patchBesluit(
+            authenticationPluginConfiguration,
+            besluitUrl,
+            request
+        )
+    }
+
     fun createBesluit(
         zaakUrl: URI,
         besluittypeUrl: URI,
@@ -163,13 +232,12 @@ class BesluitenApiPlugin(
         }
     }
 
+    private fun toLocalDate(date: String): LocalDate {
+        return LocalDate.parse(date.take(10))
+    }
+
     companion object {
         private val logger: KLogger = KotlinLogging.logger {}
         const val PLUGIN_KEY = "besluitenapi"
-        const val URL_PROPERTY = "url"
-
-        fun findConfigurationByUrl(url: URI) = { properties: JsonNode ->
-            url.toString().startsWith(properties[URL_PROPERTY].textValue())
-        }
     }
 }

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/BesluitenApiClient.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/BesluitenApiClient.kt
@@ -18,7 +18,9 @@ package com.ritense.besluitenapi.client
 
 import com.ritense.besluitenapi.BesluitenApiAuthentication
 import com.ritense.zgw.ClientTools
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.converter.ResourceHttpMessageConverter
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 import java.net.URI
@@ -70,5 +72,37 @@ class BesluitenApiClient(
             .body(besluitInformatieObject)
             .retrieve()
             .body<BesluitInformatieObject>()!!
+    }
+
+    fun patchBesluit(
+        authentication: BesluitenApiAuthentication,
+        besluitUrl: URI,
+        request: PatchBesluitRequest,
+    ): Besluit {
+        return restClient(authentication)
+            .patch()
+            .uri ( besluitUrl )
+            .headers(this::defaultHeaders)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body (request)
+            .retrieve()
+            .body<Besluit>()!!
+    }
+
+    private fun defaultHeaders(headers: HttpHeaders) {
+        headers.set("Accept-Crs", "EPSG:4326")
+        headers.set("Content-Crs", "EPSG:4326")
+    }
+
+    private fun restClient(authentication: BesluitenApiAuthentication): RestClient {
+        return restClientBuilder
+            .clone()
+            .apply {
+                authentication.applyAuth(it)
+            }
+            .messageConverters {
+                it + ResourceHttpMessageConverter(true)
+            }
+            .build()
     }
 }

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/PatchBesluitRequest.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/PatchBesluitRequest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.besluitenapi.client
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
+import java.time.LocalDate
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class PatchBesluitRequest(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val datum: LocalDate?,
+    val toelichting: String?,
+    val bestuursorgaan: String?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val ingangsdatum: LocalDate?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val vervaldatum: LocalDate?,
+    val vervalreden: Vervalreden?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val publicatiedatum: LocalDate?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val verzenddatum: LocalDate?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val uiterlijkeReactiedatum: LocalDate?,
+)

--- a/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/BesluitenApiPluginTest.kt
+++ b/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/BesluitenApiPluginTest.kt
@@ -21,6 +21,7 @@ import com.ritense.besluitenapi.client.BesluitInformatieObject
 import com.ritense.besluitenapi.client.BesluitenApiClient
 import com.ritense.besluitenapi.client.CreateBesluitInformatieObject
 import com.ritense.besluitenapi.client.CreateBesluitRequest
+import com.ritense.besluitenapi.client.PatchBesluitRequest
 import com.ritense.besluitenapi.client.Vervalreden
 import com.ritense.zakenapi.ZaakUrlProvider
 import com.ritense.zgw.Rsin
@@ -216,5 +217,70 @@ class BesluitenApiPluginTest {
         assertEquals(besluitInformatieObjectValue.informatieobject, documentUrl)
         assertEquals(besluitenApiAuthenticationValue, besluitenApiPlugin.authenticationPluginConfiguration)
         assertEquals(uriValue, besluitenApiPlugin.url)
+    }
+
+    @Test
+    fun `should patch zaakbesluit`() {
+        val authenticationMock = mock<BesluitenApiAuthentication>()
+        val besluitenApiClient = mock<BesluitenApiClient>()
+        val zaakUrlProvider = mock<ZaakUrlProvider>() // only needed for constructor if required
+
+        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider)
+        plugin.authenticationPluginConfiguration = authenticationMock
+
+        val besluitUrl = URI("http://besluiten.api/besluit")
+
+        val beslisdatum = LocalDate.of(2025, 11, 1)
+        val toelichting = "toelichting"
+        val bestuursorgaan = "680572442"
+        val ingangsdatum = LocalDate.of(2025, 11, 2)
+        val vervaldatum = LocalDate.of(2025, 11, 3)
+        val vervalreden = Vervalreden.INGETROKKEN_OVERHEID
+        val publicatiedatum = LocalDate.of(2025, 11, 4)
+        val verzenddatum = LocalDate.of(2025, 11, 5)
+        val uiterlijkeReactieDatum = LocalDate.of(2025, 11, 6)
+
+        val authenticationCaptor = argumentCaptor<BesluitenApiAuthentication>()
+        val uriCaptor = argumentCaptor<URI>()
+        val requestCaptor = argumentCaptor<PatchBesluitRequest>()
+        val besluit = mock<Besluit>()
+
+        whenever(
+            besluitenApiClient.patchBesluit(
+                authenticationCaptor.capture(),
+                uriCaptor.capture(),
+                requestCaptor.capture()
+            )
+        ).thenReturn(besluit)
+
+        val result = plugin.patchBesluit(
+            besluitUrl = besluitUrl,
+            beslisdatum = beslisdatum,
+            toelichting = toelichting,
+            bestuursorgaan = bestuursorgaan,
+            ingangsdatum = ingangsdatum,
+            vervaldatum = vervaldatum,
+            vervalreden = vervalreden,
+            publicatiedatum = publicatiedatum,
+            verzenddatum = verzenddatum,
+            uiterlijkeReactieDatum = uiterlijkeReactieDatum
+        )
+
+        assertEquals(besluit, result)
+
+        assertEquals(authenticationMock, authenticationCaptor.firstValue)
+        assertEquals(besluitUrl, uriCaptor.firstValue)
+
+        val patchBesluitRequest = requestCaptor.firstValue
+
+        assertEquals(beslisdatum, patchBesluitRequest.datum)
+        assertEquals(toelichting, patchBesluitRequest.toelichting)
+        assertEquals(bestuursorgaan, patchBesluitRequest.bestuursorgaan)
+        assertEquals(ingangsdatum, patchBesluitRequest.ingangsdatum)
+        assertEquals(vervaldatum, patchBesluitRequest.vervaldatum)
+        assertEquals(vervalreden, patchBesluitRequest.vervalreden)
+        assertEquals(publicatiedatum, patchBesluitRequest.publicatiedatum)
+        assertEquals(verzenddatum, patchBesluitRequest.verzenddatum)
+        assertEquals(uiterlijkeReactieDatum, patchBesluitRequest.uiterlijkeReactiedatum)
     }
 }

--- a/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/client/BesluitenApiClientTest.kt
+++ b/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/client/BesluitenApiClientTest.kt
@@ -218,6 +218,88 @@ class BesluitenApiClientTest {
         assertEquals(LocalDate.of(2023, 4, 25), besluit.uiterlijkeReactiedatum)
     }
 
+    @Test
+    fun `should send patch besluit request and parse response`() {
+        val restClientBuilder = RestClient.builder()
+        val client = BesluitenApiClient(restClientBuilder)
+
+        val responseBody = """
+        {
+            "url": "http://besluit.api/besluit",
+            "identificatie": "identificatie",
+            "verantwoordelijkeOrganisatie": "633182801",
+            "besluittype": "http://catalogus.api/besluittype",
+            "zaak": "http://zaken.api/zaak",
+            "datum": "2019-11-01",
+            "toelichting": "toelichting",
+            "bestuursorgaan": "680572442",
+            "ingangsdatum": "2019-11-02",
+            "vervaldatum": "2019-11-03",
+            "vervalreden": "tijdelijk",
+            "vervalredenWeergave": "reden",
+            "publicatiedatum": "2019-11-04",
+            "verzenddatum": "2019-11-05",
+            "uiterlijkeReactiedatum": "2019-11-06"
+        }
+    """.trimIndent()
+
+        mockApi.enqueue(mockResponse(responseBody))
+
+        val besluitUrl = URI(mockApi.url("/besluit").toString())
+
+        val besluit = client.patchBesluit(
+            TestAuthentication(),
+            besluitUrl,
+            PatchBesluitRequest(
+                datum = LocalDate.of(2025, 11, 1),
+                toelichting = "toelichting",
+                bestuursorgaan = "680572442",
+                ingangsdatum = LocalDate.of(2025, 11, 2),
+                vervaldatum = LocalDate.of(2025, 11, 3),
+                vervalreden = Vervalreden.TIJDELIJK,
+                publicatiedatum = LocalDate.of(2025, 11, 4),
+                verzenddatum = LocalDate.of(2025, 11, 5),
+                uiterlijkeReactiedatum = LocalDate.of(2025, 11, 6)
+            )
+        )
+
+        val recordedRequest = mockApi.takeRequest()
+        val body = recordedRequest.body.readUtf8()
+
+        // validate PATCH request body: only the patchable fields
+        assertThat(body, jsonPathMissingOrNull("$.identificatie"))
+        assertThat(body, jsonPathMissingOrNull("$.verantwoordelijkeOrganisatie"))
+        assertThat(body, jsonPathMissingOrNull("$.besluittype"))
+        assertThat(body, jsonPathMissingOrNull("$.zaak"))
+
+        assertThat(body, hasJsonPath("$.datum", equalTo("2025-11-01")))
+        assertThat(body, hasJsonPath("$.toelichting", equalTo("toelichting")))
+        assertThat(body, hasJsonPath("$.bestuursorgaan", equalTo("680572442")))
+        assertThat(body, hasJsonPath("$.ingangsdatum", equalTo("2025-11-02")))
+        assertThat(body, hasJsonPath("$.vervaldatum", equalTo("2025-11-03")))
+        assertThat(body, hasJsonPath("$.vervalreden", equalTo("tijdelijk")))
+        assertThat(body, hasJsonPath("$.publicatiedatum", equalTo("2025-11-04")))
+        assertThat(body, hasJsonPath("$.verzenddatum", equalTo("2025-11-05")))
+        assertThat(body, hasJsonPath("$.uiterlijkeReactiedatum", equalTo("2025-11-06")))
+
+        // validate response mapping
+        assertEquals(URI("http://besluit.api/besluit"), besluit.url)
+        assertEquals("identificatie", besluit.identificatie)
+        assertEquals("633182801", besluit.verantwoordelijkeOrganisatie)
+        assertEquals(URI("http://catalogus.api/besluittype"), besluit.besluittype)
+        assertEquals(URI("http://zaken.api/zaak"), besluit.zaak)
+        assertEquals(LocalDate.of(2019, 11, 1), besluit.datum)
+        assertEquals("toelichting", besluit.toelichting)
+        assertEquals("680572442", besluit.bestuursorgaan)
+        assertEquals(LocalDate.of(2019, 11, 2), besluit.ingangsdatum)
+        assertEquals(LocalDate.of(2019, 11, 3), besluit.vervaldatum)
+        assertEquals(Vervalreden.TIJDELIJK, besluit.vervalreden)
+        assertEquals("reden", besluit.vervalredenWeergave)
+        assertEquals(LocalDate.of(2019, 11, 4), besluit.publicatiedatum)
+        assertEquals(LocalDate.of(2019, 11, 5), besluit.verzenddatum)
+        assertEquals(LocalDate.of(2019, 11, 6), besluit.uiterlijkeReactiedatum)
+    }
+
     private fun mockResponse(body: String): MockResponse {
         return MockResponse()
             .addHeader("Content-Type", "application/json")

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.module.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.module.ts
@@ -19,8 +19,9 @@ import {BesluitenApiConfigurationComponent} from './components/besluiten-api-con
 import {CommonModule} from '@angular/common';
 import {PluginTranslatePipeModule} from '../../pipes';
 import {CreateZaakBesluitConfigurationComponent} from './components/create-zaak-besluit/create-zaak-besluit-configuration.component';
+import {PatchZaakBesluitConfigurationComponent} from './components/patch-zaak-besluit/patch-zaak-besluit-configuration.component';
 import {LinkDocumentToBesluitConfigurationComponent} from './components/link-document-to-besluit/link-document-to-besluit-configuration.component';
-import {LoadingModule} from 'carbon-components-angular';
+import {ButtonModule, DialogModule, IconModule, LoadingModule} from 'carbon-components-angular';
 import {
   DatePickerModule,
   FormModule,
@@ -34,6 +35,7 @@ import {
   declarations: [
     BesluitenApiConfigurationComponent,
     CreateZaakBesluitConfigurationComponent,
+    PatchZaakBesluitConfigurationComponent,
     LinkDocumentToBesluitConfigurationComponent,
   ],
   imports: [
@@ -46,10 +48,14 @@ import {
     ParagraphModule,
     RadioModule,
     LoadingModule,
+    ButtonModule,
+    DialogModule,
+    IconModule,
   ],
   exports: [
     BesluitenApiConfigurationComponent,
     CreateZaakBesluitConfigurationComponent,
+    PatchZaakBesluitConfigurationComponent,
     LinkDocumentToBesluitConfigurationComponent,
   ],
 })

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.specification.ts
@@ -18,6 +18,7 @@ import {PluginSpecification} from '../../models';
 import {BesluitenApiConfigurationComponent} from './components/besluiten-api-configuration/besluiten-api-configuration.component';
 import {BESLUITEN_API_PLUGIN_LOGO_BASE64} from './assets';
 import {CreateZaakBesluitConfigurationComponent} from './components/create-zaak-besluit/create-zaak-besluit-configuration.component';
+import {PatchZaakBesluitConfigurationComponent} from './components/patch-zaak-besluit/patch-zaak-besluit-configuration.component';
 import {LinkDocumentToBesluitConfigurationComponent} from './components/link-document-to-besluit/link-document-to-besluit-configuration.component';
 
 const besluitenApiPluginSpecification: PluginSpecification = {
@@ -26,6 +27,7 @@ const besluitenApiPluginSpecification: PluginSpecification = {
   pluginLogoBase64: BESLUITEN_API_PLUGIN_LOGO_BASE64,
   functionConfigurationComponents: {
     'create-besluit': CreateZaakBesluitConfigurationComponent,
+    'patch-besluit': PatchZaakBesluitConfigurationComponent,
     'link-document-to-besluit': LinkDocumentToBesluitConfigurationComponent,
   },
   pluginTranslations: {
@@ -51,13 +53,13 @@ const besluitenApiPluginSpecification: PluginSpecification = {
         'Een orgaan van een rechtspersoon krachtens publiekrecht ingesteld of een persoon of college, met enig openbaar gezag bekleed onder wiens verantwoordelijkheid het besluit vastgesteld is.',
       ingangsdatum: 'Ingangsdatum',
       ingangsdatumTooltip:
-        'Ingangsdatum van de werkingsperiode van het besluit. Ondersteunt de value resolver, bijv: pv:ingangsdatum of doc:/besluit/ingangsdatum. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z. Selecteer Tekst om de document of proces variabel property te gebruiken en Selectie om een datum uit een kalender te selecteren',
+        'Ingangsdatum van de werkingsperiode van het besluit. Ondersteunt de value resolver, bijv: pv:ingangsdatum of doc:/besluit/ingangsdatum. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z',
       vervaldatum: 'Vervaldatum',
       vervaldatumTooltip:
-        'Datum waarop de werkingsperiode van het besluit eindigt. Ondersteunt de value resolver, bijv: pv:vervaldatum of doc:/besluit/vervaldatum. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z. Selecteer Tekst om de document of proces variabel property te gebruiken en Selectie om een datum uit een kalender te selecteren',
+        'Datum waarop de werkingsperiode van het besluit eindigt. Ondersteunt de value resolver, bijv: pv:vervaldatum of doc:/besluit/vervaldatum. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       vervalreden: 'Vervalreden',
       vervalredenTooltip:
-        'De omschrijving die aangeeft op grond waarvan het besluit is of komt te vervallen.',
+        'De omschrijving die aangeeft op grond waarvan het besluit is of komt te vervallen. Mogelijke waarden: tijdelijk, ingetrokken_overheid, ingetrokken_belanghebbende',
       tijdelijk: 'Tijdelijk',
       ingetrokken_overheid: 'Ingetrokken door overheid',
       ingetrokken_belanghebbende: 'Ingetrokken door belanghebbende',
@@ -87,6 +89,12 @@ const besluitenApiPluginSpecification: PluginSpecification = {
         'Selecteer de dossierdefinitie waarvan u een Besluit-type wilt selecteren. Als er slechts één besluittype beschikbaar is, wordt deze standaard geselecteerd.',
       besluittypeUrlSelect: 'Besluittype',
       besluittypeUrlSelectTooltip: 'Selecteer het besluittype.',
+      'patch-besluit': 'Zaakbesluit bijwerken',
+      patchZaakBesluitInformation: 'Deze actie wijzigt een zaakbesluit in de Besluiten API.',
+      beslisdatum: 'Beslisdatum',
+      beslisdatumTooltip:
+        'De beslisdatum (AWB) van het besluit. Ondersteunt value resolver. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z',
+      addPatchBesluitProperty: 'Voeg nieuwe parameter toe',
     },
     en: {
       title: 'Besluiten API',
@@ -110,13 +118,13 @@ const besluitenApiPluginSpecification: PluginSpecification = {
         'A body of a legal person established under public law or a person or body with any public authority under whose responsibility the decision has been adopted.',
       ingangsdatum: 'Starting date',
       ingangsdatumTooltip:
-        'Commencement date of the effective period of the besluit. Supports the value resolver eg: pv:ingangsdatum or doc:/besluit/ingangsdatum. Supporting date format examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z. Select Text to use document or process variable property and Selection to select a date from a calendar.',
+        'Commencement date of the effective period of the besluit. Supports the value resolver eg: pv:ingangsdatum or doc:/besluit/ingangsdatum. Supporting date format examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       vervaldatum: 'Expiration date',
       vervaldatumTooltip:
-        'Date on which the period of operation of the besluit ends. Supports the value resolver eg: pv:vervaldatum or doc:/besluit/vervaldatum. Supporting date format examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z. Select Text to use document or process variable property and Selection to select a date from a calendar.',
+        'Date on which the period of operation of the besluit ends. Supports the value resolver eg: pv:vervaldatum or doc:/besluit/vervaldatum. Supporting date format examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       vervalreden: 'Reason for expiry',
       vervalredenTooltip:
-        'The description that indicates on the basis of which the decision has been or will be cancelled.',
+        'The description that indicates on the basis of which the decision has been or will be cancelled. Possible value: tijdelijk, ingetrokken_overheid, ingetrokken_belanghebbende',
       tijdelijk: 'Temporary',
       ingetrokken_overheid: 'Withdrawn by government',
       ingetrokken_belanghebbende: 'Withdrawn by interested party',
@@ -147,6 +155,12 @@ const besluitenApiPluginSpecification: PluginSpecification = {
         'Select the case definition from which you want to select a Besluit type. If only one Besluit type is available, it will be selected by default.',
       besluittypeUrlSelect: 'Besluittype',
       besluittypeUrlSelectTooltip: 'Select the Besluit type.',
+      'patch-besluit': 'Patch Zaakbesluit',
+      patchZaakBesluitInformation: 'This action patches a Zaakbesluit in the Besluiten API.',
+      beslisdatum: 'Decision date',
+      beslisdatumTooltip:
+        'The decision date (AWB) of the decision. Supports value resolver. Supported date examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z',
+      addPatchBesluitProperty: 'Add besluit property',
     },
     de: {
       title: 'Besluiten API',
@@ -171,13 +185,13 @@ const besluitenApiPluginSpecification: PluginSpecification = {
         'Eine Körperschaft einer juristischen Person des öffentlichen Rechts oder eine Person oder Körperschaft einer öffentlichen Behörde, unter deren Verantwortung die Entscheidung getroffen wurde.',
       ingangsdatum: 'Anfangsdatum',
       ingangsdatumTooltip:
-        'Datum des Beginns der Geltungsdauer der Entscheidung. Unterstützt den Werteauflöser, z. B.: pv:ingangsdatum oder doc:/besluit/ingangdatum. Beispiele für unterstützende Datumsformate: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z. Wählen Sie Text, um die Dokument- oder Prozessvariableneigenschaft zu verwenden, und Auswahl, um ein Datum aus einem Kalender auszuwählen',
+        'Datum des Beginns der Geltungsdauer der Entscheidung. Unterstützt den Werteauflöser, z. B.: pv:ingangsdatum oder doc:/besluit/ingangdatum. Beispiele für unterstützende Datumsformate: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       vervaldatum: 'Verfallsdatum',
       vervaldatumTooltip:
-        'Datum, an dem die Geltungsdauer der Entscheidung endet. Unterstützt den Werteauflöser, z. B.: pv:vervaldatum oder doc:/besluit/vervaldatum. Beispiele für unterstützende Datumsformate: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z. Wählen Sie Text, um die Dokument- oder Prozessvariableneigenschaft zu verwenden, und Auswahl, um ein Datum aus einem Kalender auszuwählen',
+        'Datum, an dem die Geltungsdauer der Entscheidung endet. Unterstützt den Werteauflöser, z. B.: pv:vervaldatum oder doc:/besluit/vervaldatum. Beispiele für unterstützende Datumsformate: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       vervalreden: 'Ablaufgrund',
       vervalredenTooltip:
-        'Die Beschreibung, auf deren Grundlage die Entscheidung aufgehoben wurde oder wird.',
+        'Die Beschreibung, auf deren Grundlage die Entscheidung aufgehoben wurde oder wird. Mögliche Werte: tijdelijk, ingetrokken_overheid, ingetrokken_belanghebbende',
       tijdelijk: 'Temporär',
       ingetrokken_overheid: 'Von der Regierung zurückgezogen',
       ingetrokken_belanghebbende: 'Von interessierter Partei zurückgezogen',
@@ -208,6 +222,12 @@ const besluitenApiPluginSpecification: PluginSpecification = {
         'Wählen Sie die Falltyp aus, aus der Sie einen Besluit-typ auswählen möchten. Wenn nur ein Besluit-typ verfügbar ist, wird dieser standardmäßig ausgewählt.',
       besluittypeUrlSelect: 'Besluittype',
       besluittypeUrlSelectTooltip: 'Wählen Sie den Besluit-typ aus.',
+      'patch-besluit': 'Patch Zaakbesluit',
+      patchZaakBesluitInformation: 'Diese Aktion patcht einen Fallbeschluss in der Besluiten-API.',
+      beslisdatum: 'Entscheidungsdatum',
+      beslisdatumTooltip:
+        'Das Entscheidungsdatum (AWB) des Beschlusses. Unterstützt Value Resolver. Unterstützte Datumsbeispiele: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z',
+      addPatchBesluitProperty: 'Besluit-Property hinzufügen',
     },
   },
 };

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component.html
@@ -1,0 +1,76 @@
+<ng-container
+  *ngIf="{
+    disabled: disabled$ | async,
+    prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
+  } as obs"
+>
+  <v-paragraph [margin]="true" [italic]="true">
+    {{ 'patchZaakBesluitInformation' | pluginTranslate: pluginId | async }}
+  </v-paragraph>
+
+  <v-form (valueChange)="onFormValueChanged($event)">
+    <v-input
+      name="besluitUrl"
+      [title]="'besluitUrl' | pluginTranslate: pluginId | async"
+      [margin]="true"
+      [defaultValue]="obs.prefill?.besluitUrl"
+      [disabled]="obs.disabled"
+      [required]="true"
+      [trim]="true"
+      [tooltip]="'besluitUrlTooltip' | pluginTranslate: pluginId | async"
+      [widthPx]="350"
+    ></v-input>
+
+    <div class="row">
+      <div class="col-12">
+        <button
+          cdsButton="primary"
+          [size]="'md'"
+          [cdsOverflowMenu]="addPropertyList"
+          [customPane]="true"
+          placement="bottom"
+          class="add-button"
+        >
+          {{ 'addPatchBesluitProperty' | pluginTranslate: pluginId | async }}
+          <svg class="cds--btn__icon" cdsIcon="add" size="16"></svg>
+        </button>
+      </div>
+    </div>
+
+    @for (property of propertyList; track property) {
+      <div class="row">
+        <div class="col-11">
+          <v-input
+            [name]="property"
+            [title]="translationKeyFor(property) | pluginTranslate: pluginId | async"
+            [margin]="true"
+            [defaultValue]="prefillValueFor(property, obs.prefill)"
+            [disabled]="obs.disabled"
+            [required]="true"
+            [trim]="true"
+            [tooltip]="translationKeyFor(property + 'Tooltip') | pluginTranslate: pluginId | async"
+            [widthPx]="350"
+            (valueChange)="onPropertyChanged(property, $event)"
+          ></v-input>
+        </div>
+
+        <div class="col-1">
+          <button class="btn btn-space delete-button" (click)="removeProperty(property)">
+            <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
+          </button>
+        </div>
+      </div>
+    }
+  </v-form>
+</ng-container>
+
+<ng-template #addPropertyList>
+  @for (propertyOption of propertyOptions; track propertyOption) {
+    <cds-overflow-menu-option
+      *ngIf="!hasPropertyBeenAdded(propertyOption)"
+      (click)="addProperty(propertyOption)"
+    >
+      {{ translationKeyForPropertyList(propertyOption) | pluginTranslate: pluginId | async }}
+    </cds-overflow-menu-option>
+  }
+</ng-template>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component.scss
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component.scss
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.delete-button {
+  height: 46px;
+  width: 46px;
+  margin-top: 20px;
+
+  &:hover {
+    background-color: #e12717;
+  }
+}
+
+.add-button {
+  margin-block-end: var(--v-input-margin);
+}
+
+::ng-deep .cds--overflow-menu-options {
+  z-index: 10000 !important;
+  width: 230px;
+}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component.ts
@@ -1,0 +1,154 @@
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {FunctionConfigurationComponent} from '../../../../models';
+import {BehaviorSubject, combineLatest, Observable, Subscription, take} from 'rxjs';
+import {PatchZaakBesluitConfig} from '../../models';
+import {Add16, TrashCan16} from '@carbon/icons';
+import {
+  PatchBesluitProperties,
+  PatchBesluitPropertyOptions,
+} from '../../models/patch-besluit-properties';
+import {IconService} from 'carbon-components-angular';
+
+@Component({
+  standalone: false,
+  selector: 'valtimo-patch-zaak-besluit-configuration',
+  templateUrl: './patch-zaak-besluit-configuration.component.html',
+  styleUrls: ['./patch-zaak-besluit-configuration.component.scss'],
+})
+export class PatchZaakBesluitConfigurationComponent
+  implements FunctionConfigurationComponent, OnInit, OnDestroy
+{
+  @Input() save$: Observable<void>;
+  @Input() disabled$: Observable<boolean>;
+  @Input() pluginId: string;
+  @Input() prefillConfiguration$: Observable<PatchZaakBesluitConfig>;
+  @Output() valid = new EventEmitter<boolean>();
+  @Output() configuration = new EventEmitter<PatchZaakBesluitConfig>();
+
+  public readonly propertyOptions: PatchBesluitProperties[] = [...PatchBesluitPropertyOptions];
+  public propertyList: PatchBesluitProperties[] = [];
+
+  private readonly _formValue$ = new BehaviorSubject<PatchZaakBesluitConfig | null>(null);
+  private readonly _properties = new Map<PatchBesluitProperties, string>();
+  private readonly _valid$ = new BehaviorSubject<boolean>(false);
+  private _saveSubscription!: Subscription;
+  private _prefillConfig: PatchZaakBesluitConfig | null = null;
+
+  constructor(private readonly iconService: IconService) {
+    this.iconService.registerAll([Add16, TrashCan16]);
+  }
+
+  public ngOnInit(): void {
+    this.openSaveSubscription();
+
+    this.prefillConfiguration$.pipe(take(1)).subscribe(prefill => {
+      if (!prefill) return;
+
+      this._prefillConfig = prefill;
+
+      const prefilledProperties = this.propertyOptions.filter(
+        property => !!this.prefillValueFor(property, prefill)
+      );
+
+      this.propertyList = [...prefilledProperties];
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this._saveSubscription?.unsubscribe();
+  }
+
+  public onFormValueChanged(formValue: PatchZaakBesluitConfig): void {
+    this._formValue$.next(formValue);
+    this.handleValid(formValue);
+  }
+
+  public onPropertyChanged(property: PatchBesluitProperties, value: any): void {
+    this._properties.set(property, value);
+
+    const formValue = this._formValue$.value;
+    if (!formValue) return;
+
+    this._properties.forEach((propValue, key) => {
+      formValue[key] = propValue;
+    });
+
+    this.onFormValueChanged(formValue);
+  }
+
+  public prefillValueFor(property: string, prefill: PatchZaakBesluitConfig): string | null {
+    return prefill ? ((prefill as any)[property] ?? null) : null;
+  }
+
+  public translationKeyFor(property: string): string {
+    return property === 'description' ? 'omschrijving' : property;
+  }
+
+  public translationKeyForPropertyList(property: string): string {
+    return this.translationKeyFor(property);
+  }
+
+  public addProperty(property: PatchBesluitProperties): void {
+    if (!this.propertyList.includes(property)) {
+      this.propertyList = [...this.propertyList, property];
+      const formValue = this._formValue$.value;
+      if (formValue) this.handleValid(formValue);
+    }
+  }
+
+  public removeProperty(property: PatchBesluitProperties): void {
+    if (this.propertyList.includes(property)) {
+      this.propertyList = this.propertyList.filter(p => p !== property);
+      this._properties.delete(property);
+
+      const formValue = this._formValue$.value;
+      if (formValue) {
+        (formValue as any)[property] = undefined;
+        this.handleValid(formValue);
+      }
+    }
+  }
+
+  public hasPropertyBeenAdded(property: PatchBesluitProperties): boolean {
+    return this.propertyList.includes(property);
+  }
+
+  private handleValid(formValue: PatchZaakBesluitConfig): void {
+    const combined: any = {
+      ...((this._prefillConfig as any) || {}),
+      ...(formValue as any),
+    };
+
+    const besluitUrlValid = !!combined.besluitUrl;
+    const dynamicValid = this.propertyList.every(p => !!combined[p]);
+    const valid = besluitUrlValid && dynamicValid;
+
+    this._valid$.next(valid);
+    this.valid.emit(valid);
+  }
+
+  private openSaveSubscription(): void {
+    this._saveSubscription = this.save$?.subscribe(() => {
+      combineLatest([this._formValue$, this._valid$])
+        .pipe(take(1))
+        .subscribe(([formValue, valid]) => {
+          if (!valid || !formValue) return;
+
+          const combined: any = {
+            ...((this._prefillConfig as any) || {}),
+            ...(formValue as any),
+          };
+
+          const payload: PatchZaakBesluitConfig = {
+            besluitUrl: combined.besluitUrl,
+          };
+
+          this.propertyList.forEach(property => {
+            (payload as any)[property] = combined[property];
+          });
+
+          this.configuration.emit(payload);
+        });
+    });
+  }
+}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/config.ts
@@ -45,4 +45,23 @@ interface LinkDocumentToBesluitConfig {
   documentUrl: string;
 }
 
-export {BesluitenApiConfig, CreateZaakBesluitConfig, Vervalredenen, LinkDocumentToBesluitConfig};
+interface PatchZaakBesluitConfig {
+  besluitUrl: string;
+  beslisdatum?: string;
+  toelichting?: string;
+  bestuursorgaan?: string;
+  ingangsdatum?: string;
+  vervaldatum?: string;
+  vervalreden?: string;
+  publicatiedatum?: string;
+  verzenddatum?: string;
+  uiterlijkeReactiedatum?: string;
+}
+
+export {
+  BesluitenApiConfig,
+  CreateZaakBesluitConfig,
+  Vervalredenen,
+  LinkDocumentToBesluitConfig,
+  PatchZaakBesluitConfig,
+};

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/patch-besluit-properties.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/patch-besluit-properties.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const PatchBesluitPropertyOptions = [
+  'beslisdatum',
+  'toelichting',
+  'bestuursorgaan',
+  'ingangsdatum',
+  'vervaldatum',
+  'vervalreden',
+  'publicatiedatum',
+  'verzenddatum',
+  'uiterlijkeReactieDatum',
+] as const;
+export type PatchBesluitProperties = (typeof PatchBesluitPropertyOptions)[number];

--- a/frontend/projects/valtimo/plugin/src/public-api.ts
+++ b/frontend/projects/valtimo/plugin/src/public-api.ts
@@ -108,6 +108,7 @@ export * from './lib/plugins/besluiten-api/besluiten-api-plugin.module';
 export * from './lib/plugins/besluiten-api/besluiten-api-plugin.specification';
 export * from './lib/plugins/besluiten-api/components/besluiten-api-configuration/besluiten-api-configuration.component';
 export * from './lib/plugins/besluiten-api/components/create-zaak-besluit/create-zaak-besluit-configuration.component';
+export * from './lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component';
 export * from './lib/plugins/besluiten-api/components/link-document-to-besluit/link-document-to-besluit-configuration.component';
 /* exact */
 export * from './lib/plugins/exact/exact.plugin.specification';


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/148

it's about backporting https://github.com/valtimo-platform/valtimo/pull/150 to V12.

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 
https://github.com/valtimo-platform/valtimo/tree/story/145785-patch-besluit-backport-v12

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Specify the documents branch location:
Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Describe the testing steps
- [ ] Introduce a process to create and patch a besluit
- [ ] Make sure a besluit is created (Besluiten plugin -> create-besluit)
- [ ] Configure patch-besluit plugin action
- [ ] Run the process, check the besluit in openzaak if the properties are updated.
- [ ] A demo process: 'Vastleggen besluit' is added. A besluittype should be selected in the plugin action 'create-besluit'. Other necessary configuration is already in place.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
