### PR TITLE
Added `getRequestZoneOffset` method to allow for a proper fallback strategy

### DIFF
--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/utils/RequestHelper.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/utils/RequestHelper.java
@@ -18,6 +18,7 @@ package com.ritense.valtimo.contract.utils;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.ZoneOffset;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -28,6 +29,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class RequestHelper {
     private static final Logger logger = LoggerFactory.getLogger(RequestHelper.class);
+    public static final String X_TIMEZONE_OFFSET = "X-Timezone-Offset";
 
     private RequestHelper() {
     }
@@ -43,15 +45,30 @@ public class RequestHelper {
         return ipList.toString();
     }
 
+    /**
+     * This method retrieves the ZoneOffset from the X-Timezone-Offset header.
+     * When the header is not present, UTC is returned.
+     *
+     * @deprecated Please use <code>getRequestZoneOffset()</code> instead.
+     * @return ZoneOffset
+     */
+    @Deprecated(since = "13.6.0", forRemoval = true)
     public static ZoneOffset getZoneOffset() {
-        ZoneOffset zoneOffset = ZoneOffset.UTC;
+        return getRequestZoneOffset().orElse(ZoneOffset.UTC);
+    }
+
+    /**
+     * This method retrieves the ZoneOffset from the X-Timezone-Offset header, if present.
+     */
+    public static Optional<ZoneOffset> getRequestZoneOffset() {
+        ZoneOffset zoneOffset = null;
 
         try {
             RequestAttributes attribs = RequestContextHolder.getRequestAttributes();
 
             if (attribs != null) {
                 HttpServletRequest request = ((ServletRequestAttributes) attribs).getRequest();
-                String zoneOffsetHeader = request.getHeader("X-Timezone-Offset");
+                String zoneOffsetHeader = request.getHeader(X_TIMEZONE_OFFSET);
 
                 if (StringUtils.isNotBlank(zoneOffsetHeader)) {
                     zoneOffset = ZoneOffset.of(zoneOffsetHeader);
@@ -62,6 +79,6 @@ public class RequestHelper {
             logger.error(e.getMessage(), e);
         }
 
-        return zoneOffset;
+        return Optional.ofNullable(zoneOffset);
     }
 }

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/utils/RequestHelper.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/utils/RequestHelper.java
@@ -46,7 +46,7 @@ public class RequestHelper {
     }
 
     /**
-     * This method retrieves the ZoneOffset from the X-Timezone-Offset header.
+     * This method retrieves the ZoneOffset from the Timezone Offset header.
      * When the header is not present, UTC is returned.
      *
      * @return ZoneOffset
@@ -56,7 +56,7 @@ public class RequestHelper {
     }
 
     /**
-     * This method retrieves the ZoneOffset from the TIMEZONE_OFFSET_HEADER header, if present and valid.
+     * This method retrieves the ZoneOffset from the Timezone Offset header, if present and valid.
      */
     public static Optional<ZoneOffset> getRequestZoneOffset() {
         ZoneOffset zoneOffset = null;

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/utils/RequestHelper.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/utils/RequestHelper.java
@@ -29,7 +29,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class RequestHelper {
     private static final Logger logger = LoggerFactory.getLogger(RequestHelper.class);
-    public static final String X_TIMEZONE_OFFSET = "X-Timezone-Offset";
+    public static final String TIMEZONE_OFFSET_HEADER = "X-Timezone-Offset";
 
     private RequestHelper() {
     }
@@ -49,16 +49,14 @@ public class RequestHelper {
      * This method retrieves the ZoneOffset from the X-Timezone-Offset header.
      * When the header is not present, UTC is returned.
      *
-     * @deprecated Please use <code>getRequestZoneOffset()</code> instead.
      * @return ZoneOffset
      */
-    @Deprecated(since = "13.6.0", forRemoval = true)
     public static ZoneOffset getZoneOffset() {
         return getRequestZoneOffset().orElse(ZoneOffset.UTC);
     }
 
     /**
-     * This method retrieves the ZoneOffset from the X-Timezone-Offset header, if present.
+     * This method retrieves the ZoneOffset from the TIMEZONE_OFFSET_HEADER header, if present and valid.
      */
     public static Optional<ZoneOffset> getRequestZoneOffset() {
         ZoneOffset zoneOffset = null;
@@ -68,7 +66,7 @@ public class RequestHelper {
 
             if (attribs != null) {
                 HttpServletRequest request = ((ServletRequestAttributes) attribs).getRequest();
-                String zoneOffsetHeader = request.getHeader(X_TIMEZONE_OFFSET);
+                String zoneOffsetHeader = request.getHeader(TIMEZONE_OFFSET_HEADER);
 
                 if (StringUtils.isNotBlank(zoneOffsetHeader)) {
                     zoneOffset = ZoneOffset.of(zoneOffsetHeader);

--- a/backend/contract/src/test/java/com/ritense/valtimo/contract/utils/RequestHelperTest.java
+++ b/backend/contract/src/test/java/com/ritense/valtimo/contract/utils/RequestHelperTest.java
@@ -19,6 +19,8 @@ package com.ritense.valtimo.contract.utils;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -29,9 +31,14 @@ class RequestHelperTest {
     MockHttpServletRequest mockRequest;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         mockRequest = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
     }
 
     @Test
@@ -57,5 +64,119 @@ class RequestHelperTest {
         ZoneOffset zoneOffset = RequestHelper.getZoneOffset();
 
         assertThat(zoneOffset).isSameAs(ZoneOffset.of("+01:00"));
+    }
+
+    // Tests for getRequestZoneOffset method
+
+    @Test
+    void getRequestZoneOffsetShouldReturnEmptyWhenNoRequestContext() {
+        RequestContextHolder.resetRequestAttributes();
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isEmpty();
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnEmptyWhenHeaderNotPresent() {
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isEmpty();
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnEmptyWhenHeaderIsBlank() {
+        mockRequest.addHeader("X-Timezone-Offset", "");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isEmpty();
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnEmptyWhenHeaderIsWhitespace() {
+        mockRequest.addHeader("X-Timezone-Offset", "   ");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isEmpty();
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnZoneOffsetWhenValidPositiveOffset() {
+        mockRequest.addHeader("X-Timezone-Offset", "+01:00");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isPresent();
+        assertThat(zoneOffset.orElseThrow()).isEqualTo(ZoneOffset.of("+01:00"));
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnZoneOffsetWhenValidNegativeOffset() {
+        mockRequest.addHeader("X-Timezone-Offset", "-05:00");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isPresent();
+        assertThat(zoneOffset.orElseThrow()).isEqualTo(ZoneOffset.of("-05:00"));
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnZoneOffsetWhenValidUtcOffset() {
+        mockRequest.addHeader("X-Timezone-Offset", "Z");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isPresent();
+        assertThat(zoneOffset.orElseThrow()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnZoneOffsetWhenValidOffsetWithSeconds() {
+        mockRequest.addHeader("X-Timezone-Offset", "+05:30:00");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isPresent();
+        assertThat(zoneOffset.orElseThrow()).isEqualTo(ZoneOffset.of("+05:30:00"));
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnEmptyWhenInvalidOffset() {
+        mockRequest.addHeader("X-Timezone-Offset", "invalid-offset");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isEmpty();
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnEmptyWhenOffsetOutOfRange() {
+        mockRequest.addHeader("X-Timezone-Offset", "+25:00");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isEmpty();
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnZoneOffsetWhenValidShortFormat() {
+        mockRequest.addHeader("X-Timezone-Offset", "+01");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isPresent();
+        assertThat(zoneOffset.orElseThrow()).isEqualTo(ZoneOffset.of("+01"));
+    }
+
+    @Test
+    void getRequestZoneOffsetShouldReturnZoneOffsetWhenValidMinuteOnlyOffset() {
+        mockRequest.addHeader("X-Timezone-Offset", "+00:30");
+
+        Optional<ZoneOffset> zoneOffset = RequestHelper.getRequestZoneOffset();
+
+        assertThat(zoneOffset).isPresent();
+        assertThat(zoneOffset.orElseThrow()).isEqualTo(ZoneOffset.of("+00:30"));
     }
 }


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue:
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/433

This pull request introduces a new method, `getRequestZoneOffset`, to the `RequestHelper` class.
This change is aimed at improving clarity and functionality.

**Relevant comments:**
>

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [ ] Release notes have been written for these changes.

Specify the documents branch location:
Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable