### PR TITLE
Add support for restricting accepted file types in Dropzone and Docum…

### DIFF
--- a/documentation/release-notes/12.x.x/12.23.0/README.md
+++ b/documentation/release-notes/12.x.x/12.23.0/README.md
@@ -3,3 +3,11 @@
 ## New Features
 
 * The Zaken API plugin now supports a plugin action to Update a zaak.
+
+## Enhancements
+
+* **Better handling of file extensions in the Documenten API uploader FormIO component**
+
+    - It is now possible to restrict allowed file types in the Documenten API uploader FormIO component.
+    - The file extension will now always reflect the actual file type of the uploaded file even when we set the filename
+      programmatically from within the documenten API uploader component.

--- a/frontend/projects/valtimo/components/src/lib/components/dropzone/dropzone.component.html
+++ b/frontend/projects/valtimo/components/src/lib/components/dropzone/dropzone.component.html
@@ -39,6 +39,9 @@
 <ng-template #body>
   <h2 *ngIf="!hideTitle" class="mb-4 mt-2">{{ title || ('dropzone.drop' | translate) }}</h2>
   <span *ngIf="subtitle" class="note mb-3">{{ subtitle }}</span>
+  <span *ngIf="showAcceptedFiles && acceptedFiles" class="note mb-3 small-font"
+  >{{ 'dropzone.acceptedFiles' | translate }}<b>{{ acceptedFiles }}</b></span
+  >
   <span *ngIf="showMaxFileSize" class="note mb-3 small-font"
     >{{ 'dropzone.maxFileSize' | translate }}<b>{{ maxFileSize }}mb</b></span
   >

--- a/frontend/projects/valtimo/components/src/lib/components/dropzone/dropzone.component.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/dropzone/dropzone.component.ts
@@ -45,15 +45,46 @@ export class DropzoneComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() hideTitle: boolean;
   @Input() subtitle: string;
   @Input() externalError$: BehaviorSubject<string> = new BehaviorSubject<string>('');
-  @Input() maxFileSize = 5;
   @Input() showMaxFileSize = true;
-  @Input() acceptedFiles = '.json';
+  @Input() showAcceptedFiles = true;
   @Input() clear$: Subject<any> = new Subject();
   @Input() disabled: boolean;
   @Input() hideFilePreview: boolean;
   @Input() uploading: boolean;
   @Input() camera = false;
-  @Input() maxFiles!: number;
+
+  private _maxFiles?: number;
+
+  @Input()
+  set maxFiles(value: number) {
+    this._maxFiles = value;
+    this.initDropzone();
+  }
+  get maxFiles(): number {
+    return this._maxFiles;
+  }
+
+  private _maxFileSize: number = 5;
+
+  @Input()
+  set maxFileSize(value: number) {
+    this._maxFileSize = value;
+    this.initDropzone();
+  }
+  get maxFileSize(): number {
+    return this._maxFileSize;
+  }
+
+  private _acceptedFiles: string = '';
+
+  @Input()
+  set acceptedFiles(value: string) {
+    this._acceptedFiles = value;
+    this.initDropzone();
+  }
+  get acceptedFiles(): string {
+    return this._acceptedFiles;
+  }
 
   @Output() fileSelected: EventEmitter<File> = new EventEmitter();
   readonly file$ = new BehaviorSubject<File>(undefined);
@@ -127,13 +158,13 @@ export class DropzoneComponent implements OnInit, AfterViewInit, OnDestroy {
   private initDropzone(): void {
     this.dropzone = new Dropzone(this.dropzoneRef.nativeElement, {
       url: '/',
-      maxFilesize: this.maxFileSize,
+      maxFilesize: this._maxFileSize,
       clickable: this.dropzoneRef.nativeElement,
       autoProcessQueue: false,
       createImageThumbnails: false,
-      acceptedFiles: this.acceptedFiles,
+      acceptedFiles: this._acceptedFiles,
       previewTemplate: `<p style='display:none'></p>`,
-      ...(this.maxFiles && {maxFiles: this.maxFiles}),
+      ...(this._maxFiles && {maxFiles: this._maxFiles}),
       accept: file => {
         this.dropzone.removeAllFiles();
         this.setFile(file);

--- a/frontend/projects/valtimo/config/assets/core/de.json
+++ b/frontend/projects/valtimo/config/assets/core/de.json
@@ -1336,6 +1336,7 @@
   "dropzone": {
     "drop": "Datei auswählen oder hier über drag-and-drop ablegen",
     "maxFileSize": "Maximale Datei-Größe: ",
+    "acceptedFiles": "Akzeptierte Dateien: ",
     "jsonDocDef": "Die Case-Definition muss im JSON-Format sein",
     "formJsonDocDef": "Die Formular-Definition muss im JSON-Format sein",
     "objecttypeDef": "Die Objekttypdefinition muss im JSON-Format sein",

--- a/frontend/projects/valtimo/config/assets/core/en.json
+++ b/frontend/projects/valtimo/config/assets/core/en.json
@@ -1341,6 +1341,7 @@
   "dropzone": {
     "drop": "Choose a file or drag it here",
     "maxFileSize": "Maximum file size: ",
+    "acceptedFiles": "Accepted files: ",
     "jsonDocDef": "The case definition must be in the JSON format",
     "formJsonDocDef": "The form definition must be in the JSON format",
     "objecttypeDef": "The objecttype definition must be in JSON format",

--- a/frontend/projects/valtimo/config/assets/core/nl.json
+++ b/frontend/projects/valtimo/config/assets/core/nl.json
@@ -1339,6 +1339,7 @@
   "dropzone": {
     "drop": "Kies een bestand, of sleep het hier naartoe",
     "maxFileSize": "Maximale bestandsgrootte: ",
+    "acceptedFiles": "Geaccepteerde bestanden: ",
     "jsonDocDef": "De dossier-definitie moet in het JSON-formaat zijn",
     "formJsonDocDef": "De formulier-definitie moet in het JSON-formaat zijn",
     "objecttypeDef": "De objecttype-definitie moet in JSON-formaat zjn",

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
@@ -567,8 +567,8 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
       .pipe(
         tap(([file, userEmail]) => {
           const filename = file?.bestandsnaam || this.defaultValues.bestandsnaam || file?.name;
-          this.filenameExtension = filename?.split('.')?.pop() || '';
-          if (this.filenameExtension.length === filename?.length) {
+          this.filenameExtension = file?.name?.split('.')?.pop() || '';
+          if (this.filenameExtension.length === file?.name?.length) {
             this.filenameExtension = '';
           }
           this.documentenApiMetadataForm.patchValue({

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader-edit-form.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader-edit-form.ts
@@ -123,6 +123,24 @@ export const documentenApiUploaderEditForm = () => ({
       },
     },
     {
+      type: 'textfield',
+      input: true,
+      key: 'customOptions.acceptedFiles',
+      label: 'Accepted file types (leave blank for no restrictions)',
+      placeholder: '.png, .docx, .pdf',
+      defaultValue: ''
+    },
+    {
+      type: 'checkbox',
+      input: true,
+      inputType: 'checkbox',
+      key: 'customOptions.hideAcceptedFiles',
+      label: 'Hide accepted file types',
+      validate: {
+        required: false,
+      },
+    },
+    {
       label: 'HTML',
       tag: 'div',
       content: '<h3>Documenten API metadata</h3>',

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.html
@@ -29,7 +29,8 @@
   </div>
   <valtimo-dropzone
     (fileSelected)="fileSelected($event)"
-    [acceptedFiles]="null"
+    [acceptedFiles]="acceptedFiles"
+    [showAcceptedFiles]="!hideAcceptedFiles"
     [camera]="camera"
     [disabled]="disabled || obs.linked === false || obs.linked === 'loading'"
     [hideFilePreview]="true"

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.ts
@@ -52,6 +52,8 @@ export class DocumentenApiUploaderComponent
   @Input() subtitle: string;
   @Input() maxFileSize: number;
   @Input() hideMaxFileSize: boolean;
+  @Input() acceptedFiles: string;
+  @Input() hideAcceptedFiles: boolean;
   @Input() camera: boolean;
 
   @Input() set documentTitle(defaultValue: string) {


### PR DESCRIPTION
Add support for restricting accepted file types in Dropzone and DocumentenApiUploader components.

Changed handling of correcting file extension for filename input field to always use the file extension from uploaded file.


### Describe the changes
Link to the related Github issue:https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/169
Main for V13:  https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/474

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Step 1: Add Documenten API File Upload to a form with accepted file types and a filename configured.
- [ ] Step 2: Open the form an see if you can only upload accepted file types.
- [ ] Step 3: After selecting the file, check if the filename in the modal has the file extension from the uploaded file
- [ ] Step 4: See if the extension is corrected to that of the uploaded file when you try to remove or edit the file extension in the filename field.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable

<img width="776" height="405" alt="documenten-api-file-upload" src="https://github.com/user-attachments/assets/d095cdaa-f956-4c26-8f11-7857e61c9058" />
