### PR TITLE
Added option to use current date/time in set-zaakstatus

### DIFF
--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/set-zaak-status/set-zaak-status-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/set-zaak-status/set-zaak-status-configuration.component.html
@@ -46,7 +46,7 @@
       name="inputDatumStatusGezetToggle"
       [disabled]="obs.disabled"
       [title]="'inputDatumStatusGezetToggle' | pluginTranslate: obs.pluginId | async"
-      [radioValues]="inputTypeOptions$ | async"
+      [radioValues]="datePickerInputTypeOptions$ | async"
       [defaultValue]="obs.datumStatusGezetSelectedInputOption"
       [margin]="true"
     ></v-radio>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/set-zaak-status/set-zaak-status-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/set-zaak-status/set-zaak-status-configuration.component.ts
@@ -66,7 +66,7 @@ export class SetZaakStatusConfigurationComponent
   readonly clearStatusSelection$ = new Subject<void>();
   readonly loading$ = new BehaviorSubject<boolean>(true);
   readonly selectedInputOption$ = new BehaviorSubject<InputOption>('selection');
-  readonly datumStatusGezetSelectedInputOption$ = new BehaviorSubject<InputOption>('selection');
+  readonly datumStatusGezetSelectedInputOption$ = new BehaviorSubject<string>('now');
   readonly pluginId$ = new BehaviorSubject<string>('');
   readonly formValue$ = new BehaviorSubject<SetZaakStatusConfig | null>(null);
   readonly valid$ = new BehaviorSubject<boolean>(false);
@@ -82,6 +82,22 @@ export class SetZaakStatusConfigurationComponent
       ])
     ),
     map(([selectionTranslation, textTranslation]) => [
+      {value: 'selection', title: selectionTranslation},
+      {value: 'text', title: textTranslation},
+    ])
+  );
+
+  readonly datePickerInputTypeOptions$: Observable<Array<RadioValue>> = this.pluginId$.pipe(
+    filter(pluginId => !!pluginId),
+    switchMap(pluginId =>
+      combineLatest([
+        this.pluginTranslatePipe.transform('now', pluginId),
+        this.pluginTranslatePipe.transform('selection', pluginId),
+        this.pluginTranslatePipe.transform('text', pluginId),
+      ])
+    ),
+    map(([nowTranslation, selectionTranslation, textTranslation]) => [
+      {value: 'now', title: nowTranslation},
       {value: 'selection', title: selectionTranslation},
       {value: 'text', title: textTranslation},
     ])
@@ -129,6 +145,10 @@ export class SetZaakStatusConfigurationComponent
     if (updatedFormValue.inputDatumStatusGezetToggle) {
       this.datumStatusGezetSelectedInputOption$.next(updatedFormValue.inputDatumStatusGezetToggle);
     }
+    if (updatedFormValue.inputDatumStatusGezetToggle === 'now') {
+        this.selectedDate = null;
+        this.selectedTime = null;
+    }
   }
 
   public onDateSelected(event: Date[]): void {
@@ -144,11 +164,18 @@ export class SetZaakStatusConfigurationComponent
   }
 
   private updateDatumStatusGezet(): void {
-    if (!this.selectedDate || !this.selectedTime) {
+    if (!this.selectedDate && !this.selectedTime) {
       return;
     }
 
-    const [hoursStr, minutesStr = '00', secondsStr = '00'] = this.selectedTime.split(':');
+    let hoursStr;
+    let minutesStr;
+    let secondsStr;
+    try {
+      [hoursStr, minutesStr = '00', secondsStr = '00'] = this.selectedTime.split(':');
+    } catch (error) {
+      [hoursStr, minutesStr = '00', secondsStr = '00'] = ['00', '00'];
+    }
     const date = new Date(this.selectedDate);
 
     const year = date.getFullYear();
@@ -174,14 +201,20 @@ export class SetZaakStatusConfigurationComponent
       this.prefillConfiguration$.subscribe(config => {
         let baseDate;
 
-        try {
-          baseDate = flatpickr.formatDate(
-            !!config?.datumStatusGezet ? new Date(config!.datumStatusGezet) : new Date(),
-            'Z'
-          );
-        } catch (error) {
-          baseDate = config.datumStatusGezet;
-          this.datumStatusGezetSelectedInputOption$.next('text');
+        if (config?.datumStatusGezet !== null) {
+          try {
+            baseDate = flatpickr.formatDate(
+              !!config?.datumStatusGezet ? new Date(config!.datumStatusGezet) : new Date(),
+              'Z'
+            );
+            this.datumStatusGezetSelectedInputOption$.next('selection');
+          } catch (error) {
+            baseDate = config.datumStatusGezet;
+            this.datumStatusGezetSelectedInputOption$.next('text');
+          }
+        } else {
+          baseDate = null;
+          this.datumStatusGezetSelectedInputOption$.next('now');
         }
 
         this.selectedDate = baseDate;
@@ -247,6 +280,9 @@ export class SetZaakStatusConfigurationComponent
         .pipe(take(1))
         .subscribe(([formValue, valid]) => {
           if (valid) {
+            if (formValue.inputDatumStatusGezetToggle == 'now') {
+              formValue.datumStatusGezet = null;
+            }
             this.configuration.emit({
               statustoelichting: formValue.statustoelichting,
               statustypeUrl: formValue.statustypeUrl,
@@ -260,12 +296,12 @@ export class SetZaakStatusConfigurationComponent
   }
 
   private isValidDatumStatusGezet(value: string | null | undefined): boolean {
-    if (!value) {
-      return false;
+    if (['text', 'now'].includes(this.datumStatusGezetSelectedInputOption$.getValue())) {
+      return true;
     }
 
-    if (this.datumStatusGezetSelectedInputOption$.getValue() === 'text') {
-      return true;
+    if (!value) {
+      return false;
     }
 
     const trimmed = value.trim();
@@ -282,12 +318,12 @@ export class SetZaakStatusConfigurationComponent
   }
 
   private isDateNotInFuture(value: string | null | undefined): boolean {
-    if (!value) {
-      return false;
+    if (['text', 'now'].includes(this.datumStatusGezetSelectedInputOption$.getValue())) {
+      return true;
     }
 
-    if (this.datumStatusGezetSelectedInputOption$.getValue() === 'text') {
-      return true;
+    if (!value) {
+      return false;
     }
 
     const date = new Date(value);
@@ -299,12 +335,21 @@ export class SetZaakStatusConfigurationComponent
     return isDateNotInFuture;
   }
 
+  private hasEnteredDateText(value: string | null | undefined): boolean {
+    if (this.datumStatusGezetSelectedInputOption$.getValue() !== 'text') {
+      return true;
+    }
+
+    return !value === false;
+  }
+
   private handleValid(formValue: SetZaakStatusConfig): void {
     const hasStatusType = !!formValue.statustypeUrl;
     const hasValidDatumStatusGezet = this.isValidDatumStatusGezet(formValue.datumStatusGezet);
     const dateIsNotInFuture = this.isDateNotInFuture(formValue.datumStatusGezet);
+    const hasEnteredDateText = this.hasEnteredDateText(formValue.datumStatusGezet);
 
-    const valid = hasStatusType && hasValidDatumStatusGezet && dateIsNotInFuture;
+    const valid = hasStatusType && hasValidDatumStatusGezet && dateIsNotInFuture && hasEnteredDateText;
 
     this.valid$.next(valid);
     this.valid.emit(valid);

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
@@ -36,7 +36,7 @@ interface SetZaakStatusConfig {
   statustypeUrl: string;
   statustoelichting: string;
   inputTypeZaakStatusToggle?: InputOption;
-  inputDatumStatusGezetToggle?: InputOption;
+  inputDatumStatusGezetToggle?: string;
   datumStatusGezet?: string;
 }
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
@@ -112,6 +112,7 @@ const zakenApiPluginSpecification: PluginSpecification = {
       zaakTypeSelectTooltip:
         'In dit veld moet de verwijzing komen naar de type zaak. Als er slechts één zaaktype beschikbaar is, wordt deze standaard geselecteerd.',
       inputTypeZaakTypeToggle: 'Invoertype Zaaktype-URL',
+      now: 'Gebruik huidige datum/tijd',
       text: 'Tekst',
       selection: 'Selectie',
       'create-natuurlijk-persoon-zaak-rol': 'Zaakrol aanmaken - Natuurlijk persoon',
@@ -326,6 +327,7 @@ const zakenApiPluginSpecification: PluginSpecification = {
       zaakTypeSelectTooltip:
         'In this field the reference must be made to the type of the zaak. If only one zaaktype is available, it will be selected by default.',
       inputTypeZaakTypeToggle: 'Input type Zaaktype-URL',
+      now: 'Use current date/time',
       text: 'Text',
       selection: 'Selection',
       'create-natuurlijk-persoon-zaak-rol': 'Create Zaakrol - natural person',
@@ -538,6 +540,7 @@ const zakenApiPluginSpecification: PluginSpecification = {
       zaakTypeSelectTooltip:
         'In diesem Feld muss auf die zaaktype verwiesen werden. Wenn nur ein Zaaktyp verfügbar ist, wird dieser standardmäßig ausgewählt.',
       inputTypeZaakTypeToggle: 'Eingabetyp Zaaktype-URL',
+      now: 'Aktuelles Datum/Uhrzeit verwenden',
       text: 'Text',
       selection: 'Auswahl',
       'create-natuurlijk-persoon-zaak-rol': 'Zaakrol erstellen – natürliche Person',


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/450

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [x] Release notes have been written for these changes.

Specify the documents branch location:
Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation): https://github.com/valtimo-platform/valtimo-documentation/pull/862
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
Try using the "Use current date/time" option it should save the `datumStatusGezet` option in the processLink to null. Also play around with the other options to check that if for example you select a date and then select "Use current date/time" it doesn't store the date you selected before.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
