### PR TITLE
Cherry-picked the change of PR #296 for issue 443 to Valtimo version 12.

### DIFF
--- a/backend/app/gzac/src/main/resources/config/application.yml
+++ b/backend/app/gzac/src/main/resources/config/application.yml
@@ -299,6 +299,10 @@ camunda:
             id: Admin
             password: admin
             first-name: Admin account
+    incident:
+        alert-log:
+            enabled: true
+            message-template: "CAMUNDA_INCIDENT_FAILED_JOB: processInstanceId={processInstanceId} incidentId={incidentId}"
 
 external:
     case:

--- a/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/CamundaAutoConfiguration.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/CamundaAutoConfiguration.java
@@ -19,6 +19,8 @@ package com.ritense.valtimo.autoconfigure;
 import com.ritense.valtimo.CamundaBeansPlugin;
 import com.ritense.valtimo.camunda.ProcessDefinitionDeployedEventPublisher;
 import com.ritense.valtimo.camunda.command.ValtimoSchemaOperationsCommand;
+import com.ritense.valtimo.camunda.incident.CamundaIncidentAlertLogProperties;
+import com.ritense.valtimo.camunda.incident.CamundaIncidentHandlerConfig;
 import com.ritense.valtimo.camunda.processaudit.HistoryEventAuditProcessEnginePlugin;
 import com.ritense.valtimo.camunda.processaudit.TaskEventHandler;
 import com.ritense.valtimo.camunda.repository.CustomRepositoryServiceImpl;
@@ -45,6 +47,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -53,6 +56,7 @@ import org.springframework.core.annotation.Order;
 
 @AutoConfiguration
 @AutoConfigureAfter(CamundaBpmAutoConfiguration.class)
+@EnableConfigurationProperties(CamundaIncidentAlertLogProperties.class)
 public class CamundaAutoConfiguration {
 
     @Bean
@@ -165,5 +169,12 @@ public class CamundaAutoConfiguration {
     @Order(Ordering.DEFAULT_ORDER - 2)
     public CamundaBeansPlugin camundaBeansPlugin() {
         return new CamundaBeansPlugin();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(CamundaIncidentHandlerConfig.class)
+    @ConditionalOnProperty("camunda.incident.alert-log.enabled")
+    public CamundaIncidentHandlerConfig camundaIncidentHandlerConfig(CamundaIncidentAlertLogProperties props)  {
+        return new CamundaIncidentHandlerConfig(props);
     }
 }

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/camunda/incident/CamundaIncidentAlertLogProperties.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/camunda/incident/CamundaIncidentAlertLogProperties.kt
@@ -1,0 +1,10 @@
+package com.ritense.valtimo.camunda.incident
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "camunda.incident.alert-log")
+data class CamundaIncidentAlertLogProperties(
+    val enabled: Boolean = false,
+    val messageTemplate: String =
+        "CAMUNDA_INCIDENT_FAILED_JOB: processInstanceId={processInstanceId} incidentId={incidentId}"
+)

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/camunda/incident/CamundaIncidentHandlerConfig.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/camunda/incident/CamundaIncidentHandlerConfig.kt
@@ -1,0 +1,13 @@
+package com.ritense.valtimo.camunda.incident
+
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl
+import org.camunda.bpm.spring.boot.starter.configuration.CamundaProcessEngineConfiguration
+
+class CamundaIncidentHandlerConfig(
+    private val props: CamundaIncidentAlertLogProperties
+): CamundaProcessEngineConfiguration {
+
+    override fun postInit(processEngineConfiguration: ProcessEngineConfigurationImpl) {
+        processEngineConfiguration.addIncidentHandler(CamundaIncidentHandlerDecorator(props))
+    }
+}

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/camunda/incident/CamundaIncidentHandlerDecorator.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/camunda/incident/CamundaIncidentHandlerDecorator.kt
@@ -1,0 +1,45 @@
+package com.ritense.valtimo.camunda.incident
+
+import mu.KotlinLogging
+import org.camunda.bpm.engine.impl.incident.DefaultIncidentHandler
+import org.camunda.bpm.engine.impl.incident.IncidentContext
+import org.camunda.bpm.engine.impl.incident.IncidentHandler
+import org.camunda.bpm.engine.impl.persistence.entity.IncidentEntity
+import org.camunda.bpm.engine.runtime.Incident
+
+class CamundaIncidentHandlerDecorator(
+    private val props: CamundaIncidentAlertLogProperties
+): IncidentHandler {
+
+    private val defaultIncidentHandler: DefaultIncidentHandler = DefaultIncidentHandler(IncidentEntity.FAILED_JOB_HANDLER_TYPE)
+
+    override fun getIncidentHandlerType(): String? {
+        return defaultIncidentHandler.incidentHandlerType
+    }
+
+    override fun handleIncident(
+        context: IncidentContext?,
+        message: String?
+    ): Incident {
+        val incident = defaultIncidentHandler.handleIncident(context, message)
+        val lineToLog = props.messageTemplate
+            .replace("{incidentId}", incident.id ?: "unknown")
+            .replace("{processInstanceId}", incident.processInstanceId ?: "unknown")
+
+        logger.error { lineToLog }
+
+        return incident
+    }
+
+    override fun resolveIncident(context: IncidentContext?) {
+        defaultIncidentHandler.resolveIncident(context)
+    }
+
+    override fun deleteIncident(context: IncidentContext?) {
+        defaultIncidentHandler.deleteIncident(context)
+    }
+
+    companion object {
+        val logger = KotlinLogging.logger {}
+    }
+}

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/camunda/incident/IncidentHandlerIntegrationTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/camunda/incident/IncidentHandlerIntegrationTest.kt
@@ -1,0 +1,58 @@
+package com.ritense.valtimo.camunda.incident
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.ritense.valtimo.BaseIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.camunda.bpm.engine.ManagementService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+
+@TestPropertySource(properties = [
+    "camunda.incident.alert-log.enabled=true"
+])
+class IncidentHandlerIntegrationTest(
+    @Autowired val managementService: ManagementService
+): BaseIntegrationTest() {
+
+    @Test
+    fun `engine triggers decorator and logs alert line`() {
+        val targetLogger = LoggerFactory.getLogger(CamundaIncidentHandlerDecorator::class.java) as Logger
+        val listAppender = ListAppender<ILoggingEvent>().apply { start() }
+        targetLogger.addAppender(listAppender)
+
+        try {
+            // Start a process instance that will create a failing async job
+            val procInstance = runtimeService.startProcessInstanceByKey("failing-process")
+
+            // Execute jobs until retries exhausted / incident created
+            for (i in 1..10) {
+                val job = managementService.createJobQuery().processInstanceId(procInstance.id).singleResult() ?: break
+                try {
+                    managementService.executeJob(job.id)
+                } catch (_: Exception) {
+                    // expected; keep going until incident is created
+                }
+
+                val incident = runtimeService.createIncidentQuery()
+                    .processInstanceId(procInstance.id)
+                    .singleResult()
+
+                if (incident != null) break
+            }
+
+            val incident = runtimeService.createIncidentQuery().processInstanceId(procInstance.id).singleResult()
+            assertThat(incident).isNotNull
+
+            // Assert log line
+            val msg = listAppender.list.joinToString("\n") { it.formattedMessage }
+            assertThat(msg).contains("CAMUNDA_INCIDENT_FAILED_JOB")
+        } finally {
+            targetLogger.detachAppender(listAppender)
+            listAppender.stop()
+        }
+    }
+}

--- a/backend/core/src/test/resources/bpmn/failing-process.bpmn
+++ b/backend/core/src/test/resources/bpmn/failing-process.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1qofjly" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.1">
+  <bpmn:process id="failing-process" name="Failing Process" isExecutable="true">
+    <bpmn:startEvent id="FailingTestStartEvent">
+      <bpmn:outgoing>SequenceFlow_0obzkuw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="FailingServiceTask" name="Failing service task" camunda:asyncBefore="true" camunda:expression="${nonExistingBean.nonExistingMethod()}">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="systemProcess" value="true" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0obzkuw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1gkaz89</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0obzkuw" sourceRef="FailingTestStartEvent" targetRef="FailingServiceTask" />
+    <bpmn:endEvent id="FailingTestEndEvent">
+      <bpmn:incoming>SequenceFlow_1gkaz89</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1gkaz89" sourceRef="FailingServiceTask" targetRef="FailingTestEndEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="failing-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="FailingTestStartEvent">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1du8zwk_di" bpmnElement="FailingServiceTask">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0hzhcsl_di" bpmnElement="FailingTestEndEvent">
+        <dc:Bounds x="491" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0obzkuw_di" bpmnElement="SequenceFlow_0obzkuw">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="300" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gkaz89_di" bpmnElement="SequenceFlow_1gkaz89">
+        <di:waypoint x="400" y="120" />
+        <di:waypoint x="491" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -154,6 +154,7 @@
   * [Process links](features/process/process-link.md)
   * [For developers](features/process/process/README.md)
     * [Integrating spring beans in a process](features/process/process/integrate-spring-bean-in-process.md)
+    * [Incident error logging](features/process/process/incident-error-logging.md)
     * [Whitelisting Scripting classes for Camunda](features/process/process/whitelist-scripting-classes.md)
     * [Whitelisting Spring beans for Camunda](features/process/process/whitelist-spring-bean.md)
 * [✅ Tasks](features/tasks.md)

--- a/documentation/features/process/process/README.md
+++ b/documentation/features/process/process/README.md
@@ -14,6 +14,10 @@ The for developers section within each feature gives more tech heavy information
 [integrate-spring-bean-in-process.md](integrate-spring-bean-in-process.md)
 {% endcontent-ref %}
 
+{% content-ref url="incident-error-logging.md" %}
+[incident-error-logging.md](incident-error-logging.md)
+{% endcontent-ref %}
+
 {% content-ref url="whitelist-scripting-classes.md" %}
 [whitelist-scripting-classes.md](whitelist-scripting-classes.md)
 {% endcontent-ref %}

--- a/documentation/features/process/process/incident-error-logging.md
+++ b/documentation/features/process/process/incident-error-logging.md
@@ -23,7 +23,7 @@ You can customize the log message using the Spring configuration property `camun
 For example:
 
 ```yml
-camunda.incident.alert-log.message-template: "An Camunda process has been placed in incident status after exhausting all retries: Process instance ID: {processInstanceId}"
+camunda.incident.alert-log.message-template: "A Camunda process has been placed in incident status after exhausting all retries: Process instance ID: {processInstanceId}"
 ```
 
 The following placeholders are supported in the template:

--- a/documentation/features/process/process/incident-error-logging.md
+++ b/documentation/features/process/process/incident-error-logging.md
@@ -1,0 +1,34 @@
+# Logging incidents when retries are exhausted
+
+When a process encounters an error during execution, Camunda logs the error and, depending on the configured [retry cycle](../retry-cycle.md), retries the failed task.
+Once all retries are exhausted, the process enters an incident state and further execution is halted.
+At this point, manual intervention is usually required to investigate and resolve the issue.
+
+Because incidents often require manual action, it can be useful to set up an alert for this at the infrastructure level.
+By default, Camunda does **not** log a dedicated message when a process enters an incident state due to exhausted retries.
+
+## Enabling incident alert logging
+
+To log a message when an incident is created, enable the following Spring configuration property:
+
+```yml
+camunda.incident.alert-log.enabled: true
+```
+The default log message is:
+> CAMUNDA_INCIDENT_FAILED_JOB: processInstanceId={processInstanceId} incidentId={incidentId}
+This makes it possible to configure alerts or triggers based on log entries containing the text "CAMUNDA_INCIDENT_FAILED_JOB".
+## Customizing the log message
+You can customize the log message using the Spring configuration property `camunda.incident.alert-log.message-template`.
+
+For example:
+
+```yml
+camunda.incident.alert-log.message-template: "An Camunda process has been placed in incident status after exhausting all retries: Process instance ID: {processInstanceId}"
+```
+
+The following placeholders are supported in the template:
+
+- `{processInstanceId}` - the ID of the process instance
+- `{incidentId}` - the ID of the incident
+
+These placeholders will be replaced with their corresponding values at runtime.

--- a/documentation/release-notes/12.x.x/12.24.0/README.md
+++ b/documentation/release-notes/12.x.x/12.24.0/README.md
@@ -8,9 +8,11 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Added the possibility to log an error when an Camunda process gets into incident status**
 
-  New enhancement explanation.
+  When you set the Spring property `camunda.incident.alert-log.enabled` to `true`,
+  an error will be logged when an Camunda process gets into incident status.
+  This can be useful if you want to set up an alert at infrastructure level. More information about this feature can be found in the [incident error logging documentation](../../../features/process/process/incident-error-logging.md).
 
 ## Bugfixes
 

--- a/documentation/release-notes/12.x.x/12.24.0/README.md
+++ b/documentation/release-notes/12.x.x/12.24.0/README.md
@@ -8,10 +8,10 @@
 
 ## Enhancements
 
-* **Added the possibility to log an error when an Camunda process gets into incident status**
+* **Added the possibility to log an error when a Camunda process gets into incident status**
 
   When you set the Spring property `camunda.incident.alert-log.enabled` to `true`,
-  an error will be logged when an Camunda process gets into incident status.
+  an error will be logged when a Camunda process gets into incident status.
   This can be useful if you want to set up an alert at infrastructure level. More information about this feature can be found in the [incident error logging documentation](../../../features/process/process/incident-error-logging.md).
 
 ## Bugfixes


### PR DESCRIPTION
Same as PR #296, but this time for Valtimo version 12.

Issue for V12: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/179

Original V13 Issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident alert logging for Camunda processes. When a process enters incident status due to exhausted retries, an error is logged with customizable message templates. Supports placeholder substitution for process instance and incident IDs.

* **Documentation**
  * Added documentation covering incident error logging configuration and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->