### PR TITLE
Fix typo and indentation in migration documentation example

### DIFF
--- a/documentation/release-notes/13.x.x/13.0.0/back-end-migration.md
+++ b/documentation/release-notes/13.x.x/13.0.0/back-end-migration.md
@@ -204,23 +204,23 @@ Other changes required are impossible to list because they depend on how Camunda
 
 #### Application configuration
 
-References to Camunda properties in the application configuration should be changed. Usually this is done in `applcation.yml`
+References to Camunda properties in the application configuration should be changed. Usually this is done in `application.yml`
 
 <table><thead><tr><th>Before</th><th>After</th></tr></thead><tbody><tr><td><pre class="language-yaml"><code class="lang-yaml">spring:
     jersey:
         application-path: /api/camunda-rest
 camunda:
-bpm:
-history-level: AUDIT
-history-level-default: AUDIT
+    bpm:
+        history-level: AUDIT
+        history-level-default: AUDIT
 
 </code></pre></td><td><pre class="language-yaml"><code class="lang-yaml">spring:
-jersey:
-application-path: /api/operaton-rest
+    jersey:
+        application-path: /api/operaton-rest
 operaton:
-bpm:
-history-level: AUDIT
-history-level-default: AUDIT
+    bpm:
+        history-level: AUDIT
+        history-level-default: AUDIT
 
 </code></pre></td></tr></tbody></table>
 


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: 

Fixed a typo and adjusted indentation in the application configuration example within the back-end migration documentation for improved clarity and consistency.

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
- [ ] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation with corrected references and REST API endpoint paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->