### PR TITLE
v12.x add pluginConfiguration title on configuring process link with …

### DIFF
--- a/backend/gradle/dockerComposeGzac.gradle
+++ b/backend/gradle/dockerComposeGzac.gradle
@@ -45,7 +45,7 @@ composeUp {
 }
 
 dockerCompose {
-    projectName = "gzac-docker-compose"
+    projectName = "gzac-docker-compose-v12"
     useComposeFiles.addAll(buildDir.absolutePath + "/docker/extract/gzac-docker-compose-main/docker-compose.yaml")
     composeAdditionalArgs = ["--profile", "zgw"]
     stopContainers = false

--- a/frontend/projects/valtimo/config/assets/core/en.json
+++ b/frontend/projects/valtimo/config/assets/core/en.json
@@ -1877,6 +1877,7 @@
   "processLinkConfiguration": {
     "configureStep": "Configure process step",
     "modalTitle": "Process step: {{processStepName}}",
+    "pluginConfiguration": "Plugin configuration: {{pluginConfigTitle}}",
     "chooseProcessLinkTypeDescription": "A process step can perform a variety of actions. Choose below to what type of action you would like to link this step.",
     "chooseFormDescription": "Choose the form that you want to link to the process step.",
     "chooseFormFlowDescription": "Choose the FormFlow that you want to link to the process step.",

--- a/frontend/projects/valtimo/config/assets/core/nl.json
+++ b/frontend/projects/valtimo/config/assets/core/nl.json
@@ -1878,6 +1878,7 @@
   "processLinkConfiguration": {
     "configureStep": "Processtap configureren",
     "modalTitle": "Processtap: {{processStepName}}",
+    "pluginConfiguration": "Plugin configuratie: {{pluginConfigTitle}}",
     "chooseProcessLinkTypeDescription": "Een processtap kan verschillende acties uitvoeren. Kies hieronder aan welk type actie je deze stap wilt koppelen.",
     "chooseFormDescription": "Kies hier het formulier dat je aan de processtap wilt koppelen.",
     "chooseFormFlowDescription": "Kies hier de FormFlow die je aan de processtap wilt koppelen.",

--- a/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.html
+++ b/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.html
@@ -20,6 +20,7 @@
     showModal: showModal$ | async,
     processStepName: processStepName$ | async,
     steps: steps$ | async,
+    selectedPluginConfiguration: selectedPluginConfiguration$ | async,
     currentStepIndex: currentStepIndex$ | async,
     currentStepId: currentStepId$ | async,
     showSaveButton: showSaveButton$ | async,
@@ -30,6 +31,7 @@
     saving: saving$ | async,
     hideProgressIndicator: hideProgressIndicator$ | async,
     typeOfSelectedProgressLink: typeOfSelectedProcessLink$ | async,
+
   } as obs"
 >
   <cds-modal valtimoCdsModal [open]="obs.showModal" size="lg">
@@ -38,10 +40,16 @@
       <h3 cdsModalHeaderHeading>
         {{
           'processLinkConfiguration.modalTitle'
-            | translate: {processStepName: obs.processStepName || '-'}
+                  | translate: {processStepName: obs.processStepName || '-'}
         }}
       </h3>
-      <div class="process-link-progress" *ngIf="!obs.typeOfSelectedProgressLink">
+      <h4 cdsModalHeaderLabel *ngIf="obs.typeOfSelectedProgressLink === 'plugin'">
+        {{
+          'processLinkConfiguration.pluginConfiguration'
+                  | translate: {pluginConfigTitle: obs.selectedPluginConfiguration?.title || '-'}
+        }}
+      </h4>
+      <div class="process-link-progress">
         <ng-container *ngTemplateOutlet="progressIndicator; context: {obs: obs}"></ng-container>
       </div>
     </cds-modal-header>

--- a/frontend/projects/valtimo/process-link/src/lib/services/plugin-state.service.ts
+++ b/frontend/projects/valtimo/process-link/src/lib/services/plugin-state.service.ts
@@ -16,7 +16,7 @@
 
 import {Injectable} from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, of, Subject, switchMap} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {map, take} from 'rxjs/operators';
 import {
   PluginConfiguration,
   PluginDefinition,
@@ -109,6 +109,70 @@ export class PluginStateService {
 
   selectProcessLink(processLink: ProcessLink): void {
     this._selectedProcessLink$.next(processLink);
+
+    // When editing a plugin process link, populate the plugin definition
+    if (processLink?.processLinkType === 'plugin') {
+      this.loadPluginDefinitionForProcessLink(processLink);
+    }
+  }
+
+  private loadPluginDefinitionForProcessLink(processLink: ProcessLink): void {
+    // Get the plugin definition key - either directly or from plugin specifications
+    this.getPluginDefinitionKeyForProcessLink(processLink)
+      .pipe(take(1))
+      .subscribe(pluginDefinitionKey => {
+        if (pluginDefinitionKey) {
+          // Fetch all plugin definitions and find the one matching the key
+          this.pluginManagementService
+            .getPluginDefinitions()
+            .pipe(
+              take(1),
+              map(definitions => definitions.find(d => d.key === pluginDefinitionKey))
+            )
+            .subscribe(definition => {
+              if (definition) {
+                this._selectedPluginDefinition$.next(definition);
+
+                // Also set the selected function if available
+                if (processLink.pluginActionDefinitionKey) {
+                  this._selectedPluginFunction$.next({
+                    key: processLink.pluginActionDefinitionKey,
+                  } as PluginFunction);
+                }
+              }
+            });
+        }
+      });
+
+    // Load and set the plugin configuration if available
+    if (processLink.pluginConfigurationId) {
+      this.pluginManagementService
+        .getAllPluginConfigurations()
+        .pipe(
+          take(1),
+          map(configs =>
+            configs.find(c => c.id === processLink.pluginConfigurationId))
+        )
+        .subscribe(configuration => {
+          if (configuration) {
+            this._selectedPluginConfiguration$.next(configuration);
+          }
+        });
+    }
+  }
+
+  private getPluginDefinitionKeyForProcessLink(processLink: ProcessLink): Observable<string> {
+    return this.pluginService.pluginSpecifications$.pipe(
+      map(pluginSpecifications => {
+        const pluginSpecification = pluginSpecifications.find(specification => {
+          const functionKeys =
+            specification?.functionConfigurationComponents &&
+            Object.keys(specification.functionConfigurationComponents);
+          return functionKeys?.includes(processLink.pluginActionDefinitionKey);
+        });
+        return pluginSpecification?.pluginId;
+      })
+    );
   }
 
   deselectProcessLink(): void {


### PR DESCRIPTION
### Describe the changes
See issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/210
original issue https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/587

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
Really small issue. Big help though.

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [V] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [] Release notes have been written for these changes. TODO after merging PR. Is really small change.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [V] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [V] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [V] Not applicable

Describe the testing steps
- [ ] Step 1 configure process link for a plugin
- [ ] Step 2 check plugin configuration title in process-link modal

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [V] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [V] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [V] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [V] Not applicable
