### PR TITLE
Removed double negative check to enable finalize button when there are no building blocks

### DIFF
--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-deployment/case-management-deployment.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-deployment/case-management-deployment.component.html
@@ -55,7 +55,7 @@
           <button
             cdsButton="primary"
             (click)="openFinalizeDraftConfirmationModal()"
-            [disabled]="obs?.caseDefinitionFinalizationCheckResult?.code !== 'OK'"
+            [disabled]="!obs?.caseDefinitionFinalizationCheckResult?.finalizable"
             [attr.data-test-id]="TEST_IDS.CASE_MANAGEMENT_DEPLOYMENT_FINALIZE_DRAFT_BUTTON"
           >
             {{ 'caseManagement.deployment.buttons.finalize' | translate }}

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-deployment/case-management-deployment.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-deployment/case-management-deployment.component.html
@@ -55,7 +55,7 @@
           <button
             cdsButton="primary"
             (click)="openFinalizeDraftConfirmationModal()"
-            [disabled]="!obs?.caseDefinitionFinalizationCheckResult?.code !== 'OK'"
+            [disabled]="obs?.caseDefinitionFinalizationCheckResult?.code !== 'OK'"
             [attr.data-test-id]="TEST_IDS.CASE_MANAGEMENT_DEPLOYMENT_FINALIZE_DRAFT_BUTTON"
           >
             {{ 'caseManagement.deployment.buttons.finalize' | translate }}


### PR DESCRIPTION
…e no building blocks.

https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Finalize Draft button in case management so its enabled/disabled state is now correctly determined by a direct finalizable check, ensuring the button enables only when finalization is allowed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->