### PR TITLE
story:145785 backport v12 get-besluit-from-besluiten-api.

### DIFF
--- a/backend/app/gzac/src/main/resources/bpmn/vastleggen-besluit.bpmn
+++ b/backend/app/gzac/src/main/resources/bpmn/vastleggen-besluit.bpmn
@@ -7,7 +7,7 @@
     <bpmn:startEvent id="startEventPatchBesluit">
       <bpmn:outgoing>Flow_1aqi6ks</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="LinkBesluitTask" name="Link besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
+    <bpmn:serviceTask id="LinkDocumentAanBesluitTask" name="Link document aan besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
       <bpmn:incoming>Flow_0bm9i67</bpmn:incoming>
       <bpmn:outgoing>Flow_0z587ap</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -22,28 +22,30 @@
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1aqi6ks" sourceRef="startEventPatchBesluit" targetRef="GetBesluitDocumentUrlTask" />
     <bpmn:sequenceFlow id="Flow_1ej4yoc" sourceRef="GetBesluitDocumentUrlTask" targetRef="CreateBesluitTask" />
-    <bpmn:sequenceFlow id="Flow_0bm9i67" sourceRef="CreateBesluitTask" targetRef="LinkBesluitTask" />
-    <bpmn:sequenceFlow id="Flow_0z587ap" sourceRef="LinkBesluitTask" targetRef="GetBesluitUrlsTask" />
+    <bpmn:sequenceFlow id="Flow_0bm9i67" sourceRef="CreateBesluitTask" targetRef="LinkDocumentAanBesluitTask" />
+    <bpmn:sequenceFlow id="Flow_0z587ap" sourceRef="LinkDocumentAanBesluitTask" targetRef="GetBesluitUrlsTask" />
     <bpmn:sequenceFlow id="Flow_1qap1ym" sourceRef="PatchBesluitTask" targetRef="Event_0cpeutm" />
     <bpmn:serviceTask id="CreateBesluitTask" name="Create besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
       <bpmn:incoming>Flow_1ej4yoc</bpmn:incoming>
       <bpmn:outgoing>Flow_0bm9i67</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="PatchBesluitUserTask" name="Patch besluit" camunda:candidateGroups="ROLE_ADMIN">
-      <bpmn:incoming>Flow_0pzd4cx</bpmn:incoming>
-      <bpmn:outgoing>Flow_0nppk7b</bpmn:outgoing>
-    </bpmn:userTask>
     <bpmn:serviceTask id="GetBesluitUrlsTask" name="Get besluit urls" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}" camunda:resultVariable="besluitDocumentUrl">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:outputParameter name="zaakbesluitUrl">${zaakbesluiten[0]}</camunda:outputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
+      <bpmn:extensionElements />
       <bpmn:incoming>Flow_0z587ap</bpmn:incoming>
       <bpmn:outgoing>Flow_0pzd4cx</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0pzd4cx" sourceRef="GetBesluitUrlsTask" targetRef="PatchBesluitUserTask" />
+    <bpmn:sequenceFlow id="Flow_0pzd4cx" sourceRef="GetBesluitUrlsTask" targetRef="Activity_0vbeoph" />
     <bpmn:sequenceFlow id="Flow_0nppk7b" sourceRef="PatchBesluitUserTask" targetRef="PatchBesluitTask" />
+    <bpmn:sequenceFlow id="Flow_01wttlt" sourceRef="GetBesluitByUrlTask" targetRef="PatchBesluitUserTask" />
+    <bpmn:sequenceFlow id="Flow_1dieea9" sourceRef="Activity_0vbeoph" targetRef="GetBesluitByUrlTask" />
+    <bpmn:serviceTask id="Activity_0vbeoph" name="Get the latest besluit url" camunda:asyncAfter="true" camunda:expression="${zaakbesluiten[0]}" camunda:resultVariable="zaakbesluitUrl">
+      <bpmn:incoming>Flow_0pzd4cx</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dieea9</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:userTask id="PatchBesluitUserTask" name="Patch besluit" camunda:candidateGroups="ROLE_ADMIN">
+      <bpmn:incoming>Flow_01wttlt</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nppk7b</bpmn:outgoing>
+    </bpmn:userTask>
     <bpmn:serviceTask id="PatchBesluitTask" name="Patch besluit" camunda:asyncAfter="true" implementation="##WebService" camunda:expression="${true}">
       <bpmn:incoming>Flow_0nppk7b</bpmn:incoming>
       <bpmn:outgoing>Flow_1qap1ym</bpmn:outgoing>
@@ -51,17 +53,21 @@
     <bpmn:endEvent id="Event_0cpeutm">
       <bpmn:incoming>Flow_1qap1ym</bpmn:incoming>
     </bpmn:endEvent>
+    <bpmn:serviceTask id="GetBesluitByUrlTask" name="Get besluit by the url" camunda:asyncAfter="true" camunda:expression="${true}">
+      <bpmn:incoming>Flow_1dieea9</bpmn:incoming>
+      <bpmn:outgoing>Flow_01wttlt</bpmn:outgoing>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1jayd0m">
       <bpmndi:BPMNShape id="Participant_0t1hozn_di" bpmnElement="VastleggenBesluitParticipant" isHorizontal="true">
-        <dc:Bounds x="160" y="70" width="1160" height="250" />
+        <dc:Bounds x="160" y="70" width="1410" height="250" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEventPatchBesluit">
         <dc:Bounds x="210" y="182" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0kvdccs" bpmnElement="LinkBesluitTask">
+      <bpmndi:BPMNShape id="BPMNShape_0kvdccs" bpmnElement="LinkDocumentAanBesluitTask">
         <dc:Bounds x="600" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -72,20 +78,28 @@
       <bpmndi:BPMNShape id="Activity_02iquzq_di" bpmnElement="CreateBesluitTask">
         <dc:Bounds x="440" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0xjbg3r_di" bpmnElement="PatchBesluitUserTask">
-        <dc:Bounds x="880" y="160" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1d3vt1t" bpmnElement="GetBesluitUrlsTask">
         <dc:Bounds x="740" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nd1xle_di" bpmnElement="Activity_0vbeoph">
+        <dc:Bounds x="900" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xjbg3r_di" bpmnElement="PatchBesluitUserTask">
+        <dc:Bounds x="1200" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0tb6jh7" bpmnElement="PatchBesluitTask">
-        <dc:Bounds x="1030" y="160" width="100" height="80" />
+        <dc:Bounds x="1350" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0cpeutm_di" bpmnElement="Event_0cpeutm">
-        <dc:Bounds x="1182" y="182" width="36" height="36" />
+        <dc:Bounds x="1502" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wih9x4_di" bpmnElement="GetBesluitByUrlTask">
+        <dc:Bounds x="1050" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1aqi6ks_di" bpmnElement="Flow_1aqi6ks">
         <di:waypoint x="246" y="200" />
@@ -104,16 +118,24 @@
         <di:waypoint x="740" y="200" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qap1ym_di" bpmnElement="Flow_1qap1ym">
-        <di:waypoint x="1130" y="200" />
-        <di:waypoint x="1182" y="200" />
+        <di:waypoint x="1450" y="200" />
+        <di:waypoint x="1502" y="200" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0pzd4cx_di" bpmnElement="Flow_0pzd4cx">
         <di:waypoint x="840" y="200" />
-        <di:waypoint x="880" y="200" />
+        <di:waypoint x="900" y="200" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0nppk7b_di" bpmnElement="Flow_0nppk7b">
-        <di:waypoint x="980" y="200" />
-        <di:waypoint x="1030" y="200" />
+        <di:waypoint x="1300" y="200" />
+        <di:waypoint x="1350" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01wttlt_di" bpmnElement="Flow_01wttlt">
+        <di:waypoint x="1150" y="200" />
+        <di:waypoint x="1200" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dieea9_di" bpmnElement="Flow_1dieea9">
+        <di:waypoint x="1000" y="200" />
+        <di:waypoint x="1050" y="200" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.patch-besluit.json
+++ b/backend/app/gzac/src/main/resources/config/form/vastleggen-besluit.patch-besluit.json
@@ -2,50 +2,155 @@
     "display": "form",
     "components": [
         {
-            "key": "pv.zaakbesluitUrl",
-            "type": "textfield",
-            "input": true,
-            "label": "ZaakbesluitUrl"
+            "key": "retrievedBesluitData",
+            "tag": "div",
+            "type": "htmlelement",
+            "input": false,
+            "label": "Retrieved besluit data",
+            "content": "<h4>Retrieved besluit data</h4>",
+            "tableView": false,
+            "refreshOnChange": false
         },
         {
-            "label": "Beslisdatum",
-            "format": "yyyy-MM-dd hh:mm",
+            "key": "pv:besluit",
+            "type": "container",
+            "input": true,
+            "label": "Besluit data",
             "tableView": false,
-            "datePicker": {
-                "disableWeekends": false,
-                "disableWeekdays": false
+            "attributes": {
+                "data-testid": "vastleggen-besluit.patch-besluit-pv:besluit"
             },
-            "defaultDate": "moment()",
-            "enableMinDateInput": false,
-            "enableMaxDateInput": false,
-            "validateWhenHidden": false,
+            "components": [
+                {
+                    "key": "url",
+                    "type": "textfield",
+                    "input": true,
+                    "label": "URL",
+                    "disabled": true,
+                    "tableView": true,
+                    "attributes": {
+                        "data-testid": "vastleggen-besluit.patch-besluit-url"
+                    }
+                },
+                {
+                    "key": "datum",
+                    "type": "textfield",
+                    "input": true,
+                    "label": "Beslisdatum",
+                    "disabled": true,
+                    "tableView": true,
+                    "attributes": {
+                        "data-testid": "vastleggen-besluit.patch-besluit-datum"
+                    },
+                    "enableDate": true,
+                    "enableTime": false
+                },
+                {
+                    "key": "toelichting",
+                    "type": "textfield",
+                    "input": true,
+                    "label": "Toelichting",
+                    "disabled": true,
+                    "tableView": true,
+                    "attributes": {
+                        "data-testid": "vastleggen-besluit.patch-besluit-toelichting"
+                    }
+                },
+                {
+                    "key": "vervaldatum",
+                    "type": "textfield",
+                    "input": true,
+                    "label": "Vervaldatum",
+                    "disabled": true,
+                    "tableView": true,
+                    "attributes": {
+                        "data-testid": "vastleggen-besluit.patch-besluit-vervaldatum"
+                    }
+                },
+                {
+                    "key": "vervalreden",
+                    "type": "textfield",
+                    "input": true,
+                    "label": "Vervalreden",
+                    "disabled": true,
+                    "tableView": true,
+                    "attributes": {
+                        "data-testid": "vastleggen-besluit.patch-besluit-vervalreden"
+                    }
+                }
+            ]
+        },
+        {
+            "key": "patchData",
+            "tag": "div",
+            "type": "htmlelement",
+            "input": false,
+            "label": "Patch data",
+            "content": "<h4>Besluit properties to patch</h4>",
+            "tableView": false,
+            "refreshOnChange": false
+        },
+        {
             "key": "pv.beslisdatum",
             "type": "datetime",
             "input": true,
+            "label": "Beslisdatum",
+            "format": "yyyy-MM-dd",
             "widget": {
-                "type": "calendar",
-                "displayInTimezone": "viewer",
-                "locale": "en",
-                "useLocaleSettings": false,
-                "allowInput": true,
                 "mode": "single",
-                "enableTime": true,
-                "noCalendar": false,
-                "format": "yyyy-MM-dd hh:mm",
-                "hourIncrement": 1,
-                "minuteIncrement": 1,
-                "time_24hr": false,
+                "type": "calendar",
+                "format": "yyyy-MM-dd",
+                "locale": "en",
+                "maxDate": null,
                 "minDate": null,
-                "disableWeekends": false,
+                "time_24hr": true,
+                "allowInput": true,
+                "enableTime": false,
+                "noCalendar": false,
+                "hourIncrement": 1,
                 "disableWeekdays": false,
-                "maxDate": null
-            }
+                "disableWeekends": false,
+                "minuteIncrement": 1,
+                "displayInTimezone": "viewer",
+                "useLocaleSettings": false
+            },
+            "tableView": false,
+            "attributes": {
+                "data-testid": "vastleggen-besluit.patch-besluit-pv.beslisdatum"
+            },
+            "datePicker": {
+                "disableWeekdays": false,
+                "disableWeekends": false
+            },
+            "enableTime": false,
+            "timePicker": {
+                "showMeridian": false
+            },
+            "defaultDate": "moment()",
+            "enableMaxDateInput": false,
+            "enableMinDateInput": false,
+            "validateWhenHidden": false
+        },
+        {
+            "key": "pv.toelichting",
+            "type": "textfield",
+            "input": true,
+            "label": "Toelichting",
+            "tableView": true,
+            "attributes": {
+                "data-testid": "vastleggen-besluit.patch-besluit-pv.toelichting"
+            },
+            "defaultValue": "Toelichting-2"
         },
         {
             "key": "pv.vervaldatum",
             "type": "textfield",
             "input": true,
             "label": "Vervaldatum",
+            "tableView": true,
+            "attributes": {
+                "data-testid": "vastleggen-besluit.patch-besluit-pv.vervaldatum"
+            },
             "defaultValue": "2025-11-14"
         },
         {
@@ -53,14 +158,11 @@
             "type": "textfield",
             "input": true,
             "label": "Vervalreden",
+            "tableView": true,
+            "attributes": {
+                "data-testid": "vastleggen-besluit.patch-besluit-pv.vervalreden"
+            },
             "defaultValue": "ingetrokken_overheid"
-        },
-        {
-            "key": "pv.toelichting",
-            "type": "textfield",
-            "input": true,
-            "label": "Toelichting",
-            "defaultValue": "Toelichting-2"
         },
         {
             "key": "submit",

--- a/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
+++ b/backend/app/gzac/src/main/resources/config/processlink/vastleggen-besluit.processlink.json
@@ -39,6 +39,27 @@
         }
     },
     {
+        "activityId": "GetBesluitUrlsTask",
+        "activityType": "bpmn:ServiceTask:start",
+        "processLinkType": "plugin",
+        "pluginConfigurationId": "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee",
+        "pluginActionDefinitionKey": "get-zaakbesluiten",
+        "actionProperties": {
+            "resultProcessVariable": "zaakbesluiten"
+        }
+    },
+    {
+        "activityId": "GetBesluitByUrlTask",
+        "activityType": "bpmn:ServiceTask:start",
+        "processLinkType": "plugin",
+        "pluginConfigurationId": "857d4312-c420-4a22-979b-625818d97ed5",
+        "pluginActionDefinitionKey": "get-besluit",
+        "actionProperties": {
+            "besluitUrl": "pv:zaakbesluitUrl",
+            "resultProcessVariable": "besluit"
+        }
+    },
+    {
         "activityId": "PatchBesluitUserTask",
         "activityType": "bpmn:UserTask:create",
         "processLinkType": "form",
@@ -56,16 +77,6 @@
             "vervaldatum": "pv:vervaldatum",
             "vervalreden": "pv:vervalreden",
             "toelichting": "pv:toelichting"
-        }
-    },
-    {
-        "activityId": "GetBesluitUrlsTask",
-        "activityType": "bpmn:ServiceTask:start",
-        "processLinkType": "plugin",
-        "pluginConfigurationId": "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee",
-        "pluginActionDefinitionKey": "get-zaakbesluiten",
-        "actionProperties": {
-            "resultProcessVariable": "zaakbesluiten"
         }
     }
 ]

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiAutoConfiguration.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.besluitenapi
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.besluitenapi.client.BesluitenApiClient
 import com.ritense.plugin.service.PluginService
 import com.ritense.zakenapi.ZaakUrlProvider
@@ -34,11 +35,13 @@ class BesluitenApiAutoConfiguration {
         pluginService: PluginService,
         besluitenApiClient: BesluitenApiClient,
         urlProvider: ZaakUrlProvider,
+        objectMapper: ObjectMapper
     ): BesluitenApiPluginFactory {
         return BesluitenApiPluginFactory(
             pluginService,
             besluitenApiClient,
-            urlProvider
+            urlProvider,
+            objectMapper
         )
     }
 }

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiPlugin.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiPlugin.kt
@@ -16,7 +16,9 @@
 
 package com.ritense.besluitenapi
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.besluitenapi.client.Besluit
+import com.ritense.besluitenapi.client.BesluitNotFoundException
 import com.ritense.besluitenapi.client.BesluitenApiClient
 import com.ritense.besluitenapi.client.CreateBesluitInformatieObject
 import com.ritense.besluitenapi.client.CreateBesluitRequest
@@ -27,7 +29,7 @@ import com.ritense.plugin.annotation.Plugin
 import com.ritense.plugin.annotation.PluginAction
 import com.ritense.plugin.annotation.PluginActionProperty
 import com.ritense.plugin.annotation.PluginProperty
-import com.ritense.processlink.domain.ActivityTypeWithEventName
+import com.ritense.processlink.domain.ActivityTypeWithEventName.SERVICE_TASK_START
 import com.ritense.valtimo.contract.validation.Url
 import com.ritense.zakenapi.ZaakUrlProvider
 import com.ritense.zgw.LoggingConstants.BESLUITEN_API
@@ -48,6 +50,7 @@ import java.util.UUID
 class BesluitenApiPlugin(
     private val besluitenApiClient: BesluitenApiClient,
     private val zaakUrlProvider: ZaakUrlProvider,
+    private val objectMapper: ObjectMapper
 ) {
     @Url
     @PluginProperty(key = "url", secret = false)
@@ -63,7 +66,7 @@ class BesluitenApiPlugin(
         key = "link-document-to-besluit",
         title = "Link Document to besluit",
         description = "Links a document to a besluit",
-        activityTypes = [ActivityTypeWithEventName.SERVICE_TASK_START]
+        activityTypes = [SERVICE_TASK_START]
     )
     fun linkDocumentToBesluit(
         @PluginActionProperty documentUrl: String,
@@ -89,7 +92,7 @@ class BesluitenApiPlugin(
         key = "create-besluit",
         title = "Create besluit",
         description = "Creates a besluit in the Besluiten API",
-        activityTypes = [ActivityTypeWithEventName.SERVICE_TASK_START]
+        activityTypes = [SERVICE_TASK_START]
     )
     fun createBesluit(
         execution: DelegateExecution,
@@ -132,7 +135,7 @@ class BesluitenApiPlugin(
         key = "patch-besluit",
         title = "Patch besluit",
         description = "Patches a besluit in the Besluiten API",
-        activityTypes = [ActivityTypeWithEventName.SERVICE_TASK_START]
+        activityTypes = [SERVICE_TASK_START]
     )
     fun patchBesluit(
         execution: DelegateExecution,
@@ -164,6 +167,40 @@ class BesluitenApiPlugin(
                 uiterlijkeReactieDatum = uiterlijkeReactieDatum?.let { toLocalDate(it) }
             )
         }
+    }
+
+    @PluginAction(
+        key = "get-besluit",
+        title = "Get besluit",
+        description = "This retreives a besluit from Besluiten API",
+        activityTypes = [SERVICE_TASK_START]
+    )
+    fun getBesluit(
+        execution: DelegateExecution,
+        @PluginActionProperty besluitUrl: String,
+        @PluginActionProperty resultProcessVariable: String
+    ): Besluit {
+        val documentId = UUID.fromString(execution.businessKey)
+
+        logger.debug { "Retrieving besluit with besluitUrl '$besluitUrl' for document '$documentId'" }
+
+        val besluit = try {
+            besluitenApiClient.getBesluit(
+                authenticationPluginConfiguration,
+                url,
+                getUuid(besluitUrl)
+            )
+        } catch (ex: Exception) {
+            throw BesluitNotFoundException(besluitUrl)
+        }
+
+        resultProcessVariable.let { name ->
+            execution.setVariable(name, objectMapper.valueToTree(besluit))
+        }
+
+        logger.info { "Besluit retrieved with besluitUrl '$besluitUrl' for document '$documentId'" }
+
+        return besluit
     }
 
     fun patchBesluit(
@@ -234,6 +271,11 @@ class BesluitenApiPlugin(
 
     private fun toLocalDate(date: String): LocalDate {
         return LocalDate.parse(date.take(10))
+    }
+
+    private fun getUuid(url: String): String {
+        return url.trimEnd('/')
+            .substringAfterLast('/')
     }
 
     companion object {

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiPluginFactory.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/BesluitenApiPluginFactory.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.besluitenapi
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.besluitenapi.client.BesluitenApiClient
 import com.ritense.plugin.PluginFactory
 import com.ritense.plugin.service.PluginService
@@ -25,11 +26,13 @@ class BesluitenApiPluginFactory(
     pluginService: PluginService,
     private val besluitenApiClient: BesluitenApiClient,
     private val urlProvider: ZaakUrlProvider,
+    private val objectMapper: ObjectMapper
 ) : PluginFactory<BesluitenApiPlugin>(pluginService) {
     override fun create(): BesluitenApiPlugin {
         return BesluitenApiPlugin(
             besluitenApiClient,
-            urlProvider
+            urlProvider,
+            objectMapper
         )
     }
 }

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/BesluitNotFoundException.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/BesluitNotFoundException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.besluitenapi.client
+
+class BesluitNotFoundException(besluitUrl: String) : RuntimeException("No besluit found for url '$besluitUrl'")

--- a/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/BesluitenApiClient.kt
+++ b/backend/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/BesluitenApiClient.kt
@@ -81,10 +81,26 @@ class BesluitenApiClient(
     ): Besluit {
         return restClient(authentication)
             .patch()
-            .uri ( besluitUrl )
+            .uri(besluitUrl)
             .headers(this::defaultHeaders)
             .contentType(MediaType.APPLICATION_JSON)
-            .body (request)
+            .body(request)
+            .retrieve()
+            .body<Besluit>()!!
+    }
+
+    fun getBesluit(
+        authentication: BesluitenApiAuthentication,
+        baseUrl: URI,
+        besluitUuid: String
+    ): Besluit {
+        return restClient(authentication)
+            .get()
+            .uri {
+                ClientTools.baseUrlToBuilder(it, baseUrl)
+                    .pathSegment("besluiten", besluitUuid)
+                    .build()
+            }
             .retrieve()
             .body<Besluit>()!!
     }

--- a/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/BesluitenApiPluginFactoryTest.kt
+++ b/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/BesluitenApiPluginFactoryTest.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.besluitenapi
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.ritense.besluitenapi.client.BesluitenApiClient
 import com.ritense.plugin.domain.PluginConfiguration
@@ -38,6 +39,8 @@ internal class BesluitenApiPluginFactoryTest {
         val besluitenApiClient: BesluitenApiClient = mock()
         val urlProvider: ZaakUrlProvider = mock()
         val authentication: BesluitenApiAuthentication = mock()
+        val objectMapper: ObjectMapper = mock()
+
         whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(authentication)
         whenever(pluginService.getObjectMapper()).thenReturn(MapperSingleton.get())
 
@@ -49,7 +52,7 @@ internal class BesluitenApiPluginFactoryTest {
             }
         """.trimIndent()
 
-        val factory = BesluitenApiPluginFactory(pluginService, besluitenApiClient, urlProvider)
+        val factory = BesluitenApiPluginFactory(pluginService, besluitenApiClient, urlProvider, objectMapper)
 
         val pluginDefinition = createPluginDefinition()
         val pluginConfiguration = PluginConfiguration(

--- a/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/BesluitenApiPluginTest.kt
+++ b/backend/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/BesluitenApiPluginTest.kt
@@ -16,8 +16,11 @@
 
 package com.ritense.besluitenapi
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.besluitenapi.client.Besluit
 import com.ritense.besluitenapi.client.BesluitInformatieObject
+import com.ritense.besluitenapi.client.BesluitNotFoundException
 import com.ritense.besluitenapi.client.BesluitenApiClient
 import com.ritense.besluitenapi.client.CreateBesluitInformatieObject
 import com.ritense.besluitenapi.client.CreateBesluitRequest
@@ -25,6 +28,7 @@ import com.ritense.besluitenapi.client.PatchBesluitRequest
 import com.ritense.besluitenapi.client.Vervalreden
 import com.ritense.zakenapi.ZaakUrlProvider
 import com.ritense.zgw.Rsin
+import org.junit.Assert.assertThrows
 import org.camunda.bpm.engine.delegate.DelegateExecution
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -34,6 +38,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.net.URI
@@ -45,13 +50,14 @@ class BesluitenApiPluginTest {
     lateinit var besluitenApiPlugin: BesluitenApiPlugin
     lateinit var besluitenApiClient: BesluitenApiClient
     lateinit var zaakUrlProvider: ZaakUrlProvider
-
+    lateinit var objectMapper: ObjectMapper
 
     @BeforeEach
     fun init() {
         zaakUrlProvider = mock()
         besluitenApiClient = mock()
-        besluitenApiPlugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider)
+        objectMapper = mock()
+        besluitenApiPlugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider, objectMapper)
         besluitenApiPlugin.authenticationPluginConfiguration = mock()
         besluitenApiPlugin.url = URI.create("https://some-host.nl/besluiten/api/v1/besluitinformatieobjecten")
         besluitenApiPlugin.rsin = Rsin("252170362")
@@ -62,7 +68,7 @@ class BesluitenApiPluginTest {
         val authenticationMock = mock<BesluitenApiAuthentication>()
         val executionMock = mock<DelegateExecution>()
 
-        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider)
+        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider, objectMapper)
         plugin.url = URI("http://besluiten.api")
         plugin.rsin = Rsin("633182801")
         plugin.authenticationPluginConfiguration = authenticationMock
@@ -126,7 +132,7 @@ class BesluitenApiPluginTest {
         val authenticationMock = mock<BesluitenApiAuthentication>()
         val executionMock = mock<DelegateExecution>()
 
-        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider)
+        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider, objectMapper)
         plugin.url = URI("http://besluiten.api")
         plugin.rsin = Rsin("633182801")
         plugin.authenticationPluginConfiguration = authenticationMock
@@ -225,7 +231,7 @@ class BesluitenApiPluginTest {
         val besluitenApiClient = mock<BesluitenApiClient>()
         val zaakUrlProvider = mock<ZaakUrlProvider>() // only needed for constructor if required
 
-        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider)
+        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider, objectMapper)
         plugin.authenticationPluginConfiguration = authenticationMock
 
         val besluitUrl = URI("http://besluiten.api/besluit")
@@ -282,5 +288,117 @@ class BesluitenApiPluginTest {
         assertEquals(publicatiedatum, patchBesluitRequest.publicatiedatum)
         assertEquals(verzenddatum, patchBesluitRequest.verzenddatum)
         assertEquals(uiterlijkeReactieDatum, patchBesluitRequest.uiterlijkeReactiedatum)
+    }
+
+    @Test
+    fun `should retrieve a besluit`() {
+        val authenticationMock = mock<BesluitenApiAuthentication>()
+        val executionMock = mock<DelegateExecution>()
+        val baseUrl = URI("https://test-host.nl/api/v1/besluiten")
+
+        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider, objectMapper).apply {
+            url = baseUrl
+            authenticationPluginConfiguration = authenticationMock
+        }
+
+        val documentId = UUID.randomUUID()
+        val besluitUrl = "https://test-host.nl/api/v1/besluiten/3f8a2c7e-9b41-4d6f-a2f0-7e6c1b9b6d3a"
+        val besluitUuid = "3f8a2c7e-9b41-4d6f-a2f0-7e6c1b9b6d3a"
+        val resultProcessVariable = "besluit"
+
+        whenever(executionMock.businessKey).thenReturn(documentId.toString())
+
+        val besluit = Besluit(
+            url = URI("http://catalogus.api/besluit"),
+            identificatie = null,
+            verantwoordelijkeOrganisatie = "680572442",
+            besluittype = URI("http://catalogus.api/besluittype"),
+            zaak = null,
+            datum = LocalDate.of(2025, 11, 20),
+            toelichting = "Toelichting",
+            bestuursorgaan = null,
+            ingangsdatum = LocalDate.of(2025, 11, 21),
+            vervaldatum = LocalDate.of(2025, 11, 22),
+            vervalreden = Vervalreden.TIJDELIJK,
+            vervalredenWeergave = null,
+            publicatiedatum = LocalDate.of(2025, 11, 23),
+            verzenddatum = null,
+            uiterlijkeReactiedatum = LocalDate.of(2025, 11, 24)
+        )
+
+        whenever(
+            besluitenApiClient.getBesluit(
+                authenticationMock,
+                baseUrl,
+                besluitUuid
+            )
+        ).thenReturn(besluit)
+
+        val besluitJson = mock<JsonNode>()
+        whenever(objectMapper.valueToTree<JsonNode>(besluit)).thenReturn(besluitJson)
+
+        val result = plugin.getBesluit(executionMock, besluitUrl, resultProcessVariable)
+
+        assertEquals(besluit, result)
+
+        assertEquals(URI("http://catalogus.api/besluit"), result.url)
+        assertEquals("680572442", result.verantwoordelijkeOrganisatie)
+        assertEquals(URI("http://catalogus.api/besluittype"), result.besluittype)
+        assertEquals(LocalDate.of(2025, 11, 20), result.datum)
+        assertEquals("Toelichting", result.toelichting)
+        assertEquals(LocalDate.of(2025, 11, 21), result.ingangsdatum)
+        assertEquals(LocalDate.of(2025, 11, 22), result.vervaldatum)
+        assertEquals(Vervalreden.TIJDELIJK, result.vervalreden)
+        assertEquals(LocalDate.of(2025, 11, 23), result.publicatiedatum)
+        assertEquals(LocalDate.of(2025, 11, 24), result.uiterlijkeReactiedatum)
+
+        assertNull(result.identificatie)
+        assertNull(result.bestuursorgaan)
+        assertNull(result.vervalredenWeergave)
+        assertNull(result.verzenddatum)
+
+        verify(besluitenApiClient, times(1)).getBesluit(
+            authenticationMock,
+            baseUrl,
+            besluitUuid
+        )
+        verify(executionMock, times(1)).setVariable(resultProcessVariable, besluitJson)
+    }
+
+    @Test
+    fun `should throw BesluitNotFoundException when besluit not found`() {
+        val authenticationMock = mock<BesluitenApiAuthentication>()
+        val executionMock = mock<DelegateExecution>()
+        val baseUrl = URI("https://test-host.nl/api/v1/besluiten")
+
+        val plugin = BesluitenApiPlugin(besluitenApiClient, zaakUrlProvider, objectMapper).apply {
+            url = baseUrl
+            authenticationPluginConfiguration = authenticationMock
+        }
+
+        val documentId = UUID.randomUUID()
+        val besluitUuid = "3f8a2c7e-9b41-4d6f-a2f0-7e6c1b9b6d3a"
+        val besluitUrl = "$baseUrl/$besluitUuid"
+        val resultProcessVariable = "besluit"
+
+        whenever(executionMock.businessKey).thenReturn(documentId.toString())
+
+        whenever(
+            besluitenApiClient.getBesluit(
+                authenticationMock,
+                baseUrl,
+                besluitUuid
+            )
+        ).thenThrow(RuntimeException("NOT_FOUND"))
+
+        val ex = assertThrows(BesluitNotFoundException::class.java) {
+            plugin.getBesluit(executionMock, besluitUrl, resultProcessVariable)
+        }
+
+        assertEquals("No besluit found for url '$besluitUrl'", ex.message)
+
+        verify(besluitenApiClient).getBesluit(authenticationMock, baseUrl, besluitUuid)
+
+        verify(executionMock, never()).setVariable(any(), any())
     }
 }

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.module.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.module.ts
@@ -22,6 +22,7 @@ import {CreateZaakBesluitConfigurationComponent} from './components/create-zaak-
 import {PatchZaakBesluitConfigurationComponent} from './components/patch-zaak-besluit/patch-zaak-besluit-configuration.component';
 import {LinkDocumentToBesluitConfigurationComponent} from './components/link-document-to-besluit/link-document-to-besluit-configuration.component';
 import {ButtonModule, DialogModule, IconModule, LoadingModule} from 'carbon-components-angular';
+import {GetBesluitConfigurationComponent} from './components/get-besluit/get-besluit-configuration.component';
 import {
   DatePickerModule,
   FormModule,
@@ -37,6 +38,7 @@ import {
     CreateZaakBesluitConfigurationComponent,
     PatchZaakBesluitConfigurationComponent,
     LinkDocumentToBesluitConfigurationComponent,
+    GetBesluitConfigurationComponent,
   ],
   imports: [
     CommonModule,
@@ -57,6 +59,7 @@ import {
     CreateZaakBesluitConfigurationComponent,
     PatchZaakBesluitConfigurationComponent,
     LinkDocumentToBesluitConfigurationComponent,
+    GetBesluitConfigurationComponent,
   ],
 })
 export class BesluitenApiPluginModule {}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.specification.ts
@@ -20,6 +20,7 @@ import {BESLUITEN_API_PLUGIN_LOGO_BASE64} from './assets';
 import {CreateZaakBesluitConfigurationComponent} from './components/create-zaak-besluit/create-zaak-besluit-configuration.component';
 import {PatchZaakBesluitConfigurationComponent} from './components/patch-zaak-besluit/patch-zaak-besluit-configuration.component';
 import {LinkDocumentToBesluitConfigurationComponent} from './components/link-document-to-besluit/link-document-to-besluit-configuration.component';
+import {GetBesluitConfigurationComponent} from './components/get-besluit/get-besluit-configuration.component';
 
 const besluitenApiPluginSpecification: PluginSpecification = {
   pluginId: 'besluitenapi',
@@ -29,6 +30,7 @@ const besluitenApiPluginSpecification: PluginSpecification = {
     'create-besluit': CreateZaakBesluitConfigurationComponent,
     'patch-besluit': PatchZaakBesluitConfigurationComponent,
     'link-document-to-besluit': LinkDocumentToBesluitConfigurationComponent,
+    'get-besluit': GetBesluitConfigurationComponent,
   },
   pluginTranslations: {
     nl: {
@@ -95,6 +97,10 @@ const besluitenApiPluginSpecification: PluginSpecification = {
       beslisdatumTooltip:
         'De beslisdatum (AWB) van het besluit. Ondersteunt value resolver. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z',
       addPatchBesluitProperty: 'Voeg nieuwe parameter toe',
+      'get-besluit': 'Besluit ophalen',
+      resultProcessVariable: 'Resultaat process variable',
+      resultProcessVariableTooltip:
+        'De naam van de procesvariabele waarin het resultaat moet worden opgeslagen.',
     },
     en: {
       title: 'Besluiten API',
@@ -161,6 +167,10 @@ const besluitenApiPluginSpecification: PluginSpecification = {
       beslisdatumTooltip:
         'The decision date (AWB) of the decision. Supports value resolver. Supported date examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z',
       addPatchBesluitProperty: 'Add besluit property',
+      'get-besluit': 'Retrieve besluit',
+      resultProcessVariable: 'Result process variable',
+      resultProcessVariableTooltip:
+        'The name of the process variable in which the result must be stored.',
     },
     de: {
       title: 'Besluiten API',

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/get-besluit/get-besluit-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/get-besluit/get-besluit-configuration.component.html
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright 2015-2025 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<v-form
+  (valueChange)="formValueChange($event)"
+  *ngIf="{
+    disabled: disabled$ | async,
+    prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
+  } as obs"
+>
+  <v-input
+    name="besluitUrl"
+    [title]="'besluitUrl' | pluginTranslate: pluginId | async"
+    [margin]="true"
+    [defaultValue]="obs.prefill?.besluitUrl"
+    [disabled]="obs.disabled"
+    [required]="true"
+    [trim]="true"
+    [tooltip]="'besluitUrlTooltip' | pluginTranslate: pluginId | async"
+  ></v-input>
+  <v-input
+    name="resultProcessVariable"
+    [title]="'resultProcessVariable' | pluginTranslate: pluginId | async"
+    [margin]="true"
+    [defaultValue]="obs.prefill?.resultProcessVariable"
+    [disabled]="obs.disabled"
+    [required]="true"
+    [trim]="true"
+    [tooltip]="'resultProcessVariableTooltip' | pluginTranslate: pluginId | async"
+  ></v-input>
+</v-form>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/get-besluit/get-besluit-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/get-besluit/get-besluit-configuration.component.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {FunctionConfigurationComponent} from '../../../../models';
+import {BehaviorSubject, combineLatest, Observable, Subscription, take} from 'rxjs';
+import {GetBesluitConfig} from '../../models';
+
+@Component({
+  selector: 'valtimo-get-besluit-configuration',
+  templateUrl: './get-besluit-configuration.component.html',
+  standalone: false,
+})
+export class GetBesluitConfigurationComponent
+  implements FunctionConfigurationComponent, OnInit, OnDestroy
+{
+  @Input() save$: Observable<void>;
+  @Input() disabled$: Observable<boolean>;
+  @Input() pluginId: string;
+  @Input() prefillConfiguration$: Observable<GetBesluitConfig>;
+
+  @Output() valid: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() configuration: EventEmitter<GetBesluitConfig> = new EventEmitter<GetBesluitConfig>();
+
+  private saveSubscription!: Subscription;
+  private readonly formValue$ = new BehaviorSubject<GetBesluitConfig | null>(null);
+  private readonly valid$ = new BehaviorSubject<boolean>(false);
+
+  public ngOnInit(): void {
+    this.openSaveSubscription();
+    this.valid.emit(false);
+  }
+
+  public ngOnDestroy(): void {
+    this.saveSubscription?.unsubscribe();
+  }
+
+  private openSaveSubscription(): void {
+    this.saveSubscription = this.save$?.subscribe(() => {
+      combineLatest([this.formValue$, this.valid$])
+        .pipe(take(1))
+        .subscribe(([formValue, valid]) => {
+          if (valid) {
+            this.configuration.emit(formValue);
+          }
+        });
+    });
+  }
+
+  public formValueChange(formValue: GetBesluitConfig): void {
+    this.formValue$.next(formValue);
+    this.handleValid(formValue);
+  }
+
+  private handleValid(formValue: GetBesluitConfig): void {
+    const valid = !!formValue?.besluitUrl && !!formValue?.resultProcessVariable;
+
+    this.valid$.next(valid);
+    this.valid.emit(valid);
+  }
+}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/config.ts
@@ -58,10 +58,16 @@ interface PatchZaakBesluitConfig {
   uiterlijkeReactiedatum?: string;
 }
 
+interface GetBesluitConfig {
+  besluitUrl: string;
+  resultProcessVariable: string;
+}
+
 export {
   BesluitenApiConfig,
   CreateZaakBesluitConfig,
   Vervalredenen,
   LinkDocumentToBesluitConfig,
   PatchZaakBesluitConfig,
+  GetBesluitConfig,
 };

--- a/frontend/projects/valtimo/plugin/src/public-api.ts
+++ b/frontend/projects/valtimo/plugin/src/public-api.ts
@@ -111,6 +111,7 @@ export * from './lib/plugins/besluiten-api/components/besluiten-api-configuratio
 export * from './lib/plugins/besluiten-api/components/create-zaak-besluit/create-zaak-besluit-configuration.component';
 export * from './lib/plugins/besluiten-api/components/patch-zaak-besluit/patch-zaak-besluit-configuration.component';
 export * from './lib/plugins/besluiten-api/components/link-document-to-besluit/link-document-to-besluit-configuration.component';
+export * from './lib/plugins/besluiten-api/components/get-besluit/get-besluit-configuration.component';
 /* exact */
 export * from './lib/plugins/exact/exact.plugin.specification';
 export * from './lib/plugins/exact/exact-plugin.module';


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/147

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 
https://github.com/valtimo-platform/valtimo/tree/story/145785-get-besluit-backport-v12

**Relevant comments:**
> backport for this PR: https://github.com/valtimo-platform/valtimo/pull/166

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Specify the documents branch location:
Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Describe the testing steps
- [ ] Introduce a process to create besluit, add a service task to get besluit data
- [ ] Configure the get-besluit Plugin action (Besluiten API -> get-besluit)
- [ ] Run the process and verify that the besluit data is retrieved
- [ ] A demo process: 'Vastleggen besluit' is added. A besluittype should be selected in the plugin action 'create-besluit'. Other necessary configuration is already in place.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
