### PR TITLE
story: 145785 add get zaakbesluiten plugin action backport v12

### DIFF
--- a/backend/app/gzac/src/main/resources/bpmn/vastleggen-besluit.bpmn
+++ b/backend/app/gzac/src/main/resources/bpmn/vastleggen-besluit.bpmn
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.1">
   <bpmn:collaboration id="Collaboration_1jayd0m" isClosed="false">
-    <bpmn:participant id="PatchBesluitParticipant" name="Vastleggen besluit" processRef="vastleggen-besluit" />
+    <bpmn:participant id="VastleggenBesluitParticipant" name="Vastleggen besluit" processRef="vastleggen-besluit" />
   </bpmn:collaboration>
   <bpmn:process id="vastleggen-besluit" name="Vastleggen besluit" processType="None" isClosed="false" isExecutable="true" operaton:versionTag="CD:bezwaar:1.0.1">
     <bpmn:startEvent id="startEventPatchBesluit">
       <bpmn:outgoing>Flow_1aqi6ks</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="LinkDocumentAanBesluitTask" name="Link besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
+    <bpmn:serviceTask id="LinkBesluitTask" name="Link besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
       <bpmn:incoming>Flow_0bm9i67</bpmn:incoming>
       <bpmn:outgoing>Flow_0z587ap</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -20,38 +20,48 @@
       <bpmn:incoming>Flow_1aqi6ks</bpmn:incoming>
       <bpmn:outgoing>Flow_1ej4yoc</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="Event_0cpeutm">
-      <bpmn:incoming>Flow_1qap1ym</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:serviceTask id="PatchBesluitTask" name="Patch besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
-      <bpmn:incoming>Flow_0mava74</bpmn:incoming>
-      <bpmn:outgoing>Flow_1qap1ym</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:userTask id="PatchBesluitUserTask" name="Patch besluit" camunda:candidateGroups="ROLE_ADMIN">
-      <bpmn:incoming>Flow_0z587ap</bpmn:incoming>
-      <bpmn:outgoing>Flow_0mava74</bpmn:outgoing>
-    </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_1aqi6ks" sourceRef="startEventPatchBesluit" targetRef="GetBesluitDocumentUrlTask" />
     <bpmn:sequenceFlow id="Flow_1ej4yoc" sourceRef="GetBesluitDocumentUrlTask" targetRef="CreateBesluitTask" />
-    <bpmn:sequenceFlow id="Flow_0bm9i67" sourceRef="CreateBesluitTask" targetRef="LinkDocumentAanBesluitTask" />
-    <bpmn:sequenceFlow id="Flow_0z587ap" sourceRef="LinkDocumentAanBesluitTask" targetRef="PatchBesluitUserTask" />
+    <bpmn:sequenceFlow id="Flow_0bm9i67" sourceRef="CreateBesluitTask" targetRef="LinkBesluitTask" />
+    <bpmn:sequenceFlow id="Flow_0z587ap" sourceRef="LinkBesluitTask" targetRef="GetBesluitUrlsTask" />
     <bpmn:sequenceFlow id="Flow_1qap1ym" sourceRef="PatchBesluitTask" targetRef="Event_0cpeutm" />
-    <bpmn:sequenceFlow id="Flow_0mava74" sourceRef="PatchBesluitUserTask" targetRef="PatchBesluitTask" />
     <bpmn:serviceTask id="CreateBesluitTask" name="Create besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
       <bpmn:incoming>Flow_1ej4yoc</bpmn:incoming>
       <bpmn:outgoing>Flow_0bm9i67</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:userTask id="PatchBesluitUserTask" name="Patch besluit" camunda:candidateGroups="ROLE_ADMIN">
+      <bpmn:incoming>Flow_0pzd4cx</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nppk7b</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="GetBesluitUrlsTask" name="Get besluit urls" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}" camunda:resultVariable="besluitDocumentUrl">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:outputParameter name="zaakbesluitUrl">${zaakbesluiten[0]}</camunda:outputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0z587ap</bpmn:incoming>
+      <bpmn:outgoing>Flow_0pzd4cx</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0pzd4cx" sourceRef="GetBesluitUrlsTask" targetRef="PatchBesluitUserTask" />
+    <bpmn:sequenceFlow id="Flow_0nppk7b" sourceRef="PatchBesluitUserTask" targetRef="PatchBesluitTask" />
+    <bpmn:serviceTask id="PatchBesluitTask" name="Patch besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
+      <bpmn:incoming>Flow_0nppk7b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qap1ym</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_0cpeutm">
+      <bpmn:incoming>Flow_1qap1ym</bpmn:incoming>
+    </bpmn:endEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1jayd0m">
-      <bpmndi:BPMNShape id="Participant_0t1hozn_di" bpmnElement="PatchBesluitParticipant" isHorizontal="true">
-        <dc:Bounds x="160" y="70" width="990" height="250" />
+      <bpmndi:BPMNShape id="Participant_0t1hozn_di" bpmnElement="VastleggenBesluitParticipant" isHorizontal="true">
+        <dc:Bounds x="160" y="70" width="1160" height="250" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEventPatchBesluit">
         <dc:Bounds x="210" y="182" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0kvdccs" bpmnElement="LinkDocumentAanBesluitTask">
+      <bpmndi:BPMNShape id="BPMNShape_0kvdccs" bpmnElement="LinkBesluitTask">
         <dc:Bounds x="600" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -59,19 +69,23 @@
         <dc:Bounds x="280" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0cpeutm_di" bpmnElement="Event_0cpeutm">
-        <dc:Bounds x="1059" y="182" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0tb6jh7" bpmnElement="PatchBesluitTask">
-        <dc:Bounds x="907" y="160" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0xjbg3r_di" bpmnElement="PatchBesluitUserTask">
-        <dc:Bounds x="760" y="160" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_02iquzq_di" bpmnElement="CreateBesluitTask">
         <dc:Bounds x="440" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xjbg3r_di" bpmnElement="PatchBesluitUserTask">
+        <dc:Bounds x="880" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1d3vt1t" bpmnElement="GetBesluitUrlsTask">
+        <dc:Bounds x="740" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tb6jh7" bpmnElement="PatchBesluitTask">
+        <dc:Bounds x="1030" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cpeutm_di" bpmnElement="Event_0cpeutm">
+        <dc:Bounds x="1182" y="182" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1aqi6ks_di" bpmnElement="Flow_1aqi6ks">
         <di:waypoint x="246" y="200" />
@@ -87,15 +101,19 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0z587ap_di" bpmnElement="Flow_0z587ap">
         <di:waypoint x="700" y="200" />
-        <di:waypoint x="760" y="200" />
+        <di:waypoint x="740" y="200" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qap1ym_di" bpmnElement="Flow_1qap1ym">
-        <di:waypoint x="1007" y="200" />
-        <di:waypoint x="1059" y="200" />
+        <di:waypoint x="1130" y="200" />
+        <di:waypoint x="1182" y="200" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mava74_di" bpmnElement="Flow_0mava74">
-        <di:waypoint x="860" y="200" />
-        <di:waypoint x="907" y="200" />
+      <bpmndi:BPMNEdge id="Flow_0pzd4cx_di" bpmnElement="Flow_0pzd4cx">
+        <di:waypoint x="840" y="200" />
+        <di:waypoint x="880" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nppk7b_di" bpmnElement="Flow_0nppk7b">
+        <di:waypoint x="980" y="200" />
+        <di:waypoint x="1030" y="200" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.patch-besluit.json
+++ b/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.patch-besluit.json
@@ -2,6 +2,12 @@
     "display": "form",
     "components": [
         {
+            "key": "pv.zaakbesluitUrl",
+            "type": "textfield",
+            "input": true,
+            "label": "ZaakbesluitUrl"
+        },
+        {
             "label": "Beslisdatum",
             "format": "yyyy-MM-dd hh:mm",
             "tableView": false,

--- a/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
+++ b/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
@@ -51,12 +51,21 @@
         "pluginConfigurationId": "857d4312-c420-4a22-979b-625818d97ed5",
         "pluginActionDefinitionKey": "patch-besluit",
         "actionProperties": {
-            "besluitUrl": "pv:besluitUrl",
+            "besluitUrl": "pv:zaakbesluitUrl",
             "beslisdatum": "pv:beslisdatum",
             "vervaldatum": "pv:vervaldatum",
             "vervalreden": "pv:vervalreden",
             "toelichting": "pv:toelichting"
-
+        }
+    },
+    {
+        "activityId": "GetBesluitUrlsTask",
+        "activityType": "bpmn:ServiceTask:start",
+        "processLinkType": "plugin",
+        "pluginConfigurationId": "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee",
+        "pluginActionDefinitionKey": "get-zaakbesluiten",
+        "actionProperties": {
+            "resultProcessVariable": "zaakbesluiten"
         }
     }
 ]

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -52,6 +52,7 @@ import com.ritense.zakenapi.domain.ZaakObject
 import com.ritense.zakenapi.domain.ZaakResponse
 import com.ritense.zakenapi.domain.ZaakResultaat
 import com.ritense.zakenapi.domain.ZaakStatus
+import com.ritense.zakenapi.domain.ZaakbesluitResponse
 import com.ritense.zakenapi.domain.ZaakopschortingRequest
 import com.ritense.zakenapi.domain.rol.BetrokkeneType
 import com.ritense.zakenapi.domain.rol.Rol
@@ -613,8 +614,8 @@ class ZakenApiPlugin(
 
     @PluginAction(
         key = "delete-zaakeigenschap",
-        title = "Create zaakeigenschap",
-        description = "Creates a zaakeigenschap",
+        title = "Delete zaakeigenschap",
+        description = "Deletes a zaakeigenschap",
         activityTypes = [SERVICE_TASK_START]
     )
     fun deleteZaakeigenschap(
@@ -670,6 +671,33 @@ class ZakenApiPlugin(
                 )
             )
         }
+    }
+
+    @PluginAction(
+        key = "get-zaakbesluiten",
+        title = "Get zaakbesluiten",
+        description = "This retreives all zaakbesluiten from a zaak",
+        activityTypes = [SERVICE_TASK_START]
+    )
+    fun getZaakbesluiten(
+        execution: DelegateExecution,
+        @PluginActionProperty resultProcessVariable: String
+    ): List<ZaakbesluitResponse> {
+        val documentId = UUID.fromString(execution.businessKey)
+        val zaakUrl = zaakUrlProvider.getZaakUrl(documentId)
+
+        logger.debug { "Retrieving zaakbesluiten from zaak '$zaakUrl' for document '${documentId}'" }
+
+        val zaakbesluiten = client.getZaakbesluiten(authenticationPluginConfiguration, url, zaakUrl)
+
+        resultProcessVariable.let { name ->
+            val besluiten = zaakbesluiten.map { it.besluit }
+            execution.setVariable(name, besluiten)
+        }
+
+        logger.info { "Zaakbesluiten retreived from zaak '$zaakUrl' for document '${documentId}'" }
+
+        return zaakbesluiten
     }
 
     @PluginAction(

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
@@ -36,6 +36,7 @@ import com.ritense.zakenapi.domain.ZaakObject
 import com.ritense.zakenapi.domain.ZaakResponse
 import com.ritense.zakenapi.domain.ZaakResultaat
 import com.ritense.zakenapi.domain.ZaakStatus
+import com.ritense.zakenapi.domain.ZaakbesluitResponse
 import com.ritense.zakenapi.domain.ZaakeigenschapResponse
 import com.ritense.zakenapi.domain.ZaakopschortingRequest
 import com.ritense.zakenapi.domain.ZaakopschortingResponse
@@ -62,6 +63,7 @@ import com.ritense.zakenapi.event.ZaakRollenListed
 import com.ritense.zakenapi.event.ZaakStatusCreated
 import com.ritense.zakenapi.event.ZaakStatusViewed
 import com.ritense.zakenapi.event.ZaakViewed
+import com.ritense.zakenapi.event.ZaakbesluitenListed
 import com.ritense.zakenapi.event.ZaakeigenschapCreated
 import com.ritense.zakenapi.event.ZaakeigenschapDeleted
 import com.ritense.zakenapi.event.ZaakeigenschapListed
@@ -531,6 +533,28 @@ class ZakenApiClient(
 
         outboxService.send {
             ZaakeigenschapListed(objectMapper.valueToTree(result))
+        }
+        return result
+    }
+
+    fun getZaakbesluiten(
+        authentication: ZakenApiAuthentication,
+        baseUrl: URI,
+        zaakUrl: URI,
+    ): List<ZaakbesluitResponse> {
+        validateUrlHost(baseUrl, zaakUrl)
+        val result = buildRestClient(authentication)
+            .get()
+            .uri {
+                ClientTools.baseUrlToBuilder(it, zaakUrl)
+                    .pathSegment("besluiten")
+                    .build()
+            }
+            .retrieve()
+            .body<List<ZaakbesluitResponse>>()!!
+
+        outboxService.send {
+            ZaakbesluitenListed(objectMapper.valueToTree(result))
         }
         return result
     }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/domain/ZaakbesluitResponse.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/domain/ZaakbesluitResponse.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.domain
+
+import java.net.URI
+import java.util.UUID
+
+data class ZaakbesluitResponse(
+    val url: URI,
+    val uuid: UUID,
+    val besluit: URI
+)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/event/ZaakbesluitenListed.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/event/ZaakbesluitenListed.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.event
+
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.ritense.outbox.domain.BaseEvent
+
+class ZaakbesluitenListed (zaakbesluiten: ArrayNode) : BaseEvent(
+    type = "com.ritense.gzac.zrc.zaakbesluiten.listed",
+    resultType = "List<com.ritense.zakenapi.domain.ZaakbesluitResponse>",
+    resultId = null,
+    result = zaakbesluiten
+)

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -17,9 +17,7 @@
 package com.ritense.zakenapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ritense.document.service.DocumentService
 import com.ritense.plugin.service.PluginService
-import com.ritense.processdocument.service.ProcessDocumentAssociationService
 import com.ritense.resource.service.TemporaryResourceStorageService
 import com.ritense.valueresolver.ValueResolverService
 import com.ritense.zakenapi.ZakenApiPlugin.Companion.DOCUMENT_URL_PROCESS_VAR
@@ -35,6 +33,7 @@ import com.ritense.zakenapi.domain.UpdateZaakeigenschapRequest
 import com.ritense.zakenapi.domain.ZaakHersteltermijn
 import com.ritense.zakenapi.domain.ZaakObject
 import com.ritense.zakenapi.domain.ZaakResponse
+import com.ritense.zakenapi.domain.ZaakbesluitResponse
 import com.ritense.zakenapi.domain.ZaakeigenschapResponse
 import com.ritense.zakenapi.domain.ZaakopschortingRequest
 import com.ritense.zakenapi.domain.rol.Rol
@@ -846,12 +845,14 @@ internal class ZakenApiPluginTest {
                     uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(50)
                 )
             )
-        whenever(zaakHersteltermijnRepository.findByZaakUrlAndEndDateIsNull(zaakUrl)).thenReturn(ZaakHersteltermijn(
-            zaakUrl = zaakUrl,
-            startDate = LocalDate.now().minusDays(8),
-            endDate =  null,
-            maxDurationInDays = 17
-        ))
+        whenever(zaakHersteltermijnRepository.findByZaakUrlAndEndDateIsNull(zaakUrl)).thenReturn(
+            ZaakHersteltermijn(
+                zaakUrl = zaakUrl,
+                startDate = LocalDate.now().minusDays(8),
+                endDate = null,
+                maxDurationInDays = 17
+            )
+        )
 
         val plugin = ZakenApiPlugin(
             zakenApiClient,
@@ -907,7 +908,7 @@ internal class ZakenApiPluginTest {
         whenever(zakenApiClient.createZaakeigenschap(any(), any(), any()))
             .thenReturn(
                 ZaakeigenschapResponse(
-                    url =  URI("https://example.com/zaken/1234/zaakeigenschappen/5678"),
+                    url = URI("https://example.com/zaken/1234/zaakeigenschappen/5678"),
                     zaak = zaakUrl,
                     eigenschap = eigenschapUrl,
                     waarde = "test-value"
@@ -1123,7 +1124,8 @@ internal class ZakenApiPluginTest {
             eq(authenticationMock),
             eq(plugin.url),
             eq(zaakUrl),
-            captor.capture())
+            captor.capture()
+        )
 
         val relevanteAndereZaken = captor.firstValue.relevanteAndereZaken
         assertThat(relevanteAndereZaken).hasSize(1)
@@ -1161,14 +1163,126 @@ internal class ZakenApiPluginTest {
         plugin.url = URI("https://zaken.plugin.url")
         plugin.authenticationPluginConfiguration = authenticationMock
 
-        plugin.createZaakObject(URI.create("https://zaak.url"), URI.create("https://object.url"), "zaakdetails", documentId)
+        plugin.createZaakObject(
+            URI.create("https://zaak.url"),
+            URI.create("https://object.url"),
+            "zaakdetails",
+            documentId
+        )
 
         val captor = argumentCaptor<ZaakObjectRequest>()
         verify(zakenApiClient).createZaakObject(any(), any(), captor.capture())
 
         val request = captor.firstValue
         assertEquals("https://zaak.url", request.zaakUrl.toString())
-        assertEquals("https://object.url", request.objectUrl.toString()
+        assertEquals(
+            "https://object.url", request.objectUrl.toString()
         )
     }
+
+    @Test
+    fun `should retreive zaakbesluiten`() {
+        val client: ZakenApiClient = mock()
+        val zaakUrlProvider: ZaakUrlProvider = mock()
+        val storageService: TemporaryResourceStorageService = mock()
+        val zaakInstanceLinkRepository: ZaakInstanceLinkRepository = mock()
+        val pluginService: PluginService = mock()
+        val zaakHersteltermijnRepository: ZaakHersteltermijnRepository = mock()
+        val platformTransactionManager: PlatformTransactionManager = mock()
+        val authenticationMock = mock<ZakenApiAuthentication>()
+        val valueResolverService: ValueResolverService = mock()
+        val objectMapper: ObjectMapper = mock()
+
+        val execution = mock<DelegateExecution>()
+        val documentId = UUID.randomUUID()
+        val resultProcessVariable = "zaakbesluiten"
+
+        whenever(execution.businessKey).thenReturn(documentId.toString())
+        whenever(zaakUrlProvider.getZaakUrl(documentId)).thenReturn(zaakUri())
+
+        val plugin = ZakenApiPlugin(
+            client,
+            zaakUrlProvider,
+            storageService,
+            zaakInstanceLinkRepository,
+            pluginService,
+            zaakHersteltermijnRepository,
+            platformTransactionManager,
+            valueResolverService,
+            objectMapper
+        )
+        plugin.url = URI("https://zaken.plugin.url")
+        plugin.authenticationPluginConfiguration = authenticationMock
+
+        val zaakbesluiten = listOf(
+            ZaakbesluitResponse(
+                url = zaakbesluitUri1(),
+                uuid = zaakbesluitUuid1(),
+                besluit = besluitUri1()
+            ),
+            ZaakbesluitResponse(
+                url = zaakbesluitUri2(),
+                uuid = zaakbesluitUuid2(),
+                besluit = besluitUri2()
+            )
+        )
+
+        whenever(
+            client.getZaakbesluiten(authenticationMock, zakenApiUri(), zaakUri())
+        ).thenReturn(zaakbesluiten)
+
+        val result = plugin.getZaakbesluiten(execution, resultProcessVariable)
+
+        assertEquals(2, result.size)
+        val first = result[0]
+        assertEquals(zaakbesluitUri1(), first.url)
+        assertEquals(zaakbesluitUuid1(), first.uuid)
+        assertEquals(besluitUri1(), first.besluit)
+
+        val second = result[1]
+        assertEquals(zaakbesluitUri2(), second.url)
+        assertEquals(zaakbesluitUuid2(), second.uuid)
+        assertEquals(besluitUri2(), second.besluit)
+
+        val expectedBesluitenList = zaakbesluiten.map { it.besluit }
+        verify(execution).setVariable(resultProcessVariable, expectedBesluitenList)
+
+        verify(client).getZaakbesluiten(authenticationMock, zakenApiUri(), zaakUri())
+    }
+
+    private fun zakenApiUrl() = "https://zaken.plugin.url"
+    private fun zakenApiUri() = URI(zakenApiUrl())
+
+    private fun zaakUrl(id: String = "e1e96e94-e7ff-47d1-9ea1-7c7c81713480") = "${zakenApiUrl()}/zaken/$id"
+    private fun zaakUri(id: String = "e1e96e94-e7ff-47d1-9ea1-7c7c81713480") = URI(zaakUrl(id))
+
+    private fun zaakbesluitId1() = "cccb4dd3-f4da-4812-b3a3-c05cd35722b0"
+    private fun zaakbesluitUuid1() =
+        UUID.fromString("cccb4dd3-f4da-4812-b3a3-c05cd35722b0")
+
+    private fun zaakbesluitId2() = "38f55c4a-370d-4530-9909-b486500d7d17"
+    private fun zaakbesluitUuid2() =
+        UUID.fromString("38f55c4a-370d-4530-9909-b486500d7d17")
+
+    private fun zaakbesluitUrl1(
+        zaakId: String = "15e83392-a68f-4c1a-8b93-932b54b2d83e"
+    ) = "${zakenApiUrl()}/zaken/$zaakId/besluiten/${zaakbesluitId1()}"
+
+    private fun zaakbesluitUrl2(
+        zaakId: String = "15e83392-a68f-4c1a-8b93-932b54b2d83e"
+    ) = "${zakenApiUrl()}/zaken/$zaakId/besluiten/${zaakbesluitId2()}"
+
+    private fun zaakbesluitUri1() = URI(zaakbesluitUrl1())
+    private fun zaakbesluitUri2() = URI(zaakbesluitUrl2())
+
+    private fun besluitUrl1(
+        besluitId: String = zaakbesluitId1()
+    ) = "${zakenApiUrl()}/besluiten/$besluitId"
+
+    private fun besluitUrl2(
+        besluitId: String = zaakbesluitId2()
+    ) = "${zakenApiUrl()}/besluiten/$besluitId"
+
+    private fun besluitUri1() = URI(besluitUrl1())
+    private fun besluitUri2() = URI(besluitUrl2())
 }

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/get-zaakbesluiten/get-zaakbesluiten-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/get-zaakbesluiten/get-zaakbesluiten-configuration.component.html
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright 2015-2025 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<v-form
+  (valueChange)="formValueChange($event)"
+  *ngIf="{
+    disabled: disabled$ | async,
+    prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
+  } as obs"
+>
+  <v-input
+    name="resultProcessVariable"
+    [title]="'resultProcessVariable' | pluginTranslate: pluginId | async"
+    [margin]="true"
+    [defaultValue]="obs.prefill?.resultProcessVariable"
+    [disabled]="obs.disabled"
+    [required]="true"
+    [trim]="true"
+    [tooltip]="'resultProcessVariableTooltip' | pluginTranslate: pluginId | async"
+  ></v-input>
+</v-form>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/get-zaakbesluiten/get-zaakbesluiten-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/get-zaakbesluiten/get-zaakbesluiten-configuration.component.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {FunctionConfigurationComponent} from '../../../../models';
+import {BehaviorSubject, combineLatest, Observable, Subscription, take} from 'rxjs';
+import {GetZaakbesluitenConfig} from '../../models';
+
+@Component({
+  selector: 'valtimo-get-zaakbesluiten-configuration',
+  templateUrl: './get-zaakbesluiten-configuration.component.html',
+  standalone: false,
+})
+export class GetZaakbesluitenConfigurationComponent
+  implements FunctionConfigurationComponent, OnInit, OnDestroy
+{
+  @Input() save$: Observable<void>;
+  @Input() disabled$: Observable<boolean>;
+  @Input() pluginId: string;
+  @Input() prefillConfiguration$: Observable<GetZaakbesluitenConfig>;
+  @Output() valid: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() configuration: EventEmitter<GetZaakbesluitenConfig> =
+    new EventEmitter<GetZaakbesluitenConfig>();
+
+  private saveSubscription!: Subscription;
+  private readonly formValue$ = new BehaviorSubject<GetZaakbesluitenConfig | null>(null);
+  private readonly valid$ = new BehaviorSubject<boolean>(false);
+
+  public ngOnInit(): void {
+    this.openSaveSubscription();
+    this.valid.emit(true);
+  }
+
+  public ngOnDestroy(): void {
+    this.saveSubscription?.unsubscribe();
+  }
+
+  private openSaveSubscription(): void {
+    this.saveSubscription = this.save$?.subscribe(save => {
+      combineLatest([this.formValue$, this.valid$])
+        .pipe(take(1))
+        .subscribe(([formValue, valid]) => {
+          if (valid) {
+            this.configuration.emit(formValue);
+          }
+        });
+    });
+  }
+
+  public formValueChange(formValue: GetZaakbesluitenConfig): void {
+    this.formValue$.next(formValue);
+    this.handleValid(formValue);
+  }
+
+  private handleValid(formValue: GetZaakbesluitenConfig): void {
+    const valid = !!formValue.resultProcessVariable;
+
+    this.valid$.next(valid);
+    this.valid.emit(valid);
+  }
+}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
@@ -103,6 +103,10 @@ interface RelateerZakenConfig {
   aardRelatie: string;
 }
 
+interface GetZaakbesluitenConfig {
+  resultProcessVariable: string;
+}
+
 export {
   ZakenApiConfig,
   LinkDocumentToZaakConfig,
@@ -118,4 +122,5 @@ export {
   UpdateZaakeigenschapConfig,
   DeleteZaakeigenschapConfig,
   RelateerZakenConfig,
+  GetZaakbesluitenConfig,
 };

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.module.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.module.ts
@@ -50,6 +50,9 @@ import {UpdateZaakeigenschapComponent} from './components/update-zaakeigenschap/
 import {DeleteZaakeigenschapComponent} from './components/delete-zaakeigenschap/delete-zaakeigenschap.component';
 import {CreateZaakObjectConfigurationComponent} from './components/create-zaak-object/create-zaak-object-configuration.component';
 import {RelateerZakenComponent} from './components/relateer-zaken/relateer-zaken.component';
+import {
+  GetZaakbesluitenConfigurationComponent
+} from './components/get-zaakbesluiten/get-zaakbesluiten-configuration.component';
 import {TranslateModule} from '@ngx-translate/core';
 
 @NgModule({
@@ -71,6 +74,7 @@ import {TranslateModule} from '@ngx-translate/core';
     DeleteZaakeigenschapComponent,
     CreateZaakObjectConfigurationComponent,
     RelateerZakenComponent,
+    GetZaakbesluitenConfigurationComponent,
   ],
   imports: [
     CommonModule,
@@ -107,6 +111,7 @@ import {TranslateModule} from '@ngx-translate/core';
     DeleteZaakeigenschapComponent,
     CreateZaakObjectConfigurationComponent,
     RelateerZakenComponent,
+    GetZaakbesluitenConfigurationComponent,
   ],
 })
 export class ZakenApiPluginModule {}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
@@ -33,6 +33,7 @@ import {DeleteZaakeigenschapComponent} from './components/delete-zaakeigenschap/
 import {CreateZaakObjectConfigurationComponent} from './components/create-zaak-object/create-zaak-object-configuration.component';
 import {RelateerZakenComponent} from './components/relateer-zaken/relateer-zaken.component';
 import {DeleteZaakRolComponent} from './components/delete-zaak-rol/delete-zaak-rol.component';
+import {GetZaakbesluitenConfigurationComponent} from './components/get-zaakbesluiten/get-zaakbesluiten-configuration.component';
 
 const zakenApiPluginSpecification: PluginSpecification = {
   pluginId: 'zakenapi',
@@ -55,6 +56,7 @@ const zakenApiPluginSpecification: PluginSpecification = {
     'delete-zaakeigenschap': DeleteZaakeigenschapComponent,
     'create-zaak-object': CreateZaakObjectConfigurationComponent,
     'relateer-zaken': RelateerZakenComponent,
+    'get-zaakbesluiten': GetZaakbesluitenConfigurationComponent,
   },
   pluginTranslations: {
     nl: {
@@ -207,6 +209,8 @@ const zakenApiPluginSpecification: PluginSpecification = {
       resultProcessVariable: 'Resultaat process variable',
       rolUuid: 'Rol UUID',
       rolUuidTooltip: 'De UUID van de rol',
+      resultProcessVariableTooltip: 'De naam van de procesvariabele waarin het resultaat wordt opgeslagen.',
+      'get-zaakbesluiten': 'Ophalen zaakbesluiten',
     },
     en: {
       title: 'Zaken API',
@@ -357,6 +361,8 @@ const zakenApiPluginSpecification: PluginSpecification = {
       resultProcessVariable: 'Result process variable',
       rolUuid: 'Rol UUID',
       rolUuidTooltip: 'The UUID of the rol',
+      resultProcessVariableTooltip: 'The name of the process variable in which the result is stored.',
+      'get-zaakbesluiten': 'Retrieve zaakbesluiten',
     },
     de: {
       title: 'Zaken API',
@@ -506,6 +512,8 @@ const zakenApiPluginSpecification: PluginSpecification = {
       resultProcessVariable: 'Ergebnis process variable',
       rolUuid: 'Rolle UUID',
       rolUuidTooltip: 'Die UUID der Rolle',
+      resultProcessVariableTooltip: 'Der Name der Prozessvariable, in der das Ergebnis gespeichert wird.',
+      'get-zaakbesluiten': 'Zaakbesluiten abrufen',
     },
   },
 };

--- a/frontend/projects/valtimo/plugin/src/public-api.ts
+++ b/frontend/projects/valtimo/plugin/src/public-api.ts
@@ -72,6 +72,7 @@ export * from './lib/plugins/zaken-api/components/delete-zaakeigenschap/delete-z
 export * from './lib/plugins/zaken-api/components/create-zaak-object/create-zaak-object-configuration.component';
 export * from './lib/plugins/zaken-api/components/relateer-zaken/relateer-zaken.component';
 export * from './lib/plugins/zaken-api/components/delete-zaak-rol/delete-zaak-rol.component'
+export * from './lib/plugins/zaken-api/components/get-zaakbesluiten/get-zaakbesluiten-configuration.component';
 /* objecten api plugin */
 export * from './lib/plugins/objecten-api/objecten-api-plugin-module';
 export * from './lib/plugins/objecten-api/objecten-api-plugin.specification';


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/139


<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
backport for this PR:  https://github.com/valtimo-platform/valtimo/pull/162
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Specify the documents branch location:
Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Describe the testing steps
- [ ] Introduce a process to create besluit, add a service task to get zaakbesluiten
- [ ] Create some besluits (Plugin action: Besluiten API Plugin -> create-besluit)
- [ ] Configure the get-besluiten Plugin action (Zaken API -> get-besluiten)
- [ ] Run the process and verify that the process variable is populated
- [ ] A demo process: 'Vastleggen besluit' is added. A besluittype should be selected in the plugin action 'create-besluit'. Other necessary configuration is already in place.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
