### PR TITLE
small fix for table-widget skeleton loader

### DIFF
--- a/frontend/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/carbon-list/carbon-list.component.ts
@@ -99,6 +99,7 @@ export class CarbonListComponent implements OnInit, AfterViewInit, OnDestroy {
   private _completeDataSource: TableItem[][];
 
   private readonly _items$ = new BehaviorSubject<CarbonListItem[]>([]);
+  private readonly _skeletonRowCount$ = new BehaviorSubject<number>(5);
 
   private get _items(): CarbonListItem[] {
     return this._items$.getValue();
@@ -152,6 +153,9 @@ export class CarbonListComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   @Input() loading: boolean;
+  @Input() set skeletonRowCount(value: number) {
+    this._skeletonRowCount$.next(value);
+  }
 
   /**
    * @deprecated The actions field is deprecated. Actions can be added through the **@Input field**.
@@ -286,6 +290,22 @@ export class CarbonListComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.pagination) {
       this.loadPaginationSize();
     }
+
+    this._subscriptions.add(
+      combineLatest([this._headerItems$, this._items$, this._skeletonRowCount$]).subscribe(
+        ([headers, items, skeletonRowCount]) => {
+          let rowCount = items.length > 0 ? items.length : skeletonRowCount;
+
+          if (items.length === 0 && this.pagination?.size) {
+            rowCount = this.pagination.size;
+          }
+          if (!this.hideToolbar) {
+            rowCount++;
+          }
+          this.skeletonModel = Table.skeletonModel(rowCount + 1, headers.length);
+        }
+      )
+    );
 
     this._subscriptions.add(
       this.searchFormControl.valueChanges

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.html
@@ -109,11 +109,16 @@
     ></valtimo-no-results>
   }
 
-  <cds-pagination-nav
-    *ngIf="paginationModel() && (showPagination$ | async)"
-    class="valtimo-widget-collection__pagination"
-    [model]="paginationModel()"
-    (selectPage)="onSelectPage($event)"
-  >
-  </cds-pagination-nav>
+  @if ($paginationModel() && $showPagination()) {
+    <cds-pagination-nav
+      class="valtimo-widget-collection__pagination"
+      [model]="$paginationModel()"
+      (selectPage)="onSelectPage($event)"
+    >
+    </cds-pagination-nav>
+  } @else if (!obs.widgetData) {
+    <div class="valtimo-widget-collection__pagination">
+      <cds-skeleton-text [lines]="1" [maxLineWidth]="150" [minLineWidth]="150"></cds-skeleton-text>
+    </div>
+  }
 </ng-container>

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.scss
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.scss
@@ -111,6 +111,8 @@
     padding: 8px 0;
     display: flex;
     justify-content: center;
+    height: 64px;
+    align-items: center;
   }
 
   &__render {

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.ts
@@ -81,7 +81,7 @@ export class WidgetCollectionComponent implements AfterViewInit, OnDestroy {
     this.hostClasses = `valtimo-widget-collection ${value.isCompact ? 'valtimo-widget-collection--compact' : ''}`;
   }
 
-  public readonly showPagination$ = new BehaviorSubject<boolean>(false);
+  public readonly $showPagination = signal<boolean>(false);
 
   private readonly _widgetData$ = new BehaviorSubject<Page<CollectionWidgetCardData> | null>(null);
 
@@ -116,9 +116,9 @@ export class WidgetCollectionComponent implements AfterViewInit, OnDestroy {
     this._widgetData$.next(widgetData);
 
     if (!this._paginationInitialized) {
-      this.showPagination$.next(value.totalElements > value.size);
+      this.$showPagination.set(value.totalElements > value.size);
 
-      this.paginationModel.set(
+      this.$paginationModel.set(
         value.totalPages < 0
           ? null
           : {
@@ -130,7 +130,7 @@ export class WidgetCollectionComponent implements AfterViewInit, OnDestroy {
 
       this._paginationInitialized = true;
     } else {
-      this.paginationModel.update((model: PaginationModel) => ({
+      this.$paginationModel.update((model: PaginationModel) => ({
         ...model,
         currentPage: value.number + 1,
       }));
@@ -145,7 +145,7 @@ export class WidgetCollectionComponent implements AfterViewInit, OnDestroy {
   public readonly $widgetTitle = signal('-');
 
   public readonly widgetConfiguration$ = new BehaviorSubject<CollectionWidget | null>(null);
-  public readonly paginationModel = signal<PaginationModel>(new PaginationModel());
+  public readonly $paginationModel = signal<PaginationModel>(new PaginationModel());
   public readonly amountOfColumns = signal(0);
 
   public readonly collectionWidgetCards$: Observable<
@@ -208,7 +208,9 @@ export class WidgetCollectionComponent implements AfterViewInit, OnDestroy {
   }
 
   public onSelectPage(page: number): void {
-    this.paginationEvent.emit({...this.paginationModel(), currentPage: page});
+    const paginationModel = this.$paginationModel();
+    if (!paginationModel) return;
+    this.paginationEvent.emit({...paginationModel, currentPage: page});
   }
 
   private getCardField(

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-collection/widget-collection.component.ts
@@ -145,7 +145,7 @@ export class WidgetCollectionComponent implements AfterViewInit, OnDestroy {
   public readonly $widgetTitle = signal('-');
 
   public readonly widgetConfiguration$ = new BehaviorSubject<CollectionWidget | null>(null);
-  public readonly $paginationModel = signal<PaginationModel>(new PaginationModel());
+  public readonly $paginationModel = signal<PaginationModel | null>(new PaginationModel());
   public readonly amountOfColumns = signal(0);
 
   public readonly collectionWidgetCards$: Observable<

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-interactive-table/widget-interactive-table.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-interactive-table/widget-interactive-table.component.html
@@ -37,6 +37,7 @@
     [items]="obs.widgetData || []"
     [initialSortState]="$initialSortState()"
     [loading]="obs.widgetData === null"
+    [skeletonRowCount]="widgetConfiguration?.properties?.defaultPageSize || 5"
     [pagination]="$paginationModel()"
     [paginatorConfig]="$paginatorConfig()"
     (paginationClicked)="onPaginationClicked($event)"

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.html
@@ -49,16 +49,26 @@
         [fields]="obs.fields"
         [items]="obs.widgetData || []"
         [loading]="obs.widgetData === null"
+        [skeletonRowCount]="widgetConfiguration?.properties?.defaultPageSize || 5"
       >
       </valtimo-carbon-list>
 
-      <cds-pagination-nav
-        *ngIf="$paginationModel() && $showPagination()"
-        class="valtimo-widget-table__pagination"
-        [model]="$paginationModel()"
-        (selectPage)="onSelectPage($event)"
-      >
-      </cds-pagination-nav>
+      @if ($paginationModel() && $showPagination()) {
+        <cds-pagination-nav
+          class="valtimo-widget-table__pagination"
+          [model]="$paginationModel()"
+          (selectPage)="onSelectPage($event)"
+        >
+        </cds-pagination-nav>
+      } @else if (obs.widgetData === null) {
+        <div class="valtimo-widget-table__pagination">
+          <cds-skeleton-text
+            [lines]="1"
+            [maxLineWidth]="150"
+            [minLineWidth]="150"
+          ></cds-skeleton-text>
+        </div>
+      }
     </section>
   } @else if (obs.widgetData !== null) {
     <valtimo-no-results

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.scss
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.scss
@@ -44,6 +44,10 @@
 
   &__pagination {
     padding: 8px 0;
+    display: flex;
+    justify-content: center;
+    height: 64px;
+    align-items: center;
   }
 
   .cds--data-table {

--- a/frontend/scripts/dev-mode.js
+++ b/frontend/scripts/dev-mode.js
@@ -41,7 +41,11 @@ function createRebuildLock() {
 
 function removeRebuildLock() {
   if (fs.existsSync(rebuildLockFilePath)) {
-    fs.rmSync(rebuildLockFilePath);
+    try {
+      fs.rmSync(rebuildLockFilePath);
+    } catch (err) {
+      console.error(`Failed to remove rebuild lock: ${err.message}`);
+    }
   }
 }
 
@@ -64,6 +68,11 @@ async function runNext() {
           stdio: 'inherit',
           shell: true,
         });
+
+        startProc.on('error', err => {
+          console.error('Failed to start app:', err);
+        });
+
         activeProcesses.push(startProc);
         hasStartedApp = true;
       } else {
@@ -84,10 +93,12 @@ async function runNext() {
     createRebuildLock();
 
     const buildProc = spawn(initialBuildCmd, {shell: true});
+    let output = '';
 
     buildProc.stdout.on('data', data => {
       const str = data.toString();
       process.stdout.write(str);
+      output += str;
 
       if (str.includes('Built Angular Package')) {
         console.log(`Initial library build done for: @valtimo/${libName}\n`);
@@ -100,6 +111,10 @@ async function runNext() {
           shell: true,
         });
 
+        watcherProc.on('error', err => {
+          console.error(`Watcher error for @valtimo/${libName}:`, err);
+        });
+
         activeProcesses.push(watcherProc);
         current++;
         runNext();
@@ -109,11 +124,29 @@ async function runNext() {
     buildProc.stderr.on('data', data => {
       process.stderr.write(data.toString());
     });
+
+    buildProc.on('error', err => {
+      console.error(`Failed to start build for @valtimo/${libName}:`, err);
+      removeRebuildLock();
+      process.exit(1);
+    });
+
+    buildProc.on('exit', code => {
+      if (code !== 0 && code !== null && !output.includes('Built Angular Package')) {
+        console.error(`Build failed for @valtimo/${libName} with code ${code}`);
+        removeRebuildLock();
+        process.exit(1);
+      }
+    });
   } else {
     console.log(`\nSkipping initial library build for: @valtimo/${libName}, starting watcher...\n`);
     const watcherProc = spawn(chokidarCmd, {
       stdio: 'inherit',
       shell: true,
+    });
+
+    watcherProc.on('error', err => {
+      console.error(`Watcher error for @valtimo/${libName}:`, err);
     });
 
     activeProcesses.push(watcherProc);
@@ -122,11 +155,18 @@ async function runNext() {
   }
 }
 
+let isCleaningUp = false;
+
 function cleanup() {
+  if (isCleaningUp) return;
+  isCleaningUp = true;
+
   console.log('\nCleaning up child processes and temp files...\n');
   activeProcesses.forEach(p => {
     try {
-      p.kill();
+      if (p && !p.killed) {
+        p.kill();
+      }
     } catch (err) {
       console.error('Failed to kill process:', err);
     }


### PR DESCRIPTION
Bugfix: stop layout shifts on the widget page that are caused by the wrong skeleton loader height of the table-widget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skeleton loading placeholders become configurable per widget (defaults applied), improving loading visuals.
  * Pagination now shows a proper loading fallback skeleton when data is absent.

* **Style**
  * Pagination containers aligned and given fixed height for consistent layout.

* **Chores**
  * Development mode: improved error handling and safer process cleanup to reduce dev tooling interruptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->