### PR TITLE
Allow access to Spring Actuator readiness and liveness health endpoints when details are omitted

### DIFF
--- a/backend/app/gzac/src/main/resources/config/application.yml
+++ b/backend/app/gzac/src/main/resources/config/application.yml
@@ -9,6 +9,9 @@ management:
             show-details: when_authorized
             roles:
                 - ROLE_ACTUATOR
+            probes:
+                enabled: true
+
 spring:
     application:
         name: gzac

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -223,3 +223,37 @@ tasks.withType(PublishToMavenRepository) {
 tasks.withType(PublishToMavenLocal) {
     enabled = false
 }
+
+tasks.register("cleanAll") {
+    group = "build"
+    description = "Runs all `clean` tasks across subprojects."
+
+    dependsOn subprojects.collect { subproject ->
+        subproject.tasks.matching { it.name == "clean" }
+    }
+}
+
+[
+    "test",
+    "integrationTesting",
+    "integrationTestingPostgresql",
+    "integrationTestingMysql",
+    "securityTesting"
+].each { taskName ->
+    tasks.register("${taskName}All", Test) {
+        def matchingSubprojects = subprojects.findAll { subproject ->
+            subproject.tasks.findByName(taskName)
+        }
+
+        def groupName = matchingSubprojects.collect {
+            it.tasks.findByName(taskName)?.group
+        }.find { it } ?: "other"
+
+        group = groupName
+        description = "Runs all `${taskName}` tasks across subprojects."
+
+        dependsOn subprojects.collect { subproject ->
+            subproject.tasks.matching { it.name == taskName }
+        }
+    }
+}

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorSecurityFilterChainFactory.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorSecurityFilterChainFactory.kt
@@ -67,7 +67,7 @@ class ActuatorSecurityFilterChainFactory {
                             healthEndpointProperties.roles.contains(ACTUATOR)
                         )
                 )) {
-                    it.requestMatchers(getHealthMatcher(webEndpointProperties.basePath)).permitAll()
+                    it.requestMatchers(*getPublicMatchers(webEndpointProperties.basePath)).permitAll()
                 }
                 it.requestMatchers(*matchers).hasAuthority(ACTUATOR)
             }
@@ -111,7 +111,7 @@ class ActuatorSecurityFilterChainFactory {
         antMatcher(GET, actuatorPath),
         antMatcher(GET, "${actuatorPath}/configprops"),
         antMatcher(GET, "${actuatorPath}/env"),
-        getHealthMatcher(actuatorPath),
+        *getPublicMatchers(actuatorPath),
         antMatcher(GET, "${actuatorPath}/health/liveness"),
         antMatcher(GET, "${actuatorPath}/health/readiness"),
         antMatcher(GET, "${actuatorPath}/mappings"),
@@ -121,8 +121,12 @@ class ActuatorSecurityFilterChainFactory {
         antMatcher(GET, "${actuatorPath}/info"),
     )
 
-    private fun getHealthMatcher(actuatorPath: String) =
-        antMatcher(GET, "${actuatorPath}/health")
+    private fun getPublicMatchers(actuatorPath: String) = arrayOf(
+        antMatcher(GET, actuatorPath),
+        antMatcher(GET, "${actuatorPath}/health"),
+        antMatcher(GET, "${actuatorPath}/health/liveness"),
+        antMatcher(GET, "${actuatorPath}/health/readiness"),
+    )
 
     companion object {
         const val ACTUATOR_REALM = "Actuator realm"

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/ActuatorSecurityIntTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/ActuatorSecurityIntTest.kt
@@ -31,6 +31,8 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import java.util.Base64
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 @TestPropertySource(properties = ["management.port=0"])
 class ActuatorSecurityIntTest : SecuritySpecificEndpointIntegrationTest() {
@@ -48,6 +50,20 @@ class ActuatorSecurityIntTest : SecuritySpecificEndpointIntegrationTest() {
         assertThat(pingStatus).isEqualTo("UP")
     }
 
+    @ParameterizedTest
+    @CsvSource("/actuator/health/readiness", "/actuator/health/liveness")
+    fun `actuator user should have full access to health probe endpoints`(path: String) {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, path)
+            .init()
+            .withBasicTestUser()
+
+        val response = mockMvc.perform(request).andReturn().response
+        assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+
+        val status = read<Any>(response.contentAsString, "$.status")
+        assertThat(status).isEqualTo("UP")
+    }
+
     @Test
     @WithMockUser(authorities = [AuthoritiesConstants.USER])
     fun `authenticated user should have access to health endpoint without details`() {
@@ -62,9 +78,38 @@ class ActuatorSecurityIntTest : SecuritySpecificEndpointIntegrationTest() {
         }
     }
 
+    @ParameterizedTest
+    @CsvSource("/actuator/health/readiness", "/actuator/health/liveness")
+    @WithMockUser(authorities = [AuthoritiesConstants.USER])
+    fun `authenticated user should have access to health probe endpoints without details`(path: String) {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, path)
+            .init()
+
+        val response = mockMvc.perform(request).andReturn().response
+        assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+
+        assertThrows<PathNotFoundException> {
+            read<Map<String, Any>>(response.contentAsString, "$.components")
+        }
+    }
+
     @Test
     fun `unauthenticated user should have access to health endpoint without details`() {
         val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health")
+            .init()
+
+        val response = mockMvc.perform(request).andReturn().response
+        assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+
+        assertThrows<PathNotFoundException> {
+            read<Map<String, Any>>(response.contentAsString, "$.components")
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource("/actuator/health/readiness", "/actuator/health/liveness")
+    fun `unauthenticated user should have access to health probe endpoints without details`(path: String) {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, path)
             .init()
 
         val response = mockMvc.perform(request).andReturn().response

--- a/backend/core/src/test/resources/config/application.yml
+++ b/backend/core/src/test/resources/config/application.yml
@@ -78,3 +78,5 @@ management:
             show-details: when_authorized
             roles:
                 - ROLE_ACTUATOR
+            probes:
+                enabled: true

--- a/documentation/release-notes/12.x.x/12.25.0/README.md
+++ b/documentation/release-notes/12.x.x/12.25.0/README.md
@@ -8,9 +8,10 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Allow access to Spring Actuator readiness and liveness health endpoints when details are omitted**
 
-  New enhancement explanation.
+  This behaviour, previously limited to `/{base-path}/health`, now also applies to `/{base-path}/health/readiness` and `/{base-path}/health/liveness`. (In Valtimo, `base-path` is usually set to `/management`).
+  These endpoints can be used by cloud services to determine whether the application has started successfully and is ready to receive traffic.
 
 ## Bugfixes
 


### PR DESCRIPTION
Allow access to Spring Actuator readiness and liveness health endpoints when details are omitted (making it work the same as the /health endpoint itself).

Same as PR #347, but now for V12.

Issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/445

Created a new issue for V12: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/207

Also copied some of the Gralde tasks from V13 to V12.