### PR TITLE
Add vernietigingsdatum and statusUrl to linkDocumentToZaak plugin action

### DIFF
--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -155,7 +155,9 @@ class ZakenApiPlugin(
         execution: DelegateExecution,
         @PluginActionProperty documentUrl: String,
         @PluginActionProperty titel: String?,
-        @PluginActionProperty beschrijving: String?
+        @PluginActionProperty beschrijving: String?,
+        @PluginActionProperty vernietigingsdatum: String? = null,
+        @PluginActionProperty statusUrl: String? = null
     ) {
         withLoggingContext(
             DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT to documentUrl
@@ -171,10 +173,12 @@ class ZakenApiPlugin(
             }
 
             val request = LinkDocumentRequest(
-                documentUrl,
-                zaakUrl.toString(),
-                titel,
-                beschrijving
+                informatieobject = documentUrl,
+                zaak = zaakUrl.toString(),
+                titel = titel,
+                beschrijving = beschrijving,
+                vernietigingsdatum = vernietigingsdatum,
+                status = statusUrl
             )
             client.linkDocument(authenticationPluginConfiguration, url, request)
             logger.info { "Document with URL '$documentUrl' linked successfully to zaak with URL '$zaakUrl'" }
@@ -204,10 +208,12 @@ class ZakenApiPlugin(
         }
 
         val request = LinkDocumentRequest(
-            documentUrl,
-            zaakUrl.toString(),
-            metadata["title"] as String?,
-            metadata["description"] as String?,
+            informatieobject = documentUrl,
+            zaak = zaakUrl.toString(),
+            titel = metadata["title"] as String?,
+            beschrijving = metadata["description"] as String?,
+            vernietigingsdatum = null,
+            status = null
         )
         client.linkDocument(authenticationPluginConfiguration, url, request)
         logger.info { "Linked uploaded document with URL '$documentUrl' to zaak with URL '$zaakUrl'" }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/LinkDocumentRequest.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/LinkDocumentRequest.kt
@@ -23,5 +23,7 @@ class LinkDocumentRequest(
     val informatieobject: String,
     val zaak: String,
     val titel: String?,
-    val beschrijving: String?
+    val beschrijving: String?,
+    val vernietigingsdatum: String?,
+    val status: String?
 )

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -103,7 +103,14 @@ internal class ZakenApiPluginTest {
             authenticationMock = authenticationMock
         )
 
-        plugin.linkDocumentToZaak(executionMock, documentUrl(), "titel", "beschrijving")
+        plugin.linkDocumentToZaak(
+            execution = executionMock,
+            documentUrl = documentUrl(),
+            titel = "titel",
+            beschrijving = "beschrijving",
+            vernietigingsdatum = "2025-12-31T23:59:59Z",
+            statusUrl = "https://example.com/statustypen/1"
+        )
 
         val captor = argumentCaptor<LinkDocumentRequest>()
         verify(zakenApiClient).linkDocument(any(), any(), captor.capture())
@@ -113,6 +120,8 @@ internal class ZakenApiPluginTest {
         assertEquals(zaakUrl(), request.zaak)
         assertEquals("titel", request.titel)
         assertEquals("beschrijving", request.beschrijving)
+        assertEquals("2025-12-31T23:59:59Z", request.vernietigingsdatum)
+        assertEquals("https://example.com/statustypen/1", request.status)
     }
 
     @Test
@@ -153,6 +162,8 @@ internal class ZakenApiPluginTest {
         assertEquals(zaakUrl(), request.zaak)
         assertEquals("titel", request.titel)
         assertEquals("beschrijving", request.beschrijving)
+        assertEquals(null, request.vernietigingsdatum)
+        assertEquals(null, request.status)
     }
 
     @Test

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
@@ -93,6 +93,8 @@ internal class ZakenApiClientIT @Autowired constructor(
                 zaak = "https://localhost:56273/zaken/1234",
                 titel = "titel",
                 beschrijving = "beschrijving",
+                vernietigingsdatum = null,
+                status = null
             )
         )
     }
@@ -109,6 +111,8 @@ internal class ZakenApiClientIT @Autowired constructor(
                     zaak = "https://localhost:56273/zaken/1234",
                     titel = "titel",
                     beschrijving = "beschrijving",
+                    vernietigingsdatum = null,
+                    status = null
                 )
             )
         }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
@@ -121,7 +121,9 @@ internal class ZakenApiClientTest {
                 informatieobject = HTTPS_EXAMPLE_COM,
                 zaak = zaakUrlAsString,
                 titel = "title",
-                beschrijving = "description"
+                beschrijving = "description",
+                vernietigingsdatum = null,
+                status = null
             )
         )
 
@@ -135,6 +137,8 @@ internal class ZakenApiClientTest {
         assertEquals(zaakUrlAsString, parsedOutput["zaak"])
         assertEquals("title", parsedOutput["titel"])
         assertEquals("description", parsedOutput["beschrijving"])
+        assertNull(parsedOutput["vernietigingsdatum"])
+        assertNull(parsedOutput["status"])
 
         assertEquals(HTTPS_EXAMPLE_COM, result.url)
         assertEquals(HTTPS_EXAMPLE_COM, result.informatieobject)
@@ -204,7 +208,9 @@ internal class ZakenApiClientTest {
                 informatieobject = HTTPS_EXAMPLE_COM,
                 zaak = zaakUri().toASCIIString(),
                 titel = "title",
-                beschrijving = "description"
+                beschrijving = "description",
+                vernietigingsdatum = null,
+                status = null
             )
         )
 
@@ -238,7 +244,9 @@ internal class ZakenApiClientTest {
                     informatieobject = HTTPS_EXAMPLE_COM,
                     zaak = zaakUri().toASCIIString(),
                     titel = "title",
-                    beschrijving = "description"
+                    beschrijving = "description",
+                    vernietigingsdatum = null,
+                    status = null
                 )
             )
         }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
@@ -137,8 +137,8 @@ internal class ZakenApiClientTest {
         assertEquals(zaakUrlAsString, parsedOutput["zaak"])
         assertEquals("title", parsedOutput["titel"])
         assertEquals("description", parsedOutput["beschrijving"])
-        assertNull(parsedOutput["vernietigingsdatum"])
-        assertNull(parsedOutput["status"])
+        assertThat(parsedOutput).doesNotContainKey("vernietigingsdatum")
+        assertThat(parsedOutput).doesNotContainKey("status")
 
         assertEquals(HTTPS_EXAMPLE_COM, result.url)
         assertEquals(HTTPS_EXAMPLE_COM, result.informatieobject)

--- a/documentation/features/plugins/configure-zaken-api-plugin.md
+++ b/documentation/features/plugins/configure-zaken-api-plugin.md
@@ -38,6 +38,8 @@ When creating a process link the following properties have to be entered:
 * **URL to the document.** The complete URL of the document in a Documenten API.
 * **Document title.** The title of the document within the context of the zaak that is stored in the 'zaakinformatieobject' record in the Zaken API.
 * **Document description.** The description of the document within the context of the zaak that is stored in the 'zaakinformatieobject' record in the Zaken API.
+* **Destruction date.** (Optional) The date on which the information object must be destroyed. This field supports date/time in ISO 8601 format and process variables.
+* **Status URL.** (Optional) The URL to the status of the information object. This field supports URLs and process variables.
 
 An example process link configuration:
 

--- a/documentation/features/plugins/configure-zaken-api-plugin.md
+++ b/documentation/features/plugins/configure-zaken-api-plugin.md
@@ -38,8 +38,8 @@ When creating a process link the following properties have to be entered:
 * **URL to the document.** The complete URL of the document in a Documenten API.
 * **Document title.** The title of the document within the context of the zaak that is stored in the 'zaakinformatieobject' record in the Zaken API.
 * **Document description.** The description of the document within the context of the zaak that is stored in the 'zaakinformatieobject' record in the Zaken API.
-* **Destruction date.** (Optional) The date on which the information object must be destroyed. This field supports date/time in ISO 8601 format and process variables.
-* **Status URL.** (Optional) The URL to the status of the information object. This field supports URLs and process variables.
+* **Destruction date.** (Optional) The date on which the document should be removed from the zaak. This field supports date/time in ISO 8601 format and process variables.
+* **Status URL.** (Optional) References the status of the zaak for which the document is (or was) relevant. This field supports URLs and process variables.
 
 An example process link configuration:
 

--- a/documentation/release-notes/13.x.x/13.14.0/README.md
+++ b/documentation/release-notes/13.x.x/13.14.0/README.md
@@ -12,9 +12,9 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Added vernietigingsdatum and status to Link document to zaak**
 
-  New enhancement explanation.
+  The 'Link document to zaak' plugin action now supports two additional optional properties: `vernietigingsdatum` (destruction date) and `status`. These properties are included in the 'zaakinformatieobject' request when linking a document to a zaak.
 
 ## Bugfixes
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/link-document-to-zaak/link-document-to-zaak-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/link-document-to-zaak/link-document-to-zaak-configuration.component.html
@@ -59,4 +59,26 @@
     [fullWidth]="true"
   >
   </v-input>
+  <v-input
+    name="vernietigingsdatum"
+    [title]="'vernietigingsdatum' | pluginTranslate: pluginId | async"
+    [margin]="true"
+    [defaultValue]="obs.prefill?.vernietigingsdatum"
+    [disabled]="obs.disabled"
+    [required]="false"
+    [tooltip]="'vernietigingsdatumTooltip' | pluginTranslate: pluginId | async"
+    [fullWidth]="true"
+  >
+  </v-input>
+  <v-input
+    name="statusUrl"
+    [title]="'documentStatusUrl' | pluginTranslate: pluginId | async"
+    [margin]="true"
+    [defaultValue]="obs.prefill?.statusUrl"
+    [disabled]="obs.disabled"
+    [required]="false"
+    [tooltip]="'documentStatusUrlTooltip' | pluginTranslate: pluginId | async"
+    [fullWidth]="true"
+  >
+  </v-input>
 </v-form>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/models/config.ts
@@ -28,6 +28,8 @@ interface LinkDocumentToZaakConfig {
   documentUrl: string;
   titel: string;
   beschrijving: string;
+  vernietigingsdatum?: string;
+  statusUrl?: string;
 }
 
 interface GetZaakInformatieobjectenConfig {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
@@ -102,6 +102,12 @@ const zakenApiPluginSpecification: PluginSpecification = {
       beschrijving: 'Documentbeschrijving',
       beschrijvingTooltip:
         '(Optioneel) Vult het beschrijving veld in de metadata van de link tussen de Zaak en het Document',
+      vernietigingsdatum: 'Vernietigingsdatum',
+      vernietigingsdatumTooltip:
+        '(Optioneel) De datum waarop het informatieobject vernietigd moet worden. Dit veld ondersteunt datum/tijd in ISO 8601 formaat en proces variabelen.',
+      documentStatusUrl: 'Status URL',
+      documentStatusUrlTooltip:
+        '(Optioneel) De referentie naar de bij Zaak behorende Status waarvoor het document relevant is (geweest). Dit veld ondersteunt URLs en proces variabelen.',
       authenticationPluginConfiguration: 'Configuratie authenticatie-plug-in',
       authenticationPluginConfigurationTooltip:
         'Selecteer de plugin die de authenticatie kan afhandelen. Wanneer de selectiebox leeg blijft zal de authenticatie plugin (bv. OpenZaak) eerst aangemaakt moeten worden',
@@ -345,6 +351,12 @@ const zakenApiPluginSpecification: PluginSpecification = {
       beschrijving: 'Document description',
       beschrijvingTooltip:
         '(Optional) Fills the description field in the metadata of the link between the Zaak and the Document',
+      vernietigingsdatum: 'Destruction date',
+      vernietigingsdatumTooltip:
+        '(Optional) The date on which the information object must be destroyed. This field supports date/time in ISO 8601 format and process variables.',
+      documentStatusUrl: 'Status URL',
+      documentStatusUrlTooltip:
+        '(Optional) The reference to the Status associated with the Zaak for which the document is (or was) relevant. This field supports URLs and process variables.',
       authenticationPluginConfiguration: 'Authentication plugin configuration',
       authenticationPluginConfigurationTooltip:
         'Select the plugin that can handle the authentication. If the selection box remains empty, the authentication plugin (e.g. OpenZaak) will have to be created first',

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/zaken-api-plugin.specification.ts
@@ -104,10 +104,10 @@ const zakenApiPluginSpecification: PluginSpecification = {
         '(Optioneel) Vult het beschrijving veld in de metadata van de link tussen de Zaak en het Document',
       vernietigingsdatum: 'Vernietigingsdatum',
       vernietigingsdatumTooltip:
-        '(Optioneel) De datum waarop het informatieobject vernietigd moet worden. Dit veld ondersteunt datum/tijd in ISO 8601 formaat en proces variabelen.',
+        '(Optioneel) De datum waarop het document van de zaak verwijderd moet worden. Dit veld ondersteunt datum/tijd in ISO 8601 formaat en proces variabelen.',
       documentStatusUrl: 'Status URL',
       documentStatusUrlTooltip:
-        '(Optioneel) De referentie naar de bij Zaak behorende Status waarvoor het document relevant is (geweest). Dit veld ondersteunt URLs en proces variabelen.',
+        '(Optioneel) De referentie naar de bij Zaak behorende Status waarvoor het document relevant is (geweest).',
       authenticationPluginConfiguration: 'Configuratie authenticatie-plug-in',
       authenticationPluginConfigurationTooltip:
         'Selecteer de plugin die de authenticatie kan afhandelen. Wanneer de selectiebox leeg blijft zal de authenticatie plugin (bv. OpenZaak) eerst aangemaakt moeten worden',
@@ -353,7 +353,7 @@ const zakenApiPluginSpecification: PluginSpecification = {
         '(Optional) Fills the description field in the metadata of the link between the Zaak and the Document',
       vernietigingsdatum: 'Destruction date',
       vernietigingsdatumTooltip:
-        '(Optional) The date on which the information object must be destroyed. This field supports date/time in ISO 8601 format and process variables.',
+        '(Optional) The date on which the document should be removed from the zaak. This field supports date/time in ISO 8601 format and process variables.',
       documentStatusUrl: 'Status URL',
       documentStatusUrlTooltip:
         '(Optional) The reference to the Status associated with the Zaak for which the document is (or was) relevant. This field supports URLs and process variables.',


### PR DESCRIPTION
Add two optional properties to the 'Link document to zaak' plugin action: vernietigingsdatum (destruction date) and statusUrl (reference to zaak status).

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/162

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: `story/gh-162_zaken-api-create-informatieobject`

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Create a process definition in a case which makes use of the Zaken API plugin action 'link document to zaak' and configure 'vernietigingsdatum' and 'status'.
- [ ] Make sure the Zaken API contains an 'document' (enkelvoudiginformatieobject) which is not linked to the zaak as a zaakinformatieobject.
- [ ] Start the process

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Link document to zaak" action now accepts two optional fields: destruction date and status URL; these values are included when linking a document to a zaak.

* **Documentation**
  * Configuration guide and release notes updated to describe the new optional fields and their usage.

* **UI**
  * Plugin configuration form adds inputs for destruction date and status URL with translations and tooltips.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->