### PR TITLE
Updated `SchedulerAutoConfiguration` to configure `JdbcTemplateLockProvider` with specified timezone defaulting to UTC

### DIFF
--- a/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,27 +18,33 @@ package com.ritense.valtimo.autoconfigure;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 
+import java.util.TimeZone;
 import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.JdbcTemplate;
-import java.util.TimeZone;
 
 @AutoConfiguration
 @ConditionalOnClass(DataSource.class)
 public class SchedulerAutoConfiguration {
 
-    @Order(HIGHEST_PRECEDENCE + 13)
     @Bean
-    public LockProvider lockProvider(DataSource dataSource) {
+    @ConditionalOnMissingBean(LockProvider.class)
+    @Order(HIGHEST_PRECEDENCE + 13)
+    public LockProvider lockProvider(
+        final DataSource dataSource,
+        @Value("${timezone:UTC}") final String timeZone
+    ) {
         return new JdbcTemplateLockProvider(
             JdbcTemplateLockProvider.Configuration.builder()
                 .withJdbcTemplate(new JdbcTemplate(dataSource))
-                .withTimeZone(TimeZone.getTimeZone("UTC"))
+                .withTimeZone(TimeZone.getTimeZone(timeZone))
                 .build()
         );
     }

--- a/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
@@ -25,6 +25,8 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import java.util.TimeZone;
 
 @AutoConfiguration
 @ConditionalOnClass(DataSource.class)
@@ -33,6 +35,11 @@ public class SchedulerAutoConfiguration {
     @Order(HIGHEST_PRECEDENCE + 13)
     @Bean
     public LockProvider lockProvider(DataSource dataSource) {
-        return new JdbcTemplateLockProvider(dataSource);
+        return new JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(new JdbcTemplate(dataSource))
+                .withTimeZone(TimeZone.getDefault())
+                .build()
+        );
     }
 }

--- a/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
@@ -18,6 +18,8 @@ package com.ritense.valtimo.autoconfigure;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 
+import java.time.DateTimeException;
+import java.time.ZoneId;
 import java.util.TimeZone;
 import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockProvider;
@@ -41,10 +43,16 @@ public class SchedulerAutoConfiguration {
         final DataSource dataSource,
         @Value("${timezone:UTC}") final String timeZone
     ) {
+        final ZoneId zoneId;
+        try {
+            zoneId = ZoneId.of(timeZone);
+        } catch (DateTimeException ex) {
+            throw new IllegalArgumentException("Invalid timezone: " + timeZone, ex);
+        }
         return new JdbcTemplateLockProvider(
             JdbcTemplateLockProvider.Configuration.builder()
                 .withJdbcTemplate(new JdbcTemplate(dataSource))
-                .withTimeZone(TimeZone.getTimeZone(timeZone))
+                .withTimeZone(TimeZone.getTimeZone(zoneId))
                 .build()
         );
     }

--- a/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/SchedulerAutoConfiguration.java
@@ -38,7 +38,7 @@ public class SchedulerAutoConfiguration {
         return new JdbcTemplateLockProvider(
             JdbcTemplateLockProvider.Configuration.builder()
                 .withJdbcTemplate(new JdbcTemplate(dataSource))
-                .withTimeZone(TimeZone.getDefault())
+                .withTimeZone(TimeZone.getTimeZone("UTC"))
                 .build()
         );
     }

--- a/backend/core/src/test/resources/config/application.yml
+++ b/backend/core/src/test/resources/config/application.yml
@@ -1,4 +1,4 @@
-timezone: etc/UTC
+timezone: Etc/UTC
 spring:
     datasource:
         type: com.zaxxer.hikari.HikariDataSource

--- a/documentation/release-notes/13.x.x/13.13.0/README.md
+++ b/documentation/release-notes/13.x.x/13.13.0/README.md
@@ -18,4 +18,4 @@
 
 ## Bugfixes
 
-* New bugfix.
+* LockProvider configuration now uses the `TimeZone.getDefault()` to determine the time zone, ensuring consistency with the system's default time zone settings.


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/540

Updated the LockProvider bean configuration to use the configuration builder which allows specifying the timezone. 

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: `story/gh-540_shedlock-lockprovider-config`

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduler lock time zone is validated and now defaults to UTC when unspecified, preventing invalid time zone configuration.

* **Chores**
  * Lock provider creation is now conditional to avoid duplicate instances and supports deployment-configurable time zone.

* **Documentation**
  * Release notes updated to reflect the new configurable/default time zone behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->