### PR TITLE
fix: json editor not rendering + documentation

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -164,6 +164,7 @@
 
 * [Release notes](release-notes/release-notes.md)
 * [13.x.x](release-notes/13.x.x/README.md)
+  * [13.15.0](release-notes/13.x.x/13.15.0/README.md)
   * [13.14.0](release-notes/13.x.x/13.14.0/README.md)
   * [13.13.0](release-notes/13.x.x/13.13.0/README.md)
   * [13.12.0](release-notes/13.x.x/13.12.0/README.md)
@@ -184,8 +185,8 @@
   * [13.1.2](release-notes/13.x.x/13.1.2/README.md)
   * [13.1.1](release-notes/13.x.x/13.1.1/README.md)
   * [13.0.0](release-notes/13.x.x/13.0.0/README.md)
-    * [13.0.2](release-notes/13.x.x/13.0.2/README.md)
-    * [13.0.1](release-notes/13.x.x/13.0.1/README.md)
+  * [13.0.2](release-notes/13.x.x/13.0.2/README.md)
+  * [13.0.1](release-notes/13.x.x/13.0.1/README.md)
   * [Front-end migration](release-notes/13.x.x/13.0.0/front-end-migration.md)
   * [Back-end migration](release-notes/13.x.x/13.0.0/back-end-migration.md)
 

--- a/documentation/release-notes/13.x.x/13.13.0/README.md
+++ b/documentation/release-notes/13.x.x/13.13.0/README.md
@@ -6,7 +6,7 @@
 
 ## Migration
 
-* [Front-end migration](front-end-migration.md)
+* [Front-end migration](./front-end-migration.md)
 
 ## New Features
 

--- a/documentation/release-notes/13.x.x/13.15.0/README.md
+++ b/documentation/release-notes/13.x.x/13.15.0/README.md
@@ -1,0 +1,22 @@
+# 13.50.0
+
+{% hint style="info" %}
+**Release date xx-xx-2026**
+{% endhint %}
+
+## New Features
+
+* **New feature title**
+
+  New feature explanation.
+
+## Enhancements
+
+* **New enhancement title**
+
+  New enhancement explanation.
+
+## Bugfixes
+
+* When working with the JSON editor for document or form definitions, the editor would occasionally fail to display. 
+  This issue has been resolved, and the JSON editor should now appear consistently.

--- a/frontend/projects/valtimo/components/src/lib/components/editor/editor.component.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/editor/editor.component.ts
@@ -85,6 +85,11 @@ export class EditorComponent implements AfterViewInit, OnDestroy {
 
   public ngOnDestroy(): void {
     this._layoutSubscription?.unsubscribe();
+    if (this._editor) {
+      const model = this._editor.getModel();
+      this._editor.dispose();
+      model?.dispose();
+    }
   }
 
   private openLayoutSubscription(): void {
@@ -183,6 +188,11 @@ export class EditorComponent implements AfterViewInit, OnDestroy {
 
     this.setEditorEvents();
     this.updateModel();
+
+    // Ensure layout is recalculated after container dimensions are set by fitPage directive
+    requestAnimationFrame(() => {
+      this._editor?.layout();
+    });
   }
 
   private initJsonSchemaValidation() {

--- a/frontend/projects/valtimo/form-management/src/lib/components/form-management-edit/form-management-edit.component.html
+++ b/frontend/projects/valtimo/form-management/src/lib/components/form-management-edit/form-management-edit.component.html
@@ -41,7 +41,7 @@
       </cds-tab>
 
       <cds-tab [heading]="TABS.EDITOR | translate" (selected)="onSelectedTab(TABS.EDITOR)">
-        @if (activeTab === TABS.EDITOR) {
+        @if (activeTab === TABS.EDITOR && obs.jsonFormDefinition) {
           <ng-container
             *ngTemplateOutlet="
               jsonEditor;
@@ -68,7 +68,7 @@
           (change)="onOutputChange($event)"
         ></valtimo-form-io>
 
-        @if (activeTab === TABS.OUTPUT) {
+        @if (activeTab === TABS.OUTPUT && obs.jsonOutput) {
           <ng-container
             *ngTemplateOutlet="
               jsonEditor;

--- a/frontend/projects/valtimo/form-management/src/lib/components/form-management-edit/form-management-edit.component.ts
+++ b/frontend/projects/valtimo/form-management/src/lib/components/form-management-edit/form-management-edit.component.ts
@@ -222,7 +222,7 @@ export class FormManagementEditComponent implements OnInit, OnDestroy {
     this._changeActive = true;
     this.modifiedFormDefinition = event.form;
     this._formDefinition$.next({...this._formDefinition, formDefinition: event.form});
-    this.jsonFormDefinition$.next({...definition, value: JSON.stringify(event.form)});
+    this.jsonFormDefinition$.next({...definition, value: JSON.stringify(event.form), language: 'json'});
     this._changeActive = false;
   }
 


### PR DESCRIPTION
closes https://ritense.atlassian.net/wiki/spaces/RIT/pages/2320171009/Building+blocks+solution+design

I think the link to the story is https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/359

How to test:
- Start up next-minor
- Open the application in Firefox
- Create a new independent form (outside of case)
- Add a component in builder
- Switch to JSON editor tab
- Note that the JSON editor is not rendering
- Switch to this branch, go through previous steps, note JSON editor is now rendering
