### PR TITLE
fix: docker database init scripts

### DIFF
--- a/backend/app/gzac/imports/open-notificaties/database/1-setup-notificaties.sql
+++ b/backend/app/gzac/imports/open-notificaties/database/1-setup-notificaties.sql
@@ -22,14 +22,35 @@ INSERT INTO authorizations_applicatie VALUES (2, '1f5cb913-caa3-433b-851d-9a371a
 INSERT INTO authorizations_applicatie VALUES (3, 'd346a22a-7f6a-48ef-99f2-4439c3f8f17d', '{openzaak}', 'Open Zaak', true);
 SELECT setval(pg_get_serial_sequence('authorizations_applicatie', 'id'), 3, true);
 
-INSERT INTO authorizations_authorizationsconfig VALUES (1, 'http://openzaak:8000/autorisaties/api/v1/', 'nrc');
-SELECT setval(pg_get_serial_sequence('authorizations_authorizationsconfig', 'id'), 1, true);
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'authorizations_authorizationsconfig') THEN
+        INSERT INTO authorizations_authorizationsconfig (id, api_root, component)
+        VALUES (1, 'http://openzaak:8000/autorisaties/api/v1/', 'nrc')
+        ON CONFLICT (id) DO NOTHING;
+        PERFORM setval(pg_get_serial_sequence('authorizations_authorizationsconfig', 'id'), 1, true);
+    END IF;
+END $$;
 
-INSERT INTO notifications_notificationsconfig VALUES (1, 'https://open-notificaties/api/v1/');
-SELECT setval(pg_get_serial_sequence('notifications_notificationsconfig', 'id'), 1, true);
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'notifications_notificationsconfig') THEN
+        INSERT INTO notifications_notificationsconfig (id, api_root)
+        VALUES (1, 'https://open-notificaties/api/v1/')
+        ON CONFLICT (id) DO NOTHING;
+        PERFORM setval(pg_get_serial_sequence('notifications_notificationsconfig', 'id'), 1, true);
+    END IF;
+END $$;
 
-INSERT INTO vng_api_common_apicredential VALUES (1, 'http://openzaak:8000/autorisaties/api/v1/', 'opennotificaties', 'opennotificaties', 'openzaak', 'opennotificaties', 'opennotificaties');
-SELECT setval(pg_get_serial_sequence('vng_api_common_apicredential', 'id'), 1, true);
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'vng_api_common_apicredential') THEN
+        INSERT INTO vng_api_common_apicredential (id, api_root, client_id, secret, label, user_id, user_representation)
+        VALUES (1, 'http://openzaak:8000/autorisaties/api/v1/', 'opennotificaties', 'opennotificaties', 'openzaak', 'opennotificaties', 'opennotificaties')
+        ON CONFLICT (id) DO NOTHING;
+        PERFORM setval(pg_get_serial_sequence('vng_api_common_apicredential', 'id'), 1, true);
+    END IF;
+END $$;
 
 INSERT INTO vng_api_common_jwtsecret VALUES (1, 'objectsapi', '9wu2''''Z`[x(eEk![:.$mBT6&:F!,%)EY74TS.AU+6');
 INSERT INTO vng_api_common_jwtsecret VALUES (2, 'valtimo', 'zZ!xRP&$qTn4A9ETa^ZMKepDm^8egjPz');

--- a/backend/app/gzac/imports/open-notificaties/database/fill-data-on-startup.sh
+++ b/backend/app/gzac/imports/open-notificaties/database/fill-data-on-startup.sh
@@ -5,7 +5,7 @@ useradd notifications
 while true
 do
     verifier=$(psql -U notifications -d notifications -t -A -c "select count(id)>0 from auth_permission")
-    if [ "t" = $verifier ]
+    if [ "t" = "$verifier" ]
         then
             echo "Running database setup scripts"
             for file in /docker-entrypoint-initdb.d/database/*.sql

--- a/backend/app/gzac/imports/open-zaak/database/1-setup-zaaktype.sql
+++ b/backend/app/gzac/imports/open-zaak/database/1-setup-zaaktype.sql
@@ -81,15 +81,19 @@ SELECT setval(pg_get_serial_sequence('catalogi_besluittype_zaaktypen', 'id'), 1,
 INSERT INTO catalogi_zaaktypeinformatieobjecttype(id, uuid, volgnummer, richting, informatieobjecttype_id, statustype_id, zaaktype_id, _etag) VALUES (1, '405da8a9-7296-439c-a2eb-a470b84f17ee', 1, 'inkomend', 1, NULL, 1, '_etag');
 SELECT setval(pg_get_serial_sequence('catalogi_zaaktypeinformatieobjecttype', 'id'), 1, true);
 
-UPDATE notifications_notificationsconfig SET api_root = 'http://host.docker.internal:8002/api/v1/';
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'notifications_notificationsconfig') THEN
+        UPDATE notifications_notificationsconfig SET api_root = 'http://host.docker.internal:8002/api/v1/';
+    END IF;
+END $$;
 
-DELETE FROM zgw_consumers_service where id = 1;
-INSERT INTO zgw_consumers_service(id, uuid, label, api_type, api_root, client_id, secret, auth_type, header_key, header_value, oas, nlx, user_id, user_representation, oas_file) VALUES (1, uuid_generate_v4(), 'Open formulieren', 'nrc', 'http://host.docker.internal:8002/api/v1/', 'openzaak', 'openzaak', 'zgw', '', '', 'http://host.docker.internal:8002/api/v1/schema/openapi.yaml', '', '', '', '');
+INSERT INTO zgw_consumers_service(id, uuid, label, api_type, api_root, client_id, secret, auth_type, header_key, header_value, oas, nlx, user_id, user_representation, oas_file, timeout, api_connection_check_path, slug) VALUES (1, uuid_generate_v4(), 'Open formulieren', 'nrc', 'http://host.docker.internal:8002/api/v1/', 'openzaak', 'openzaak', 'zgw', '', '', 'http://host.docker.internal:8002/api/v1/schema/openapi.yaml', '', '', '', '', 10, '', 'open-formulieren') ON CONFLICT (id) DO UPDATE SET api_root = EXCLUDED.api_root, client_id = EXCLUDED.client_id, secret = EXCLUDED.secret;
 SELECT setval(pg_get_serial_sequence('zgw_consumers_service', 'id'), 1, true);
 
 INSERT INTO zaken_zaakidentificatie(id, identificatie, bronorganisatie) VALUES (1, 'ZAAK-2024-0000000001', '000000000');
 SELECT setval(pg_get_serial_sequence('zaken_zaakidentificatie', 'id'), 1, true);
-INSERT INTO zaken_zaak(id, uuid, identificatie, bronorganisatie, omschrijving, toelichting, registratiedatum, verantwoordelijke_organisatie, startdatum, producten_of_diensten, communicatiekanaal, vertrouwelijkheidaanduiding, betalingsindicatie, verlenging_reden, opschorting_indicatie, opschorting_reden, selectielijstklasse, archiefstatus, _zaaktype_id, hoofdzaak_id, _etag, opdrachtgevende_organisatie, identificatie_ptr_id, processobject_datumkenmerk, processobject_identificatie, processobject_objecttype, processobject_registratie, processobjectaard) values (1, uuid_generate_v4(), 'ZAAK-2021-0000000001', '051845623', '', '', now(), '051845623', now(), '{}', '', 'openbaar', '', '', false, '', '', 'nog_te_archiveren', 1, 1, '_etag', '051845623', 1, '', '', '', '', '');
+INSERT INTO zaken_zaak(id, uuid, identificatie, bronorganisatie, omschrijving, toelichting, registratiedatum, verantwoordelijke_organisatie, startdatum, producten_of_diensten, communicatiekanaal, vertrouwelijkheidaanduiding, betalingsindicatie, verlenging_reden, opschorting_indicatie, opschorting_reden, selectielijstklasse, archiefstatus, _zaaktype_id, hoofdzaak_id, _etag, opdrachtgevende_organisatie, identificatie_ptr_id, processobject_datumkenmerk, processobject_identificatie, processobject_objecttype, processobject_registratie, processobjectaard, created_on, communicatiekanaal_naam) values (1, uuid_generate_v4(), 'ZAAK-2021-0000000001', '051845623', '', '', now(), '051845623', now(), '{}', '', 'openbaar', '', '', false, '', '', 'nog_te_archiveren', 1, 1, '_etag', '051845623', 1, '', '', '', '', '', now(), '');
 SELECT setval(pg_get_serial_sequence('zaken_zaak', 'id'), 1, true);
 INSERT INTO zaken_rol(id, uuid, betrokkene, betrokkene_type, omschrijving, omschrijving_generiek, roltoelichting, registratiedatum, indicatie_machtiging, _roltype_id, zaak_id, _etag, afwijkende_naam_betrokkene, contactpersoon_rol_emailadres, contactpersoon_rol_functie, contactpersoon_rol_naam, contactpersoon_rol_telefoonnummer) VALUES (1, uuid_generate_v4(), '', 'natuurlijk_persoon', 'Aanvrager', 'initiator', 'Test rol', now(), 'gemachtigde', 1, 1, '_etag', '', '', '', '', '');
 SELECT setval(pg_get_serial_sequence('zaken_rol', 'id'), 1, true);

--- a/backend/app/gzac/imports/open-zaak/database/fill-data-on-startup.sh
+++ b/backend/app/gzac/imports/open-zaak/database/fill-data-on-startup.sh
@@ -5,7 +5,7 @@ useradd openzaak
 while true
 do
     verifier=$(psql -U openzaak -d openzaak -t -A -c "select count(id) from accounts_user where username = 'admin'")
-    if [ "1" = $verifier ]
+    if [ "1" = "$verifier" ]
         then
             echo "Running database setup scripts"
             for file in /docker-entrypoint-initdb.d/database/*.sql


### PR DESCRIPTION
In response to: https://ritensebv.slack.com/archives/C1ZHMQGF7/p1770392096656029

https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/209

How to test:

- Run docker compose up on next-minor, Find errors in the logs of gzac-docker-compose-open-notificaties-database and gzac-docker-compose-openzaak-database
- Clean docker images, run docker compose up on this branch, check if there's no errors in logs
- Verify application booted up and is running normally