### PR TITLE
Re-enable the plugin form after creation or edit fails

### DIFF
--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-modal/plugin-add-modal.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-modal/plugin-add-modal.component.ts
@@ -33,10 +33,10 @@ export class PluginAddModalComponent {
 
   @Output() closeModal: EventEmitter<boolean> = new EventEmitter();
 
-  readonly inputDisabled$ = this.stateService.inputDisabled$;
-  readonly selectedPluginDefinition$ = this.stateService.selectedPluginDefinition$;
-  readonly configurationValid$ = new BehaviorSubject<boolean>(false);
-  readonly returnToFirstStepSubject$ = new Subject<boolean>();
+  public readonly inputDisabled$ = this.stateService.inputDisabled$;
+  public readonly selectedPluginDefinition$ = this.stateService.selectedPluginDefinition$;
+  public readonly configurationValid$ = new BehaviorSubject<boolean>(false);
+  public readonly returnToFirstStepSubject$ = new Subject<boolean>();
 
   constructor(
     private readonly stateService: PluginManagementStateService,
@@ -44,11 +44,11 @@ export class PluginAddModalComponent {
     private readonly logger: NGXLogger
   ) {}
 
-  complete(): void {
+  public complete(): void {
     this.stateService.save();
   }
 
-  hide(): void {
+  public hide(): void {
     this.closeModal.emit();
 
     setTimeout(() => {
@@ -58,16 +58,14 @@ export class PluginAddModalComponent {
     }, CARBON_CONSTANTS.modalAnimationMs);
   }
 
-  onValid(valid: boolean): void {
+  public onValid(valid: boolean): void {
     this.configurationValid$.next(valid);
   }
 
-  onConfiguration(configuration: PluginConfigurationData): void {
+  public onConfiguration(configuration: PluginConfigurationData): void {
     const pluginConfiguration = {...configuration};
     delete pluginConfiguration['configurationId'];
     delete pluginConfiguration['configurationTitle'];
-
-    this.stateService.disableInput();
 
     this.stateService.selectedPluginDefinition$.pipe(take(1)).subscribe(selectedDefinition => {
       this.pluginManagementService

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-modal/plugin-add-modal.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-modal/plugin-add-modal.component.ts
@@ -67,6 +67,8 @@ export class PluginAddModalComponent {
     delete pluginConfiguration['configurationId'];
     delete pluginConfiguration['configurationTitle'];
 
+    this.stateService.disableInput();
+
     this.stateService.selectedPluginDefinition$.pipe(take(1)).subscribe(selectedDefinition => {
       this.pluginManagementService
         .savePluginConfiguration({
@@ -82,6 +84,7 @@ export class PluginAddModalComponent {
           },
           error: () => {
             this.logger.error('Something went wrong with saving the plugin configuration.');
+            this.stateService.enableInput();
           },
         });
     });

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-select/plugin-add-select.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-select/plugin-add-select.component.ts
@@ -26,9 +26,9 @@ import {PluginDefinition, PluginManagementService} from '@valtimo/plugin';
   styleUrls: ['./plugin-add-select.component.scss'],
 })
 export class PluginAddSelectComponent implements OnInit, OnDestroy {
-  readonly selectedPluginDefinition$ = this.stateService.selectedPluginDefinition$;
-  readonly disabled$ = this.stateService.inputDisabled$;
-  readonly pluginDefinitionsWithLogos$ = this.stateService.pluginDefinitionsWithLogos$;
+  public readonly selectedPluginDefinition$ = this.stateService.selectedPluginDefinition$;
+  public readonly disabled$ = this.stateService.inputDisabled$;
+  public readonly pluginDefinitionsWithLogos$ = this.stateService.pluginDefinitionsWithLogos$;
 
   private refreshSubscription!: Subscription;
 
@@ -37,20 +37,20 @@ export class PluginAddSelectComponent implements OnInit, OnDestroy {
     private readonly stateService: PluginManagementStateService
   ) {}
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.openRefreshSubscription();
     this.getPluginDefinitions();
   }
 
-  ngOnDestroy(): void {
+  public ngOnDestroy(): void {
     this.refreshSubscription?.unsubscribe();
   }
 
-  selectPluginDefinition(event: {value: PluginDefinition}): void {
+  public selectPluginDefinition(event: {value: PluginDefinition}): void {
     this.stateService.selectPluginDefinition(event.value);
   }
 
-  deselectPluginDefinition(): void {
+  public  deselectPluginDefinition(): void {
     this.stateService.clearSelectedPluginDefinition();
   }
 

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-configure/plugin-configure.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-configure/plugin-configure.component.ts
@@ -31,23 +31,23 @@ export class PluginConfigureComponent {
   @Output() configuration: EventEmitter<PluginConfigurationData> =
     new EventEmitter<PluginConfigurationData>();
 
-  readonly save$ = this.stateService.save$;
+  public readonly save$ = this.stateService.save$;
 
-  readonly pluginDefinitionKey$ = this.stateService.selectedPluginDefinition$.pipe(
+  public readonly pluginDefinitionKey$ = this.stateService.selectedPluginDefinition$.pipe(
     map(definition => definition?.key)
   );
 
-  readonly prefillConfiguration$ = of(undefined);
+  public readonly prefillConfiguration$ = of(undefined);
 
-  readonly disabled$ = this.stateService.inputDisabled$;
+  public readonly disabled$ = this.stateService.inputDisabled$;
 
   constructor(private readonly stateService: PluginManagementStateService) {}
 
-  onValid(valid: boolean): void {
+  public onValid(valid: boolean): void {
     this.valid.emit(valid);
   }
 
-  onFunctionConfiguration(configuration: PluginConfigurationData) {
+  public onFunctionConfiguration(configuration: PluginConfigurationData): void{
     this.configuration.emit(configuration);
   }
 }

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-edit-modal/plugin-edit-modal.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-edit-modal/plugin-edit-modal.component.ts
@@ -37,10 +37,10 @@ export class PluginEditModalComponent {
 
   @Output() closeModal: EventEmitter<boolean> = new EventEmitter();
 
-  readonly inputDisabled$ = this.stateService.inputDisabled$;
-  readonly selectedPluginConfiguration$: Observable<PluginConfiguration> =
+  public readonly inputDisabled$ = this.stateService.inputDisabled$;
+  public readonly selectedPluginConfiguration$: Observable<PluginConfiguration> =
     this.stateService.selectedPluginConfiguration$;
-  readonly configurationValid$ = new BehaviorSubject<boolean>(false);
+  public readonly configurationValid$ = new BehaviorSubject<boolean>(false);
 
   constructor(
     private readonly stateService: PluginManagementStateService,
@@ -48,11 +48,11 @@ export class PluginEditModalComponent {
     private readonly logger: NGXLogger
   ) {}
 
-  save(): void {
+  public save(): void {
     this.stateService.saveEdit();
   }
 
-  delete(): void {
+  public delete(): void {
     this.stateService.delete();
     this.stateService.disableInput();
 

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-edit/plugin-edit.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-edit/plugin-edit.component.ts
@@ -30,13 +30,13 @@ export class PluginEditComponent {
   @Output() configuration: EventEmitter<PluginConfigurationData> =
     new EventEmitter<PluginConfigurationData>();
 
-  readonly saveEdit$ = this.stateService.saveEdit$;
+  public readonly saveEdit$ = this.stateService.saveEdit$;
 
-  readonly pluginDefinitionKey$ = this.stateService.selectedPluginConfiguration$.pipe(
+  public readonly pluginDefinitionKey$ = this.stateService.selectedPluginConfiguration$.pipe(
     map(configuration => configuration?.pluginDefinition?.key)
   );
 
-  readonly prefillConfiguration$ = this.stateService.selectedPluginConfiguration$.pipe(
+  public readonly prefillConfiguration$ = this.stateService.selectedPluginConfiguration$.pipe(
     map(configuration =>
       configuration
         ? {
@@ -48,15 +48,15 @@ export class PluginEditComponent {
     )
   );
 
-  readonly disabled$ = this.stateService.inputDisabled$;
+  public readonly disabled$ = this.stateService.inputDisabled$;
 
   constructor(private readonly stateService: PluginManagementStateService) {}
 
-  onValid(valid: boolean): void {
+  public onValid(valid: boolean): void {
     this.valid.emit(valid);
   }
 
-  onFunctionConfiguration(configuration: PluginConfigurationData) {
+  public onFunctionConfiguration(configuration: PluginConfigurationData): void {
     this.configuration.emit(configuration);
   }
 }


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/462

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 
Re-enable the plugin form after creation or edit fails

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes.

Specify the documents branch location:
Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Describe the testing steps
- [ ] Go to Plugins
- [ ] Create a plugin using the ID of an existing plugin
- [ ] Verify that the form inputs remain enabled
- [ ] Change the ID to a unique one
- [ ] Verify that the configuration is saved correctly

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
