### PR TITLE
NPM version format compatibility

### DIFF
--- a/.github/workflows/determine_test_env.yml
+++ b/.github/workflows/determine_test_env.yml
@@ -31,7 +31,7 @@ jobs:
             echo "source_sha=$(echo '${{ github.event.pull_request.head.sha }}')" >> "$GITHUB_OUTPUT"
           elif [[ "$EVENT" == 'push' ]]; then
             # Turn / into - and make all lowercase
-            safe_branch_name=$(echo "${{ github.ref_name }}" | sed 's/[\/+|<>,;]/-/g' | tr '[:upper:]' '[:lower:]')
+            safe_branch_name=$(echo "${{ github.ref_name }}" | sed 's/[\/+|<>,;_]/-/g' | tr '[:upper:]' '[:lower:]')
             echo "name=$safe_branch_name" >> "$GITHUB_OUTPUT"
             echo "source_sha=$(echo '${{ github.sha }}')" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/frontend_build_test_libraries.yml
+++ b/.github/workflows/frontend_build_test_libraries.yml
@@ -105,7 +105,7 @@ jobs:
           fi
 
           # replace special characters with -
-          SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/+|<>,;]/-/g' | tr '[:upper:]' '[:lower:]')
+          SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/+|<>,;_]/-/g' | tr '[:upper:]' '[:lower:]')
 
           SEMVER_VERSION=$(cat gradle.properties | grep 'projectVersion=' | cut -d '=' -f 2)     
           PROJECT_VERSION="${SEMVER_VERSION}-${SAFE_BRANCH_NAME}.${BUILD_NUMBER}"


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: n/a, reported pipeline failure in Slack

Currently, branch names with underscore break the front end build pipeline. This PR adds the underscore to the list of to replace characters in the process of creating an NPM-safe version string.

Example failed run: https://github.com/valtimo-platform/valtimo/actions/runs/20026543913/job/57425153530

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [x] Create a new branch containing an underscore
- [x] Run the frontend build pipeline
- [x] See it fail

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
