### PR TITLE
Only creates RestJackson2Provider once to reduce overhead for all keycloak calls

### DIFF
--- a/backend/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakService.java
+++ b/backend/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakService.java
@@ -18,6 +18,7 @@ package com.valtimo.keycloak.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.keycloak.OAuth2Constants;
@@ -45,30 +46,26 @@ public class KeycloakService {
     public static final String KEYCLOAK_JWT_CLIENT_REGISTRATION = "keycloakjwt";
     private final KeycloakSpringBootProperties properties;
     private final String clientName;
-    private ResteasyJackson2Provider jacksonProvider = null;
+    private ResteasyClientBuilder restEasyClientBuilder = null;
 
     public KeycloakService(KeycloakSpringBootProperties properties, String keycloakClientName) {
         this.properties = ValtimoKeycloakPropertyResolver.resolveProperties();
         this.clientName = keycloakClientName;
+        ObjectMapper mapper = new ObjectMapper()
+            .configure(
+                FAIL_ON_UNKNOWN_PROPERTIES,
+                false
+            ); // Use a lenient Jackson ObjectMapper so the Keycloak Admin Client can deserialize newer server responses that include additional/unknown fields without failing.
+
+        ResteasyJackson2Provider jacksonProvider = new ResteasyJackson2Provider();
+        jacksonProvider.setMapper(mapper);
+        restEasyClientBuilder = new ResteasyClientBuilderImpl()
+            .connectionPoolSize(10)
+            .register(jacksonProvider);
     }
 
     public Keycloak keycloak() {
-        if (jacksonProvider == null) {
-
-            ObjectMapper mapper = new ObjectMapper()
-                .configure(
-                    FAIL_ON_UNKNOWN_PROPERTIES,
-                    false
-                ); // Use a lenient Jackson ObjectMapper so the Keycloak Admin Client can deserialize newer server responses that include additional/unknown fields without failing.
-
-            jacksonProvider = new ResteasyJackson2Provider();
-            jacksonProvider.setMapper(mapper);
-
-        }
-
-        ResteasyClient resteasyClient = new ResteasyClientBuilderImpl()
-            .connectionPoolSize(10)
-            .register(jacksonProvider)
+        ResteasyClient resteasyClient = restEasyClientBuilder
             .build();
 
         return KeycloakBuilder.builder()

--- a/backend/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakService.java
+++ b/backend/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakService.java
@@ -45,6 +45,7 @@ public class KeycloakService {
     public static final String KEYCLOAK_JWT_CLIENT_REGISTRATION = "keycloakjwt";
     private final KeycloakSpringBootProperties properties;
     private final String clientName;
+    private ResteasyJackson2Provider jacksonProvider = null;
 
     public KeycloakService(KeycloakSpringBootProperties properties, String keycloakClientName) {
         this.properties = ValtimoKeycloakPropertyResolver.resolveProperties();
@@ -52,12 +53,18 @@ public class KeycloakService {
     }
 
     public Keycloak keycloak() {
+        if (jacksonProvider == null) {
 
-        ObjectMapper mapper = new ObjectMapper()
-            .configure(FAIL_ON_UNKNOWN_PROPERTIES, false); // Use a lenient Jackson ObjectMapper so the Keycloak Admin Client can deserialize newer server responses that include additional/unknown fields without failing.
+            ObjectMapper mapper = new ObjectMapper()
+                .configure(
+                    FAIL_ON_UNKNOWN_PROPERTIES,
+                    false
+                ); // Use a lenient Jackson ObjectMapper so the Keycloak Admin Client can deserialize newer server responses that include additional/unknown fields without failing.
 
-        ResteasyJackson2Provider jacksonProvider = new ResteasyJackson2Provider();
-        jacksonProvider.setMapper(mapper);
+            jacksonProvider = new ResteasyJackson2Provider();
+            jacksonProvider.setMapper(mapper);
+
+        }
 
         ResteasyClient resteasyClient = new ResteasyClientBuilderImpl()
             .connectionPoolSize(10)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal initialization in the authentication service to reduce per-request overhead and improve performance and resource efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->