### PR TITLE
strip /api from Formio.apiUrl

### DIFF
--- a/documentation/release-notes/13.x.x/13.17.0/README.md
+++ b/documentation/release-notes/13.x.x/13.17.0/README.md
@@ -1,0 +1,11 @@
+# 13.17.0
+
+{% hint style="info" %}
+**Release date 25-02-2026**
+{% endhint %}
+
+## Bugfixes
+
+* **Fix Formio Data Source URL**
+
+  The Formio Data Source URL now no longer contains an additional `/api`. 

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io/form-io.component.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io/form-io.component.ts
@@ -161,11 +161,9 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   public ngOnInit(): void {
-    if (!Formio.projectUrlSet) {
-      Formio.setBaseUrl(location.origin);
-      Formio.setProjectUrl(location.origin);
-      Formio.authUrl = location.origin;
-    }
+    Formio.setBaseUrl(location.origin);
+    Formio.setProjectUrl(location.origin);
+    Formio.authUrl = location.origin;
 
     this.openRouteSubscription();
     this.errors$.next([]);

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/form-io.module.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/form-io.module.ts
@@ -29,7 +29,6 @@ import {FileSizeModule} from '../file-size/file-size.module';
 import {ResourceModule} from '@valtimo/resource';
 import {RouterModule} from '@angular/router';
 import {FormIoCurrentUserComponent} from './components/form-io-current-user/form-io-current-user.component';
-import {ConfigService} from '@valtimo/shared';
 import {FormIoIbanComponent} from './components/form-io-iban/iban.component';
 import {ReactiveFormsModule} from '@angular/forms';
 import {FormioValueResolverSelectorComponent} from './components/formio-value-resolver-selector/formio-value-resolver-selector.component';
@@ -73,8 +72,7 @@ import {FormIoCurrencyComponent} from './components/form-io-currency/currency.co
     FormIoDomService,
     {
       provide: FormioAppConfig,
-      deps: [ConfigService],
-      useFactory: (configService: ConfigService) => getFormioAppConfig(configService.config),
+      useFactory: () => getFormioAppConfig(),
     },
   ],
 })

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/formio-config.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/formio-config.ts
@@ -14,17 +14,10 @@
  * limitations under the License.
  */
 
-import {UrlUtils, ValtimoConfig} from '@valtimo/shared';
-
-const getFormioAppConfig = (config: ValtimoConfig) => {
-  const baseUrl = UrlUtils.formatUrlTrailingSlash(
-    `${window.location.origin}${config.valtimoApi.endpointUri}`,
-    false
-  );
-
+const getFormioAppConfig = () => {
   return {
-    appUrl: baseUrl,
-    apiUrl: baseUrl,
+    appUrl: window.location.origin,
+    apiUrl: window.location.origin,
     icons: 'fontawesome',
     formOnly: false,
   };


### PR DESCRIPTION
- issue:
<img width="665" height="282" alt="image" src="https://github.com/user-attachments/assets/79e97a94-9957-47bd-98a6-7aa54e63521d" />


- Related to [Formio Builder crashes browser](https://github.com/valtimo-platform/valtimo/pull/327)