### PR TITLE
UI improvements

### DIFF
--- a/frontend/projects/valtimo/access-control-management/src/lib/components/export-role-modal/export-role-modal.component.html
+++ b/frontend/projects/valtimo/access-control-management/src/lib/components/export-role-modal/export-role-modal.component.html
@@ -46,7 +46,7 @@
   </section>
 
   <cds-modal-footer>
-    <button [disabled]="disabled" cdsButton="ghost" (click)="onCancel()">
+    <button [disabled]="disabled" cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/access-control-management/src/lib/components/role-metadata-modal/role-metadata-modal.component.html
+++ b/frontend/projects/valtimo/access-control-management/src/lib/components/role-metadata-modal/role-metadata-modal.component.html
@@ -51,7 +51,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCancel()">
+    <button cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/building-block-management/src/lib/components/building-block-management-create-modal/building-block-management-create-modal.component.html
+++ b/frontend/projects/valtimo/building-block-management/src/lib/components/building-block-management-create-modal/building-block-management-create-modal.component.html
@@ -117,7 +117,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCloseModal()">
+    <button cdsButton="secondary" (click)="onCloseModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/building-block-management/src/lib/components/building-block-management-detail-actions/building-block-management-detail-actions.component.html
+++ b/frontend/projects/valtimo/building-block-management/src/lib/components/building-block-management-detail-actions/building-block-management-detail-actions.component.html
@@ -111,7 +111,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="closeDraftModal()">
+    <button cdsButton="secondary" (click)="closeDraftModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/building-block-management/src/lib/components/building-block-management-process-upload/building-block-management-process-upload.component.html
+++ b/frontend/projects/valtimo/building-block-management/src/lib/components/building-block-management-process-upload/building-block-management-process-upload.component.html
@@ -33,7 +33,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="closeModal()">
+    <button cdsButton="secondary" (click)="closeModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/building-block-management/src/public-api.ts
+++ b/frontend/projects/valtimo/building-block-management/src/public-api.ts
@@ -18,5 +18,5 @@
  * Public API Surface of building-block-management
  */
 
-export * from './lib/building-block-management.module'
+export * from './lib/building-block-management.module';
 export * from './lib/services';

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-create-draft-version/case-management-create-draft-version.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-create-draft-version/case-management-create-draft-version.component.html
@@ -114,7 +114,7 @@
   </div>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCloseModal()">
+    <button cdsButton="secondary" (click)="onCloseModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-create-draft-version/case-management-create-draft-version.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-create-draft-version/case-management-create-draft-version.component.html
@@ -31,7 +31,7 @@
     </h3>
   </cds-modal-header>
 
-  <div cdsModalContent>
+  <div cdsModalContent [cdsLayer]="1">
     <p class="valtimo-definition-create__description">{{ obs.createDraftDescription }}</p>
 
     <form [formGroup]="draftVersionForm" class="valtimo-definition-create__content">

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-create/case-management-create.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-create/case-management-create.component.html
@@ -36,6 +36,7 @@
   <form
     [formGroup]="formGroup"
     cdsModalContent
+    [cdsLayer]="1"
     class="valtimo-definition-create__content"
   >
     <cds-label>

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-create/case-management-create.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-create/case-management-create.component.html
@@ -33,7 +33,11 @@
     </h3>
   </cds-modal-header>
 
-  <form [formGroup]="formGroup" cdsModalContent class="valtimo-definition-create__content">
+  <form
+    [formGroup]="formGroup"
+    cdsModalContent
+    class="valtimo-definition-create__content"
+  >
     <cds-label>
       {{ 'caseManagement.createDefinition.name' | translate }}
 
@@ -133,7 +137,7 @@
   </form>
 
   <cds-modal-footer>
-    <button data-test-id="caseCreateCloseButton" cdsButton="ghost" (click)="onCloseModal()">
+    <button data-test-id="caseCreateCloseButton" cdsButton="secondary" (click)="onCloseModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-statuses/case-management-status-modal/case-management-status-modal.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-statuses/case-management-status-modal/case-management-status-modal.component.html
@@ -151,7 +151,7 @@
 </ng-template>
 
 <ng-template #buttons let-obs="obs">
-  <button cdsButton="secondary" data-test-id="caseStatusCancelButton" (click)="onClose()" [disabled]="obs.disabled">
+  <button cdsButton="ghost" data-test-id="caseStatusCancelButton" (click)="onClose()" [disabled]="obs.disabled">
     {{ 'interface.cancel' | translate }}
   </button>
 

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tabs/case-management-edit-tab-modal/case-management-edit-tab-modal.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tabs/case-management-edit-tab-modal/case-management-edit-tab-modal.component.html
@@ -24,7 +24,11 @@
     </h3>
   </cds-modal-header>
 
-  <section [formGroup]="form" cdsModalContent>
+  <section
+    [formGroup]="form"
+    cdsModalContent
+    [cdsLayer]="1"
+  >
     <valtimo-tab-form
       [configuredContentKeys]="configuredKeysForEdit"
       [tabType]="tab?.type"

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tabs/widget-tab/case-management-widget-tab-edit-modal/case-management-widget-tab-edit-modal.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tabs/widget-tab/case-management-widget-tab-edit-modal/case-management-widget-tab-edit-modal.html
@@ -27,7 +27,7 @@
     <h3 cdsModalHeaderHeading>{{ 'widgetTabManagement.tab.editWidgetTab' | translate }}</h3>
   </cds-modal-header>
 
-  <section cdsModalContent>
+  <section cdsModalContent [cdsLayer]="1">
     <ng-container *ngTemplateOutlet="editWidgetTabFormTemplate;context:{obs: obs}"></ng-container>
   </section>
 

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tabs/widget-tab/case-management-widget-tab-edit-modal/case-management-widget-tab-edit-modal.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tabs/widget-tab/case-management-widget-tab-edit-modal/case-management-widget-tab-edit-modal.html
@@ -53,7 +53,7 @@
 </ng-template>
 
 <ng-template #editWidgetTabButtons let-obs="obs">
-  <button cdsButton="ghost" [disabled]="obs.disabled" (click)="closeModal()">
+  <button cdsButton="secondary" [disabled]="obs.disabled" (click)="closeModal()">
     {{ 'widgetTabManagement.tab.cancel' | translate }}
   </button>
 

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tags/case-management-tags-modal/case-management-tags-modal.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-tags/case-management-tags-modal/case-management-tags-modal.component.html
@@ -87,7 +87,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="secondary" data-test-id="caseTagCancelButton" (click)="close()" [disabled]="obs.disabled">
+    <button cdsButton="ghost" data-test-id="caseTagCancelButton" (click)="close()" [disabled]="obs.disabled">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-upload/case-management-upload.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-upload/case-management-upload.component.html
@@ -40,7 +40,12 @@
     </h3>
   </cds-modal-header>
 
-  <section [ngSwitch]="obs.activeStep" cdsModalContent class="valtimo-definition-uploader__content">
+  <section
+    [ngSwitch]="obs.activeStep"
+    [cdsLayer]="1"
+    cdsModalContent
+    class="valtimo-definition-uploader__content"
+  >
     <ng-template ngSwitchDefault>
       <valtimo-case-management-upload-step
         [message]="

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-upload/case-management-upload.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-upload/case-management-upload.component.html
@@ -41,7 +41,7 @@
   </cds-modal-header>
 
   <section [ngSwitch]="obs.activeStep" cdsModalContent class="valtimo-definition-uploader__content">
-  <ng-template ngSwitchDefault>
+    <ng-template ngSwitchDefault>
       <valtimo-case-management-upload-step
         [message]="
           'caseManagement.importDefinition.steps.' + obs.activeStep + '.message' | translate

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-upload/case-management-upload.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-upload/case-management-upload.component.html
@@ -41,7 +41,7 @@
   </cds-modal-header>
 
   <section [ngSwitch]="obs.activeStep" cdsModalContent class="valtimo-definition-uploader__content">
-    <ng-template ngSwitchDefault>
+  <ng-template ngSwitchDefault>
       <valtimo-case-management-upload-step
         [message]="
           'caseManagement.importDefinition.steps.' + obs.activeStep + '.message' | translate

--- a/frontend/projects/valtimo/components/assets/css/color.scss
+++ b/frontend/projects/valtimo/components/assets/css/color.scss
@@ -15,14 +15,14 @@
  */
 
 :root {
-  --vcds-color-100: #12051b; /* Deep purple black */
-  --vcds-color-90: #30123c; /* Very dark violet */
-  --vcds-color-80: #4c2362; /* Dark royal purple */
-  --vcds-color-70: #683589; /* Strong purple */
-  --vcds-color-60: #8546b0; /* Medium bright purple */
-  --vcds-color-50: #a368c0; /* Mid-lavender */
-  --vcds-color-40: #bf8cd0; /* Light lavender */
-  --vcds-color-30: #d4aee0; /* Pale lilac */
-  --vcds-color-20: #e8cfef; /* Light pastel violet */
-  --vcds-color-10: #f7effb; /* Almost white with purple tint */
+  --vcds-color-100: #002547;
+  --vcds-color-90: #002c54;
+  --vcds-color-80: #003361;
+  --vcds-color-70: #286198;
+  --vcds-color-60: #2b79bd;
+  --vcds-color-50: #61aedf;
+  --vcds-color-40: #8acff2;
+  --vcds-color-30: #aadcf6;
+  --vcds-color-20: #c9e9f9;
+  --vcds-color-10: #e9f6fd;
 }

--- a/frontend/projects/valtimo/components/assets/css/compatibility.scss
+++ b/frontend/projects/valtimo/components/assets/css/compatibility.scss
@@ -182,6 +182,11 @@ valtimo-modal {
 }
 
 .case-detail-overflow {
+  .cds--btn--primary .cds--btn__icon,
+  .cds--btn--primary .cds--btn__icon path {
+    fill: currentColor !important;
+  }
+
   &.--compact {
     button {
       min-block-size: 32px !important;

--- a/frontend/projects/valtimo/decision/src/lib/decision-deploy/decision-deploy.component.html
+++ b/frontend/projects/valtimo/decision/src/lib/decision-deploy/decision-deploy.component.html
@@ -33,7 +33,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="closeModal()">
+    <button cdsButton="secondary" (click)="closeModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/form-flow-management/src/lib/components/new-form-flow-modal/new-form-flow-modal.component.html
+++ b/frontend/projects/valtimo/form-flow-management/src/lib/components/new-form-flow-modal/new-form-flow-modal.component.html
@@ -44,7 +44,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCancel()">
+    <button cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/form-management/src/lib/components/form-management-create/form-management-create.component.html
+++ b/frontend/projects/valtimo/form-management/src/lib/components/form-management-create/form-management-create.component.html
@@ -51,12 +51,8 @@
     </section>
 
     <cds-modal-footer [cdsLayer]="1">
-      <button cdsButton="secondary" type="button" (click)="onBackButtonClick()">
-        {{ 'formManagement.back' | translate }}
-      </button>
-
-      <button cdsButton="ghost" type="button" (click)="reset()">
-        {{ 'formManagement.reset' | translate }}
+      <button cdsButton="secondary" (click)="$event.preventDefault(); onBackButtonClick()">
+        {{ 'interface.cancel' | translate }}
       </button>
 
       <button cdsButton="primary" type="submit" [disabled]="form?.invalid">

--- a/frontend/projects/valtimo/form-management/src/lib/components/form-management-create/form-management-create.component.html
+++ b/frontend/projects/valtimo/form-management/src/lib/components/form-management-create/form-management-create.component.html
@@ -51,7 +51,7 @@
     </section>
 
     <cds-modal-footer [cdsLayer]="1">
-      <button cdsButton="ghost" type="button" (click)="onBackButtonClick()">
+      <button cdsButton="secondary" type="button" (click)="onBackButtonClick()">
         {{ 'formManagement.back' | translate }}
       </button>
 

--- a/frontend/projects/valtimo/form-management/src/lib/components/form-management-upload/form-management-upload.component.html
+++ b/frontend/projects/valtimo/form-management/src/lib/components/form-management-upload/form-management-upload.component.html
@@ -33,7 +33,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="closeModal()">
+    <button cdsButton="secondary" (click)="closeModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-management-api/repository-modal/iko-management-repository-modal.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-management-api/repository-modal/iko-management-repository-modal.component.html
@@ -59,7 +59,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCancel()">
+    <button cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/list-modal/list-modal.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/list-modal/list-modal.component.html
@@ -131,7 +131,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="closeModal()">
+    <button cdsButton="secondary" (click)="closeModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/search-actions/search-action-modal/search-action-modal.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/search-actions/search-action-modal/search-action-modal.component.html
@@ -59,7 +59,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCancel()">
+    <button cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/search-fields/search-field-modal/search-field-modal.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/search-fields/search-field-modal/search-field-modal.component.html
@@ -190,7 +190,7 @@
   </form>
 
   <cds-modal-footer>
-    <button data-testid="-search-cancel" cdsButton="ghost" (click)="onCancel()">
+    <button data-testid="-search-cancel" cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/tab-detail-modal/iko-management-tab-details-modal.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-management-details/components/tab-detail-modal/iko-management-tab-details-modal.component.html
@@ -68,7 +68,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="closeModal()">
+    <button cdsButton="secondary" (click)="closeModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-management/view-modal/iko-management-view-modal.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-management/view-modal/iko-management-view-modal.component.html
@@ -51,7 +51,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCancel()">
+    <button cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-search/iko-search.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-search/iko-search.component.html
@@ -49,7 +49,6 @@
                     [defaultValue]="formValues[field.key]"
                     (valueChange)="singleValueChange(field.key, $event, field.dataType)"
                   ></v-input>
-
                 } @else if (field.dataType === 'text' && field.fieldType === 'range') {
                   <v-form
                     className="multiple-search-fields"
@@ -69,8 +68,7 @@
                       [placeholder]="'searchFields.textPlaceholder' | translate"
                     ></v-input>
                   </v-form>
-                }
-                @else if (field.dataType === 'text' && (field.fieldType === 'single-select-dropdown' || field.fieldType === 'single_select_dropdown')) {
+                } @else if (field.dataType === 'text' && (field.fieldType === 'single-select-dropdown' || field.fieldType === 'single_select_dropdown')) {
                   <v-select
                     *ngIf="dropdownSelectItemsMap[field.key]"
                     [items]="dropdownSelectItemsMap[field.key]"
@@ -81,8 +79,7 @@
                     (selectedChange)="singleValueChange(field.key, $event, field.dataType)"
                     [appendInline]="false"
                   ></v-select>
-                }
-                @else if (field.dataType === 'text' && (field.fieldType === 'multi-select-dropdown' || field.fieldType === 'multi_select_dropdown')) {
+                } @else if (field.dataType === 'text' && (field.fieldType === 'multi-select-dropdown' || field.fieldType === 'multi_select_dropdown')) {
                   <v-select
                     *ngIf="dropdownSelectItemsMap[field.key]"
                     [items]="dropdownSelectItemsMap[field.key]"
@@ -94,8 +91,7 @@
                     (selectedChange)="multipleValueChange(field.key, $event, field.dataType)"
                     [appendInline]="false"
                   ></v-select>
-                }
-                @else if (field.dataType === 'number' && field.fieldType === 'single') {
+                } @else if (field.dataType === 'number' && field.fieldType === 'single') {
                   <v-input
                     type="number"
                     [hideNumberSpinBox]="true"
@@ -124,16 +120,13 @@
                       [placeholder]="'searchFields.numberPlaceholder' | translate"
                     ></v-input>
                   </v-form>
-                }
-                @else if (field.dataType === 'boolean' && field.fieldType === 'single') {
+                } @else if (field.dataType === 'boolean' && field.fieldType === 'single') {
                   <v-select
                     *ngIf="booleanItems$ | async as booleanItems"
                     [items]="booleanItems"
                     (selectedChange)="singleValueChange(field.key, $event, field.dataType)"
                   ></v-select>
-                }
-
-                @else if (field.dataType === 'time' && field.fieldType === 'single') {
+                } @else if (field.dataType === 'time' && field.fieldType === 'single') {
                   <cds-timepicker
                     [placeholder]="'searchFields.timePlaceholder' | translate"
                     [ngModel]="formValues[field.key]"
@@ -153,8 +146,7 @@
 
                     <cds-timepicker [(ngModel)]="formValues[field.key + '_end']"></cds-timepicker>
                   </v-form>
-                }
-                @else if (field.dataType === 'date' && field.fieldType === 'single') {
+                } @else if (field.dataType === 'date' && field.fieldType === 'single') {
                   <valtimo-date-time-picker
                     [defaultDate]="formValues[field.key] ?? ''"
                     [enableTime]="false"
@@ -183,8 +175,7 @@
                       [showFieldLabel]="false"
                     ></valtimo-date-time-picker>
                   </v-form>
-                }
-                @else if (field.dataType === 'datetime' && field.fieldType === 'single') {
+                } @else if (field.dataType === 'datetime' && field.fieldType === 'single') {
                   <valtimo-date-time-picker
                     [enableTime]="true"
                     [showFieldLabel]="false"

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-divider-modal/widget-management-divider-modal.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-divider-modal/widget-management-divider-modal.component.html
@@ -50,7 +50,7 @@
   </form>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="onCloseModal()">
+    <button cdsButton="secondary" (click)="onCloseModal()">
       {{ 'caseManagement.allVersionsModal.closeButton' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/object/src/lib/components/object-detail-container/tabs/object-detail/object-detail.component.html
+++ b/frontend/projects/valtimo/object/src/lib/components/object-detail-container/tabs/object-detail/object-detail.component.html
@@ -92,7 +92,7 @@
   <cds-modal-footer>
     <ng-container>
       <button
-        cdsButton="secondary"
+        cdsButton="ghost"
         [attr.modal-primary-focus]="true"
         (click)="closeModal()"
         [disabled]="modalObs.disableInput"

--- a/frontend/projects/valtimo/object/src/lib/components/object-list/object-list.component.html
+++ b/frontend/projects/valtimo/object/src/lib/components/object-list/object-list.component.html
@@ -116,7 +116,7 @@
   <cds-modal-footer>
     <ng-container>
       <button
-        cdsButton="secondary"
+        cdsButton="ghost"
         [attr.modal-primary-focus]="true"
         (click)="closeModal()"
         [disabled]="modalObs.disableInput"

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-select/plugin-add-select.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-add-select/plugin-add-select.component.ts
@@ -50,7 +50,7 @@ export class PluginAddSelectComponent implements OnInit, OnDestroy {
     this.stateService.selectPluginDefinition(event.value);
   }
 
-  public  deselectPluginDefinition(): void {
+  public deselectPluginDefinition(): void {
     this.stateService.clearSelectedPluginDefinition();
   }
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/components/get-resultaattypen/get-resultaattypen-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/components/get-resultaattypen/get-resultaattypen-configuration.component.html
@@ -21,7 +21,7 @@
   } as obs"
 >
   <v-paragraph [margin]="true" [italic]="true">
-    {{ 'getResultaattypenInformation' | pluginTranslate: pluginId  | async }}
+    {{ 'getResultaattypenInformation' | pluginTranslate: pluginId | async }}
   </v-paragraph>
 
   <v-form (valueChange)="formValueChange($event)">

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/patch-zaaknotitie/patch-zaaknotitie-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/zaken-api/components/patch-zaaknotitie/patch-zaaknotitie-configuration.component.html
@@ -69,9 +69,9 @@
           />
         </div>
         <div class="col-1">
-            <button class="btn btn-space delete-button" (click)="removeProperty(property.name)">
-              <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
-            </button>
+          <button class="btn btn-space delete-button" (click)="removeProperty(property.name)">
+            <svg class="cds--btn__icon" cdsIcon="trash-can" size="16"></svg>
+          </button>
         </div>
       </div>
     }

--- a/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.html
+++ b/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.html
@@ -134,43 +134,39 @@
 
 <ng-template #footer let-obs="obs">
   <cds-modal-footer *ngIf="!obs.saving">
-    <div class="cancel-button">
-      <button cdsButton="ghost" (click)="closeModal()" [disabled]="obs.disabled">
-        {{ 'processLinkConfiguration.cancel' | translate }}
-      </button>
-    </div>
+    <button cdsButton="ghost" (click)="closeModal()" [disabled]="obs.disabled">
+      {{ 'processLinkConfiguration.cancel' | translate }}
+    </button>
     <div class="footer-spacer"></div>
-    <div class="action-buttons">
-      <button
-        cdsButton="danger--primary"
-        *ngIf="obs.isEditing"
-        (click)="unlinkButtonClick()"
-      >
-        {{ 'processLinkConfiguration.unlink' | translate }}
-      </button>
-      <button
-        *ngIf="obs.showBackButton && !obs.saving"
-        cdsButton="secondary"
-        (click)="backButtonClick()"
-      >
-        {{ 'processLinkConfiguration.back' | translate }}
-      </button>
-      <button
-        cdsButton="primary"
-        *ngIf="obs.showNextButton && !obs.saving"
-        [disabled]="!obs.enableNextButton"
-        (click)="nextButtonClick()"
-      >
-        {{ 'processLinkConfiguration.next' | translate }}
-      </button>
-      <button
-        cdsButton="primary"
-        *ngIf="obs.showSaveButton && !obs.saving"
-        [disabled]="!obs.enableSaveButton"
-        (click)="saveButtonClick()"
-      >
-        {{ 'processLinkConfiguration.complete' | translate }}
-      </button>
-    </div>
+    <button
+      cdsButton="danger--primary"
+      *ngIf="obs.isEditing"
+      (click)="unlinkButtonClick()"
+    >
+      {{ 'processLinkConfiguration.unlink' | translate }}
+    </button>
+    <button
+      *ngIf="obs.showBackButton && !obs.saving"
+      cdsButton="secondary"
+      (click)="backButtonClick()"
+    >
+      {{ 'processLinkConfiguration.back' | translate }}
+    </button>
+    <button
+      cdsButton="primary"
+      *ngIf="obs.showNextButton && !obs.saving"
+      [disabled]="!obs.enableNextButton"
+      (click)="nextButtonClick()"
+    >
+      {{ 'processLinkConfiguration.next' | translate }}
+    </button>
+    <button
+      cdsButton="primary"
+      *ngIf="obs.showSaveButton && !obs.saving"
+      [disabled]="!obs.enableSaveButton"
+      (click)="saveButtonClick()"
+    >
+      {{ 'processLinkConfiguration.complete' | translate }}
+    </button>
   </cds-modal-footer>
 </ng-template>

--- a/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.html
+++ b/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.html
@@ -134,39 +134,43 @@
 
 <ng-template #footer let-obs="obs">
   <cds-modal-footer *ngIf="!obs.saving">
-    <button cdsButton="ghost" (click)="closeModal()" [disabled]="obs.disabled">
-      {{ 'processLinkConfiguration.cancel' | translate }}
-    </button>
+    <div class="cancel-button">
+      <button cdsButton="ghost" (click)="closeModal()" [disabled]="obs.disabled">
+        {{ 'processLinkConfiguration.cancel' | translate }}
+      </button>
+    </div>
     <div class="footer-spacer"></div>
-    <button
-      cdsButton="danger--primary"
-      *ngIf="obs.isEditing"
-      (click)="unlinkButtonClick()"
-    >
-      {{ 'processLinkConfiguration.unlink' | translate }}
-    </button>
-    <button
-      *ngIf="obs.showBackButton && !obs.saving"
-      cdsButton="secondary"
-      (click)="backButtonClick()"
-    >
-      {{ 'processLinkConfiguration.back' | translate }}
-    </button>
-    <button
-      cdsButton="primary"
-      *ngIf="obs.showNextButton && !obs.saving"
-      [disabled]="!obs.enableNextButton"
-      (click)="nextButtonClick()"
-    >
-      {{ 'processLinkConfiguration.next' | translate }}
-    </button>
-    <button
-      cdsButton="primary"
-      *ngIf="obs.showSaveButton && !obs.saving"
-      [disabled]="!obs.enableSaveButton"
-      (click)="saveButtonClick()"
-    >
-      {{ 'processLinkConfiguration.complete' | translate }}
-    </button>
+    <div class="action-buttons">
+      <button
+        cdsButton="danger--primary"
+        *ngIf="obs.isEditing"
+        (click)="unlinkButtonClick()"
+      >
+        {{ 'processLinkConfiguration.unlink' | translate }}
+      </button>
+      <button
+        *ngIf="obs.showBackButton && !obs.saving"
+        cdsButton="secondary"
+        (click)="backButtonClick()"
+      >
+        {{ 'processLinkConfiguration.back' | translate }}
+      </button>
+      <button
+        cdsButton="primary"
+        *ngIf="obs.showNextButton && !obs.saving"
+        [disabled]="!obs.enableNextButton"
+        (click)="nextButtonClick()"
+      >
+        {{ 'processLinkConfiguration.next' | translate }}
+      </button>
+      <button
+        cdsButton="primary"
+        *ngIf="obs.showSaveButton && !obs.saving"
+        [disabled]="!obs.enableSaveButton"
+        (click)="saveButtonClick()"
+      >
+        {{ 'processLinkConfiguration.complete' | translate }}
+      </button>
+    </div>
   </cds-modal-footer>
 </ng-template>

--- a/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.scss
+++ b/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.scss
@@ -19,9 +19,8 @@
   min-height: 70%;
 }
 
-::ng-deep .process-link-modal-container .cds--modal-footer {
-  display: flex;
-  flex-direction: row;
+::ng-deep .process-link-modal-container .cds--modal-footer .footer-spacer {
+  flex: 0 1 50%;
 }
 
 .cds-loading-container {
@@ -37,31 +36,6 @@
   background: var(--cds-layer);
   z-index: 99;
   box-sizing: border-box;
-}
-
-.cancel-button {
-  width: 20%;
-  display: flex;
-
-  button {
-    width: 100%;
-  }
-}
-
-.footer-spacer {
-  width: 20%;
-}
-
-.action-buttons {
-  width: 60%;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-
-  button {
-    flex: 1;
-    max-width: 33.33%;
-  }
 }
 
 .process-link-progress {

--- a/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.scss
+++ b/frontend/projects/valtimo/process-link/src/lib/components/process-link-modal/process-link-modal.component.scss
@@ -19,8 +19,9 @@
   min-height: 70%;
 }
 
-::ng-deep .process-link-modal-container .cds--modal-footer .footer-spacer {
-  flex: 0 1 50%;
+::ng-deep .process-link-modal-container .cds--modal-footer {
+  display: flex;
+  flex-direction: row;
 }
 
 .cds-loading-container {
@@ -36,6 +37,31 @@
   background: var(--cds-layer);
   z-index: 99;
   box-sizing: border-box;
+}
+
+.cancel-button {
+  width: 20%;
+  display: flex;
+
+  button {
+    width: 100%;
+  }
+}
+
+.footer-spacer {
+  width: 20%;
+}
+
+.action-buttons {
+  width: 60%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+
+  button {
+    flex: 1;
+    max-width: 33.33%;
+  }
 }
 
 .process-link-progress {

--- a/frontend/projects/valtimo/process-management/src/lib/components/process-management-upload/process-management-upload.component.html
+++ b/frontend/projects/valtimo/process-management/src/lib/components/process-management-upload/process-management-upload.component.html
@@ -33,7 +33,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" (click)="closeModal()">
+    <button cdsButton="secondary" (click)="closeModal()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/task-management/src/lib/components/task-management-search-fields-modal/task-management-search-fields-modal.component.html
+++ b/frontend/projects/valtimo/task-management/src/lib/components/task-management-search-fields-modal/task-management-search-fields-modal.component.html
@@ -217,7 +217,7 @@
   </form>
 
   <cds-modal-footer>
-    <button data-testid="task-management-search-cancel" cdsButton="ghost" (click)="onCancel()">
+    <button data-testid="task-management-search-cancel" cdsButton="secondary" (click)="onCancel()">
       {{ 'interface.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/zgw/src/lib/modules/notificaties-api/components/failed-notification-detail/failed-notification-detail.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/notificaties-api/components/failed-notification-detail/failed-notification-detail.component.html
@@ -53,7 +53,7 @@
   </section>
 
   <cds-modal-footer>
-    <button cdsButton="ghost" type="button" (click)="onClose()">
+    <button cdsButton="secondary" type="button" (click)="onClose()">
       {{ 'interface.close' | translate }}
     </button>
     <button

--- a/frontend/projects/valtimo/zgw/src/lib/modules/zaken-api/components/zaken-api-zaaktype-link/zaken-api-zaaktype-link.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/zaken-api/components/zaken-api-zaaktype-link/zaken-api-zaaktype-link.component.html
@@ -134,7 +134,7 @@
     </section>
 
     <cds-modal-footer>
-      <button cdsButton="ghost" (click)="closeModal()">
+      <button cdsButton="secondary" (click)="closeModal()">
         {{ 'interface.cancel' | translate }}
       </button>
 


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/205
Close this pull request: https://github.com/valtimo-platform/valtimo/pull/369

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps

- Removed 'Reset' button in the 'create form' modal
- Fixed layering issues in modals
- Fixed button spacing in process link modal
- Fixed supporting processes button icon from black to white
- Changed colors to Valtimo blue
- Modals in Admin section used 'cancel' and 'close' in both secondary and ghost style: Fixed this to use 'Cancel' with a ghost style in every modal.

According to Carbon guidelines:
- If there is a cancel button and another primary button, the cancel button should be 50% wide secondary
- If there is more than 2 buttons, the cancel button should be ghost style, and a spacer should be in place

That behaviour have to be tested in the following scenarios:
- form-management
  - form-management-create (+ "Back" -> "Cancel")
  - form-management-upload
- form-flow-management
  - new-form-flow-modal
- case-management
  - case-management-create
  - case-management-create-draft-version
  - case-management-edit-tab-modal
  - case-management-widget-tab-edit-modal
  - case-management-search-fields
  - case-management-list-columns
- object-management
  - object-management-list-columns
  - object-management-list-search-fields
- task-management
  - task-management-column-modal
  - task-management-search-fields-modal
- process-management
  - process-management-upload
- decision
  - decision-deploy
- access-control-management
  - role-metadata-modal
  - export-role-modal
- building-block-management
  - building-block-management-create-modal
  - building-block-management-process-upload
  - building-block-management-detail-actions
- layout
  - widget-management-divider-modal
- iko
  - iko-management-view-modal
  - iko-management-tab-details-modal
  - search-field-modal
  - search-action-modal
  - list-modal
  - iko-management-repository-modal
- zgw
  - document-objecten-api-sync
  - failed-notification-detail
  - zaken-api-zaaktype-link

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
