### PR TITLE
Fix: keycloak user migration

### DIFF
--- a/backend/keycloak-iam/src/main/java/com/valtimo/keycloak/liquibase/changelog/AbstractMigrateWithKeycloakChangeLog.kt
+++ b/backend/keycloak-iam/src/main/java/com/valtimo/keycloak/liquibase/changelog/AbstractMigrateWithKeycloakChangeLog.kt
@@ -109,7 +109,11 @@ abstract class AbstractMigrateWithKeycloakChangeLog : EnvironmentPostProcessor {
     }
 
     protected fun getKeycloakUser(emailOrUsernameOrUserId: String?): AbstractUserRepresentation? {
-        return userCache[emailOrUsernameOrUserId]
+        return if (emailOrUsernameOrUserId == null) {
+            null
+        } else {
+            userCache[emailOrUsernameOrUserId]
+        }
     }
 
     protected fun getKeycloakUserFromKeycloak(emailOrUsernameOrUserId: String?): AbstractUserRepresentation? {


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/456

Reproduce bug:
1. Have `intermediate_submission` table with `edited_by=NULL`
2. Run migration script: `20250506-migrate-to-keycloak-username.xml`
3. The `intermediate_submission.created_by` column was then not migrated properly. This has now been fixed.
<img width="1273" height="395" alt="image" src="https://github.com/user-attachments/assets/12e78548-4c91-4581-8fab-81cb7ad9ae69" />
