### PR TITLE
cicd: Make separate test/prod backend images, use test images in PR test envs 

### DIFF
--- a/.github/test_env_comments/initial.md
+++ b/.github/test_env_comments/initial.md
@@ -3,6 +3,6 @@ Closing or merging this PR will automatically delete the test environment. Pushi
 Progress:
 
 - [ ] Creating test environment
-- [ ] Waiting for frontend and backend images with tag `"testEnv.${TEST_ENV_NAME}\_commit.\<commit sha\>\_contents.\<contents sha\>\_build.\<build number\>"`. Check the GitHub Actions logs for progress on the build / image tagging.
+- [ ] Waiting for frontend and backend images with tag `"testEnv.${TEST_ENV_NAME}_commit.<commit sha>_contents.<contents sha>_build.<build number>"`. Check the GitHub Actions logs for progress on the build / image tagging.
 - [ ] Starting test environment
 - [ ] Waiting for environment to run

--- a/.github/test_env_comments/waiting_for_images.md
+++ b/.github/test_env_comments/waiting_for_images.md
@@ -3,6 +3,6 @@ Closing or merging this PR will automatically delete the test environment. Pushi
 Progress:
 
 - [x] Created test environment
-- [ ] Waiting for frontend and backend images with tag `"testEnv.${TEST_ENV_NAME}\_commit.\<commit sha\>\_contents.\<contents sha\>\_build.\<build number\>"`. Check the GitHub Actions logs for progress on the build / image tagging.
+- [ ] Waiting for frontend and backend images with tag `"testEnv.${TEST_ENV_NAME}_commit.<commit sha>_contents.<contents sha>_build.<build number>"`. Check the GitHub Actions logs for progress on the build / image tagging.
 - [ ] Starting test environment
 - [ ] Waiting for environment to run

--- a/.github/workflows/backend_build_push_docker_image.yml
+++ b/.github/workflows/backend_build_push_docker_image.yml
@@ -11,18 +11,19 @@ on:
         description: Name of the backend build artifact to download with 'download-artifact'
         type: "string"
     outputs:
-      tagged_image:
-        description: "Tag of the Docker image that was built"
-        value: ${{ jobs.build_image.outputs.image_tag }}
-
-env:
-  ORG_GRADLE_PROJECT_includeDev: false
-
-# Defaults removed as gradlew is now in root
+      built_test_image:
+        description: "Tag of the test Docker image that was built"
+        # Equal to the first tag of 'generate_tags' step. Can't use its output directly because of the matrix job, so we reconstruct it.
+        value: ${{ github.head_ref || github.ref_name }}-test.${{ github.run_number }}
 
 jobs:
   assemble:
+    strategy:
+      matrix:
+        build_type: ["production", "test"]
+
     runs-on: ubuntu-latest
+    name: "assemble-${{ matrix.build_type }}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,7 +40,7 @@ jobs:
           name: ${{ inputs.backend_libraries_build_artifact_name }}
           path: .
 
-      - run: ./gradlew -PincludeDev=false :backend:app:gzac:assemble
+      - run: ./gradlew -PincludeDev=${{ matrix.build_type == 'test'}} :backend:app:gzac:assemble
 
       - name: Prepare deployment folder
         run: |
@@ -49,18 +50,19 @@ jobs:
       - name: Archive deployment folder
         uses: actions/upload-artifact@v4
         with:
-          name: gzac-app-backend-deployment
+          name: gzac-app-backend-deployment-${{ matrix.build_type }}
           path: backend/deployment/
           retention-days: 1
 
   build_image:
+    strategy:
+      matrix:
+        build_type: ["production", "test"]
     runs-on: ubuntu-latest
     needs: assemble
     permissions:
       contents: read
       packages: write
-    outputs:
-      image_tag: ${{ steps.primary_tag.outputs.tag }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
@@ -85,22 +87,16 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/gzac-backend
           tags: |
-            type=raw,value=${{ env.BRANCH_NAME }}.${{ github.run_number }}
-            type=raw,value=commit-${{ github.sha }}
-            type=raw,value=contents-${{ steps.backend_tree.outputs.tree }}
+            type=raw,value=${{ env.BRANCH_NAME }}-${{ matrix.build_type }}.${{ github.run_number }}
+            type=raw,value=commit-${{ matrix.build_type }}-${{ github.sha }}
+            type=raw,value=contents-${{ matrix.build_type }}-${{ steps.backend_tree.outputs.tree }}
           flavor: |
             latest=false
-
-      - name: Extract primary image tag
-        id: primary_tag
-        run: |
-          full_tag='${{ fromJson(steps.generate_tags.outputs.json).tags[0] }}'
-          echo "tag=${full_tag##*:}" >> "$GITHUB_OUTPUT"
 
       - name: Download deployment artifact
         uses: actions/download-artifact@v4
         with:
-          name: gzac-app-backend-deployment
+          name: gzac-app-backend-deployment-${{ matrix.build_type }}
           path: backend/deployment/
 
       - name: Set up Buildx

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -45,5 +45,5 @@ jobs:
     secrets: inherit
     with:
       target: "gzac-backend"
-      image_to_tag: ${{ needs.build_and_push_image.outputs.tagged_image }}
+      image_to_tag: ${{ needs.build_and_push_image.outputs.built_test_image }}
       contents_sha: ${{ needs.build_and_test_libraries.outputs.contents_sha }}

--- a/.github/workflows/create_test_env.yml
+++ b/.github/workflows/create_test_env.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           HASH=$(git rev-parse HEAD:backend)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
-          echo "image_tag=contents-${HASH}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=contents-test-${HASH}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -173,7 +173,7 @@ jobs:
           if docker manifest inspect "${IMAGE}:${IMAGE_TAG}" > /dev/null 2>&1; then
             echo "Found ${IMAGE}:${IMAGE_TAG}"
           else
-            echo "Backend was unchanged in this PR, so an attempt was made to re-use a backend image tagged with its Git contents-hash (${CONTENTS_HASH})." >&2
+            echo "Backend was unchanged in this PR, so an attempt was made to re-use a backend image tagged with its Git tree hash (${CONTENTS_HASH})." >&2
             echo "But no image tagged with ${IMAGE_TAG} was found in ${IMAGE}." >&2
             echo "The test environment will not work until an image with tag ${IMAGE}:${IMAGE_TAG} exists" >&2
             echo "To fix this:" >&2

--- a/.github/workflows/create_test_env.yml
+++ b/.github/workflows/create_test_env.yml
@@ -56,14 +56,6 @@ jobs:
       envName: ${{ inputs.env_name }}
       source_sha: ${{ inputs.commit_sha }}
 
-  neither_changed:
-    needs:
-      - detect_changes
-    if: ${{ needs.detect_changes.outputs.frontend_changed != 'true' && needs.detect_changes.outputs.backend_changed != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No frontend or backend changes detected; skipping test environment setup."
-
   comment_on_pr:
     if: ${{ (needs.detect_changes.outputs.frontend_changed == 'true' || needs.detect_changes.outputs.backend_changed == 'true') && github.event.pull_request.number }}
     runs-on: ubuntu-latest
@@ -130,11 +122,11 @@ jobs:
             "${DISPATCH_URL}" \
             -d "{\"ref\":\"main\",\"inputs\":{\"envName\":\"${ENV_NAME}\",\"githubCommentId\":\"${COMMENT_ID}\"}}"
 
-  only_frontend_changed:
+  retag_existing_backend_image:
     needs:
       - detect_changes
       - create_test_environment
-    if: ${{ needs.detect_changes.outputs.frontend_changed == 'true' && needs.detect_changes.outputs.backend_changed != 'true' }}
+    if: ${{ needs.detect_changes.outputs.backend_changed != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.backend_hash.outputs.image_tag }}
@@ -185,21 +177,21 @@ jobs:
 
   tag_backend_test_env_image:
     needs:
-      - only_frontend_changed
+      - retag_existing_backend_image
     uses: ./.github/workflows/tag_test_env_image.yml
     secrets: inherit
     with:
       target: gzac-backend
       env_name: ${{ inputs.env_name }}
-      contents_sha: ${{ needs.only_frontend_changed.outputs.contents_sha }}
-      image_to_tag: ${{ needs.only_frontend_changed.outputs.image_tag }}
+      contents_sha: ${{ needs.retag_existing_backend_image.outputs.contents_sha }}
+      image_to_tag: ${{ needs.retag_existing_backend_image.outputs.image_tag }}
       source_sha: ${{ github.event.pull_request.base.sha || inputs.commit_sha }}
 
-  only_backend_changed:
+  retag_existing_frontend_image:
     needs:
       - detect_changes
       - create_test_environment
-    if: ${{ needs.detect_changes.outputs.frontend_changed != 'true' && needs.detect_changes.outputs.backend_changed == 'true' }}
+    if: ${{ needs.detect_changes.outputs.frontend_changed != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.frontend_hash.outputs.image_tag }}
@@ -250,13 +242,13 @@ jobs:
 
   tag_frontend_test_env_image:
     needs:
-      - only_backend_changed
+      - retag_existing_frontend_image
       - determine_test_env
     uses: ./.github/workflows/tag_test_env_image.yml
     secrets: inherit
     with:
       target: gzac-frontend
       env_name: ${{ inputs.env_name }}
-      contents_sha: ${{ needs.only_backend_changed.outputs.contents_sha }}
-      image_to_tag: ${{ needs.only_backend_changed.outputs.image_tag }}
+      contents_sha: ${{ needs.retag_existing_frontend_image.outputs.contents_sha }}
+      image_to_tag: ${{ needs.retag_existing_frontend_image.outputs.image_tag }}
       source_sha: ${{ github.event.pull_request.base.sha || inputs.commit_sha }}

--- a/.github/workflows/create_test_env.yml
+++ b/.github/workflows/create_test_env.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
           HASH=$(git rev-parse HEAD:frontend)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
-          echo "image_tag=contents-${HASH}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=contents-test-${HASH}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/create_test_env.yml
+++ b/.github/workflows/create_test_env.yml
@@ -57,7 +57,6 @@ jobs:
       source_sha: ${{ inputs.commit_sha }}
 
   comment_on_pr:
-    if: ${{ (needs.detect_changes.outputs.frontend_changed == 'true' || needs.detect_changes.outputs.backend_changed == 'true') && github.event.pull_request.number }}
     runs-on: ubuntu-latest
     needs:
       - detect_changes
@@ -103,7 +102,6 @@ jobs:
     needs:
       - detect_changes
       - comment_on_pr
-    if: ${{ needs.detect_changes.outputs.frontend_changed == 'true' || needs.detect_changes.outputs.backend_changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Create or update test environment

--- a/.github/workflows/create_test_env.yml
+++ b/.github/workflows/create_test_env.yml
@@ -228,8 +228,7 @@ jobs:
           if docker manifest inspect "${IMAGE}:${IMAGE_TAG}" > /dev/null 2>&1; then
             echo "Found ${IMAGE}:${IMAGE_TAG}"
           else
-            echo "Frontend was unchanged in this PR, so an attempt was made to re-use a frontend image tagged with its Git contents-hash (${CONTENTS_HASH})." >&2
-            echo "But no image tagged with ${IMAGE_TAG} was found in ${IMAGE}." >&2
+            echo "Frontend was unchanged in this PR, so an attempt was made to re-use a frontend image tagged with its Git tree hash (${CONTENTS_HASH})." >&2            echo "But no image tagged with ${IMAGE_TAG} was found in ${IMAGE}." >&2
             echo "The test environment will not work until an image with tag ${IMAGE}:${IMAGE_TAG} exists" >&2
             echo "To fix this:" >&2
             echo "  1. If commit ${BASE_COMMIT_SHA} of branch ${BASE_BRANCH_NAME} already has a built frontend image, manually tag it for the test environment." >&2

--- a/.github/workflows/frontend_build_push_docker_image.yml
+++ b/.github/workflows/frontend_build_push_docker_image.yml
@@ -117,7 +117,7 @@ jobs:
           tags: |
             type=raw,value=${{ env.BRANCH_NAME }}.${{ github.run_number }}
             type=raw,value=commit-${{ github.sha }}
-            type=raw,value=contents-${{ steps.frontend_tree.outputs.tree }}
+            type=raw,value=contents-test-${{ steps.frontend_tree.outputs.tree }}
           flavor: |
             latest=false
 


### PR DESCRIPTION
Updated the backend CI pipeline to build both production and test Docker images in parallel.

Build Matrix: Added production vs test matrix to backend build jobs.
test builds run with -PincludeDev=true to include dev/test configurations.
production builds run with -PincludeDev=false.
Test Environments: backend_ci now explicitly deploys the test image variant to PR environments.
Tagging: Updated Docker tags to distinguish between build types (e.g., commit-test-abc vs commit-production-abc).