### PR TITLE
[BE] Process links are not executed for auto-assigned tasks

### DIFF
--- a/backend/app/gzac/src/dev/resources/config/case/bezwaar/1-0-1/bpmn/create-portaal-taak-process.bpmn
+++ b/backend/app/gzac/src/dev/resources/config/case/bezwaar/1-0-1/bpmn/create-portaal-taak-process.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" expressionLanguage="http://www.w3.org/1999/XPath" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" typeLanguage="http://www.w3.org/2001/XMLSchema">
+  <bpmn:process id="create-portaal-taak-process" isClosed="false" isExecutable="true" name="Create portaal taak" operaton:versionTag="CD:bezwaar:1.0.1" processType="None">
+    <bpmn:startEvent id="StartEvent_1" isInterrupting="true" parallelMultiple="false">
+      <bpmn:outgoing>Flow_004hxoz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_004hxoz" sourceRef="StartEvent_1" targetRef="Activity_01zdn8o"/>
+    <bpmn:sequenceFlow id="Flow_108mgls" sourceRef="Activity_01zdn8o" targetRef="Activity_0um6ijv"/>
+    <bpmn:endEvent id="Event_1450elh">
+      <bpmn:incoming>Flow_0x0ofi0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0x0ofi0" sourceRef="Activity_0um6ijv" targetRef="Event_1450elh"/>
+    <bpmn:userTask camunda:candidateGroups="ROLE_USER" completionQuantity="1" id="Activity_0um6ijv" implementation="##unspecified" isForCompensation="false" name="Portaal taak in Objecten API" startQuantity="1">
+      <bpmn:incoming>Flow_108mgls</bpmn:incoming>
+      <bpmn:outgoing>Flow_0x0ofi0</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask completionQuantity="1" id="Activity_01zdn8o" implementation="##WebService" isForCompensation="false" name="Create zaak role: Initiator" operaton:asyncAfter="true" operaton:expression="${null}" startQuantity="1">
+      <bpmn:incoming>Flow_004hxoz</bpmn:incoming>
+      <bpmn:outgoing>Flow_108mgls</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane bpmnElement="create-portaal-taak-process" id="BPMNPlane_1">
+      <bpmndi:BPMNShape bpmnElement="StartEvent_1" id="_BPMNShape_StartEvent_2">
+        <dc:Bounds height="36" width="36" x="173" y="102"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Event_1450elh" id="Event_1450elh_di">
+        <dc:Bounds height="36" width="36" x="582" y="102"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_0um6ijv" id="Activity_1vagrw8_di">
+        <dc:Bounds height="80" width="100" x="420" y="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="Activity_01zdn8o" id="Activity_1txdjri_di">
+        <dc:Bounds height="80" width="100" x="260" y="80"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="Flow_004hxoz" id="Flow_004hxoz_di">
+        <di:waypoint x="209" y="120"/>
+        <di:waypoint x="260" y="120"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="Flow_108mgls" id="Flow_108mgls_di">
+        <di:waypoint x="360" y="120"/>
+        <di:waypoint x="420" y="120"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="Flow_0x0ofi0" id="Flow_0x0ofi0_di">
+        <di:waypoint x="520" y="120"/>
+        <di:waypoint x="582" y="120"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/backend/app/gzac/src/dev/resources/config/case/bezwaar/1-0-1/process-document-link/bezwaar.process-document-link.json
+++ b/backend/app/gzac/src/dev/resources/config/case/bezwaar/1-0-1/process-document-link/bezwaar.process-document-link.json
@@ -15,12 +15,17 @@
         "startableByUser": true
     },
     {
-        "processDefinitionKey": "patch-zaak",
+        "processDefinitionKey": "create-portaal-taak-process",
         "canInitializeDocument": false,
         "startableByUser": true
     },
     {
         "processDefinitionKey": "create-zaaknotitie",
+        "canInitializeDocument": false,
+        "startableByUser": true
+    },
+    {
+        "processDefinitionKey": "patch-zaak",
         "canInitializeDocument": false,
         "startableByUser": true
     },

--- a/backend/app/gzac/src/dev/resources/config/case/bezwaar/1-0-1/process-link/create-portaal-taak-process.process-link.json
+++ b/backend/app/gzac/src/dev/resources/config/case/bezwaar/1-0-1/process-link/create-portaal-taak-process.process-link.json
@@ -1,0 +1,39 @@
+[
+    {
+        "activityId": "StartEvent_1",
+        "activityType": "bpmn:StartEvent:start",
+        "formDefinitionName": "empty-form",
+        "formDisplayType": "modal",
+        "formSize": "medium",
+        "processLinkType": "form"
+    },
+    {
+        "activityId": "Activity_01zdn8o",
+        "activityType": "bpmn:ServiceTask:start",
+        "pluginConfigurationId": "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee",
+        "pluginActionDefinitionKey": "create-natuurlijk-persoon-zaak-rol",
+        "actionProperties": {
+            "inpBsn": "999990755",
+            "roltypeUrl": "http://localhost:8001/catalogi/api/v1/roltypen/1c359a1b-c38d-47b8-bed5-994db88ead61",
+            "rolToelichting": "Initiator"
+        },
+        "referenceType": "FIXED",
+        "processLinkType": "plugin"
+    },
+    {
+        "activityId": "Activity_0um6ijv",
+        "activityType": "bpmn:UserTask:create",
+        "pluginConfigurationId": "d65113e0-a9cb-4904-93e1-5e8b1206e625",
+        "pluginActionDefinitionKey": "create-portaaltaak",
+        "actionProperties": {
+            "formType": "id",
+            "receiver": "zaakInitiator",
+            "sendData": [],
+            "formTypeId": "test-form",
+            "receiveData": [],
+            "verloopDurationInDays": "5"
+        },
+        "referenceType": "FIXED",
+        "processLinkType": "plugin"
+    }
+]

--- a/backend/building-block/src/main/kotlin/com/ritense/buildingblock/processlink/service/BuildingBlockCallActivityListener.kt
+++ b/backend/building-block/src/main/kotlin/com/ritense/buildingblock/processlink/service/BuildingBlockCallActivityListener.kt
@@ -25,6 +25,7 @@ import com.ritense.buildingblock.service.BuildingBlockInstanceService
 import com.ritense.document.domain.impl.request.NewDocumentRequest
 import com.ritense.processlink.service.ProcessLinkService
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import com.ritense.valtimo.contract.buildingblock.BuildingBlockConstants.Companion.BUILDING_BLOCK_DOCUMENT_ID_VARIABLE
 import com.ritense.valtimo.contract.process.ProcessConstants.OPERATON_BUILDING_BLOCK_DEFINITION_VERSION_TAG_PREFIX
 import com.ritense.valtimo.contract.process.ProcessConstants.OPERATON_CASE_DEFINITION_VERSION_TAG_PREFIX
@@ -46,11 +47,12 @@ class BuildingBlockCallActivityListener(
 ) {
 
     @EventListener(
-        condition = """#execution.bpmnModelElementInstance != null
-            && #execution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).CALL_ACTIVITY
-            && #execution.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START"""
+        condition = """#event.delegateExecution.bpmnModelElementInstance != null
+            && #event.delegateExecution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).CALL_ACTIVITY
+            && #event.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START"""
     )
-    fun onCallActivityStart(execution: DelegateExecution) {
+    fun onCallActivityStart(event: OperatonExecutionEvent) {
+        val execution = event.delegateExecution
         val activityId = execution.currentActivityId ?: return
         val links = processLinkService.getProcessLinks(execution.processDefinitionId, activityId)
             .filterIsInstance<BuildingBlockProcessLink>()
@@ -124,11 +126,12 @@ class BuildingBlockCallActivityListener(
     }
 
     @EventListener(
-        condition = """#execution.bpmnModelElementInstance != null
-            && #execution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).CALL_ACTIVITY
-            && #execution.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_END"""
+        condition = """#event.delegateExecution.bpmnModelElementInstance != null
+            && #event.delegateExecution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).CALL_ACTIVITY
+            && #event.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_END"""
     )
-    fun onCallActivityEnd(execution: DelegateExecution) {
+    fun onCallActivityEnd(event: OperatonExecutionEvent) {
+        val execution = event.delegateExecution
 
         val buildingBlockVariableString = execution.getVariableLocal(BUILDING_BLOCK_DOCUMENT_ID_VARIABLE)?.let {
             it as String

--- a/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/BuildingBlockCallActivityListenerTest.kt
+++ b/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/BuildingBlockCallActivityListenerTest.kt
@@ -73,6 +73,7 @@ class BuildingBlockCallActivityListenerTest {
             on { processDefinitionId } doReturn "case-process"
             on { businessKey } doReturn caseDocumentId.toString()
             on { processBusinessKey } doReturn caseDocumentId.toString()
+            on { this.eventName } doReturn "start"
         }
         val inputMappings = listOf(
             BuildingBlockInputMapping(
@@ -153,6 +154,7 @@ class BuildingBlockCallActivityListenerTest {
             on { processDefinitionId } doReturn "parent-bb-process"
             on { businessKey } doReturn parentBBDocumentId.toString()
             on { processBusinessKey } doReturn parentBBDocumentId.toString()
+            on { this.eventName } doReturn "start"
         }
 
         val inputMappings = listOf(
@@ -200,6 +202,7 @@ class BuildingBlockCallActivityListenerTest {
             on { currentActivityId } doReturn "callActivity"
             on { processDefinitionId } doReturn "case-process"
             on { businessKey } doReturn UUID.randomUUID().toString()
+            on { this.eventName } doReturn "start"
         }
         whenever(processLinkService.getProcessLinks("case-process", "callActivity")).thenReturn(emptyList())
 
@@ -218,6 +221,7 @@ class BuildingBlockCallActivityListenerTest {
             on { businessKey } doReturn caseDocumentId.toString()
             on { processDefinitionId } doReturn testProcessDefinitionId
             on { getVariableLocal("buildingBlockDocumentId") } doReturn buildingBlockDocumentId.toString()
+            on { this.eventName } doReturn "start"
         }
 
         val buildingBlockDefinitionId = BuildingBlockDefinitionId.of("bb", "1.0.0")

--- a/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/BuildingBlockCallActivityListenerTest.kt
+++ b/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/BuildingBlockCallActivityListenerTest.kt
@@ -29,6 +29,7 @@ import com.ritense.processlink.service.ProcessLinkService
 import com.ritense.valtimo.contract.buildingblock.BuildingBlockDefinitionId
 import com.ritense.valtimo.contract.json.MapperSingleton
 import com.ritense.valtimo.contract.process.ProcessConstants.OPERATON_CASE_DEFINITION_VERSION_TAG_PREFIX
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import com.ritense.valtimo.operaton.domain.OperatonProcessDefinition
 import com.ritense.valtimo.operaton.service.OperatonRepositoryService
 import com.ritense.valueresolver.ValueResolverService
@@ -112,7 +113,7 @@ class BuildingBlockCallActivityListenerTest {
         )
         .thenReturn(buildingBlockInstance)
 
-        listener.onCallActivityStart(execution)
+        listener.onCallActivityStart(OperatonExecutionEvent(execution))
 
         val capturedContent = requestCaptor.firstValue.content()
         assertThat(capturedContent.get("name").asText()).isEqualTo("Ada Lovelace")
@@ -187,7 +188,7 @@ class BuildingBlockCallActivityListenerTest {
         )
         .thenReturn(newBBInstance)
 
-        listener.onCallActivityStart(execution)
+        listener.onCallActivityStart(OperatonExecutionEvent(execution))
 
         val capturedContent = requestCaptor.firstValue.content()
         assertThat(capturedContent.get("input").asText()).isEqualTo("parent data")
@@ -202,7 +203,7 @@ class BuildingBlockCallActivityListenerTest {
         }
         whenever(processLinkService.getProcessLinks("case-process", "callActivity")).thenReturn(emptyList())
 
-        listener.onCallActivityStart(execution)
+        listener.onCallActivityStart(OperatonExecutionEvent(execution))
 
         verify(buidingBlockInstanceService, never()).create(any(), any(), any(), any())
     }
@@ -268,7 +269,7 @@ class BuildingBlockCallActivityListenerTest {
             )
         ).thenReturn(mapOf("doc:/result" to "value"))
 
-        listener.onCallActivityEnd(execution)
+        listener.onCallActivityEnd(OperatonExecutionEvent(execution))
 
         verify(valueResolverService).handleValues(caseDocumentId, mapOf("doc:/result" to "value"))
     }

--- a/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolverIT.kt
+++ b/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolverIT.kt
@@ -32,6 +32,7 @@ import com.ritense.processlink.domain.ActivityTypeWithEventName
 import com.ritense.valtimo.contract.buildingblock.BuildingBlockConstants.Companion.BUILDING_BLOCK_DOCUMENT_ID_VARIABLE
 import com.ritense.valtimo.contract.buildingblock.BuildingBlockDefinitionId
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -175,7 +176,7 @@ class DefaultBuildingBlockPluginConfigurationResolverIT @Autowired constructor(
         )
 
         runWithoutAuthorization {
-            listener.onCallActivityStart(bb1Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb1Execution))
         }
 
         val bb1Instance = buildingBlockInstanceRepository.findAll().first()
@@ -188,7 +189,7 @@ class DefaultBuildingBlockPluginConfigurationResolverIT @Autowired constructor(
         )
 
         runWithoutAuthorization {
-            listener.onCallActivityStart(bb2Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb2Execution))
         }
 
         val bb2Instance = buildingBlockInstanceRepository.findAll().find { it.definition.id == bb2DefinitionId }!!
@@ -264,7 +265,7 @@ class DefaultBuildingBlockPluginConfigurationResolverIT @Autowired constructor(
         )
 
         runWithoutAuthorization {
-            listener.onCallActivityStart(bb1Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb1Execution))
         }
 
         val bb1Instance = buildingBlockInstanceRepository.findAll().first()
@@ -310,6 +311,7 @@ class DefaultBuildingBlockPluginConfigurationResolverIT @Autowired constructor(
             on { this.processDefinitionId } doReturn processDefinitionId
             on { this.businessKey } doReturn businessKey
             on { this.processBusinessKey } doReturn businessKey
+            on { this.eventName } doReturn "start"
         }
     }
 }

--- a/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/NestedBuildingBlockIT.kt
+++ b/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/NestedBuildingBlockIT.kt
@@ -39,6 +39,7 @@ import com.ritense.valtimo.contract.buildingblock.BuildingBlockDefinitionId
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
 import com.ritense.valtimo.contract.process.ProcessConstants.OPERATON_BUILDING_BLOCK_DEFINITION_VERSION_TAG_PREFIX
 import com.ritense.valtimo.contract.process.ProcessConstants.OPERATON_CASE_DEFINITION_VERSION_TAG_PREFIX
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import com.ritense.valtimo.operaton.domain.OperatonProcessDefinition
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -227,7 +228,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityStart(bb1Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb1Execution))
         })
 
         // Verify BB1 was created
@@ -247,7 +248,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityStart(bb2Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb2Execution))
         })
 
         // Verify BB2 was created with correct parent reference
@@ -266,7 +267,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityStart(bb3Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb3Execution))
         })
 
         // Verify BB3 was created with correct parent reference
@@ -308,7 +309,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityStart(bb1Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb1Execution))
         })
 
         val bb1Instance = buildingBlockInstanceRepository.findAll().first()
@@ -371,7 +372,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityStart(bb1Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb1Execution))
         })
 
         val bb1Instance = buildingBlockInstanceRepository.findAll().first()
@@ -385,7 +386,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityStart(bb2Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb2Execution))
         })
 
         val bb2Instance = buildingBlockInstanceRepository.findAll().find { it.definition.id == bb2DefinitionId }!!
@@ -407,7 +408,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityEnd(bb2EndExecution)
+            listener.onCallActivityEnd(OperatonExecutionEvent(bb2EndExecution))
         })
 
         // Verify BB1's document was updated (not the case document)
@@ -476,7 +477,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityStart(bb1Execution)
+            listener.onCallActivityStart(OperatonExecutionEvent(bb1Execution))
         })
 
         val bb1Instance = buildingBlockInstanceRepository.findAll().first()
@@ -498,7 +499,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         )
 
         AuthorizationContext.runWithoutAuthorization(Callable {
-            listener.onCallActivityEnd(bb1EndExecution)
+            listener.onCallActivityEnd(OperatonExecutionEvent(bb1EndExecution))
         })
 
         // Verify case document was updated
@@ -526,6 +527,7 @@ class NestedBuildingBlockIT @Autowired constructor(
             on { this.businessKey } doReturn businessKey
             on { this.processBusinessKey } doReturn businessKey  // Used by findParentBuildingBlockInstance
             on { this.processInstance } doReturn processInstance
+            on { this.eventName } doReturn "start"
         }
     }
 
@@ -538,6 +540,7 @@ class NestedBuildingBlockIT @Autowired constructor(
         return mock {
             on { this.processDefinitionId } doReturn processDefinitionId
             on { getVariableLocal(BUILDING_BLOCK_DOCUMENT_ID_VARIABLE) } doReturn buildingBlockDocumentId.toString()
+            on { this.eventName } doReturn "end"
         }
     }
 

--- a/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/ValtimoAutoConfiguration.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/ValtimoAutoConfiguration.java
@@ -37,6 +37,7 @@ import com.ritense.valtimo.operaton.CallDepthExecutionListener;
 import com.ritense.valtimo.operaton.ProcessApplicationStartedEventListener;
 import com.ritense.valtimo.operaton.ProcessDefinitionPropertyListener;
 import com.ritense.valtimo.operaton.TaskCompletedListener;
+import com.ritense.valtimo.operaton.listener.OperatonEventListener;
 import com.ritense.valtimo.operaton.repository.CustomRepositoryServiceImpl;
 import com.ritense.valtimo.operaton.repository.OperatonExecutionRepository;
 import com.ritense.valtimo.operaton.repository.OperatonIdentityLinkRepository;
@@ -135,6 +136,12 @@ public class ValtimoAutoConfiguration {
     @ConditionalOnMissingBean(CallDepthExecutionListener.class)
     public CallDepthExecutionListener callDepthExecutionListener(final ValtimoProperties valtimoProperties) {
         return new CallDepthExecutionListener(valtimoProperties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(OperatonEventListener.class)
+    public OperatonEventListener operatonEventListener(final ApplicationEventPublisher publisher) {
+        return new OperatonEventListener(publisher);
     }
 
     @Bean

--- a/backend/core/src/main/java/com/ritense/valtimo/operaton/TaskCompletedListener.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/operaton/TaskCompletedListener.java
@@ -21,6 +21,7 @@ import static com.ritense.logging.LoggingContextKt.withLoggingContext;
 import com.ritense.valtimo.operaton.domain.OperatonTask;
 import com.ritense.valtimo.contract.audit.utils.AuditHelper;
 import com.ritense.valtimo.contract.event.TaskCompletedEvent;
+import com.ritense.valtimo.event.OperatonTaskEvent;
 import com.ritense.valtimo.contract.utils.RequestHelper;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -37,10 +38,11 @@ public class TaskCompletedListener {
         this.applicationEventPublisher = applicationEventPublisher;
     }
 
-    @EventListener(condition = "#delegateTask.bpmnModelElementInstance != null " +
-        "&& #delegateTask.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_USER_TASK " +
-        "&& #delegateTask.eventName == T(org.operaton.bpm.engine.delegate.TaskListener).EVENTNAME_COMPLETE")
-    public void notify(DelegateTask delegateTask) {
+    @EventListener(condition = "#event.delegateTask.bpmnModelElementInstance != null " +
+        "&& #event.delegateTask.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_USER_TASK " +
+        "&& #event.eventName == T(org.operaton.bpm.engine.delegate.TaskListener).EVENTNAME_COMPLETE")
+    public void notify(OperatonTaskEvent event) {
+        DelegateTask delegateTask = event.getDelegateTask();
         withLoggingContext(OperatonTask.class, delegateTask.getId(), () ->
             applicationEventPublisher.publishEvent(
                 new TaskCompletedEvent(

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/event/OperatonExecutionEvent.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/event/OperatonExecutionEvent.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.event
+
+import org.operaton.bpm.engine.delegate.DelegateExecution
+
+/**
+ * Wrapper for [DelegateExecution] to be used in [org.springframework.context.event.EventListener].
+ *
+ * The [DelegateExecution.getEventName] can be modified by an [org.operaton.bpm.engine.delegate.ExecutionListener].
+ * This event stores the original event name to ensure that subsequent [org.springframework.context.event.EventListener]
+ * conditions based on the event name remain valid.
+ */
+class OperatonExecutionEvent(
+    val delegateExecution: DelegateExecution,
+    val eventName: String = delegateExecution.eventName,
+)

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/event/OperatonTaskEvent.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/event/OperatonTaskEvent.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.event
+
+import org.operaton.bpm.engine.delegate.DelegateTask
+
+/**
+ * Wrapper for [DelegateTask] to be used in [org.springframework.context.event.EventListener].
+ *
+ * The [DelegateTask.getEventName] can be modified by an [org.operaton.bpm.engine.delegate.TaskListener].
+ * This event stores the original event name to ensure that subsequent [org.springframework.context.event.EventListener]
+ * conditions based on the event name remain valid.
+ */
+class OperatonTaskEvent(
+    val delegateTask: DelegateTask,
+    val eventName: String = delegateTask.eventName,
+)

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/operaton/CallDepthExecutionListener.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/operaton/CallDepthExecutionListener.kt
@@ -17,6 +17,7 @@
 package com.ritense.valtimo.operaton
 
 import com.ritense.valtimo.contract.config.ValtimoProperties
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import org.operaton.bpm.engine.delegate.DelegateExecution
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
@@ -26,11 +27,13 @@ class CallDepthExecutionListener(
 ) {
 
     @EventListener(
-        condition = "#execution.bpmnModelElementInstance != null "
-            + "&& #execution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).START_EVENT "
-            + "&& #execution.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START"
+        condition = """#event.delegateExecution.bpmnModelElementInstance != null
+            && #event.delegateExecution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).START_EVENT
+            && #event.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START
+        """
     )
-    fun onProcessStart(execution: DelegateExecution) {
+    fun onProcessStart(event: OperatonExecutionEvent) {
+        val execution = event.delegateExecution
         val initialSuperExecution = execution.processInstance?.superExecution
         if (initialSuperExecution != null) {
             val parentDepth = findAndSetParentDepthIfNotPresent(initialSuperExecution)

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/operaton/listener/OperatonEventListener.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/operaton/listener/OperatonEventListener.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.operaton.listener
+
+import com.ritense.valtimo.contract.annotation.SkipComponentScan
+import com.ritense.valtimo.event.OperatonExecutionEvent
+import com.ritense.valtimo.event.OperatonTaskEvent
+import org.operaton.bpm.engine.delegate.DelegateExecution
+import org.operaton.bpm.engine.delegate.DelegateTask
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@SkipComponentScan
+class OperatonEventListener(
+    private val publisher: ApplicationEventPublisher,
+) {
+
+    @Transactional
+    @EventListener(DelegateTask::class)
+    fun notifyTaskEvent(delegateTask: DelegateTask) {
+        publisher.publishEvent(OperatonTaskEvent(delegateTask))
+    }
+
+    @Transactional
+    @EventListener(DelegateExecution::class)
+    fun notifyExecutionEvent(delegateExecution: DelegateExecution) {
+        publisher.publishEvent(OperatonExecutionEvent(delegateExecution))
+    }
+}

--- a/backend/core/src/test/java/com/ritense/valtimo/operaton/TaskCompletedListenerTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/operaton/TaskCompletedListenerTest.java
@@ -53,6 +53,7 @@ class TaskCompletedListenerTest {
         when(delegateTask.getProcessInstanceId()).thenReturn("processInstanceId");
         when(delegateTask.getVariables()).thenReturn(mock(VariableMap.class));
         when(delegateTask.getExecution()).thenReturn(mock(DelegateExecution.class));
+        when(delegateTask.getEventName()).thenReturn("start");
     }
 
     @Test

--- a/backend/core/src/test/java/com/ritense/valtimo/operaton/TaskCompletedListenerTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/operaton/TaskCompletedListenerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ritense.valtimo.contract.event.TaskCompletedEvent;
+import com.ritense.valtimo.event.OperatonTaskEvent;
 import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ class TaskCompletedListenerTest {
 
     @Test
     void shouldPublishTaskCompletedEventWhenDelegateTaskIsCompleted() {
-        taskCompletedListener.notify(delegateTask);
+        taskCompletedListener.notify(new OperatonTaskEvent(delegateTask, delegateTask.getEventName()));
         verify(applicationEventPublisher, times(1)).publishEvent(taskCompletedEventCaptor.capture());
     }
 

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/operaton/CallDepthExecutionListenerTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/operaton/CallDepthExecutionListenerTest.kt
@@ -116,6 +116,7 @@ class CallDepthExecutionListenerTest {
         whenever(processInstance.superExecution).thenReturn(superExecution)
         val execution = mock<DelegateExecution>()
         whenever(execution.processInstance).thenReturn(processInstance)
+        whenever(execution.eventName).thenReturn("start")
         return execution
     }
 

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/operaton/CallDepthExecutionListenerTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/operaton/CallDepthExecutionListenerTest.kt
@@ -21,6 +21,7 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import com.ritense.valtimo.contract.config.ValtimoProperties
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -37,7 +38,7 @@ class CallDepthExecutionListenerTest {
         val execution = executionWithProcessInstance(superExecution = null)
         whenever(execution.getVariableLocal("VTM_callDepth")).thenReturn(null)
 
-        listener.onProcessStart(execution)
+        listener.onProcessStart(OperatonExecutionEvent(execution))
 
         verify(execution).setVariableLocal("VTM_callDepth", 0)
     }
@@ -56,7 +57,7 @@ class CallDepthExecutionListenerTest {
         targetLogger.addAppender(listAppender)
 
         try {
-            listener.onProcessStart(execution)
+            listener.onProcessStart(OperatonExecutionEvent(execution))
         } finally {
             targetLogger.detachAppender(listAppender)
             listAppender.stop()
@@ -79,7 +80,7 @@ class CallDepthExecutionListenerTest {
 
         val execution = executionWithProcessInstance(superExecution = parentExecution)
 
-        listener.onProcessStart(execution)
+        listener.onProcessStart(OperatonExecutionEvent(execution))
 
         verify(parentExecution).setVariableLocal("VTM_callDepth", 0)
         verify(execution).setVariableLocal("VTM_callDepth", 1)
@@ -104,7 +105,7 @@ class CallDepthExecutionListenerTest {
 
         val execution = executionWithProcessInstance(superExecution = parentExecution)
 
-        listener.onProcessStart(execution)
+        listener.onProcessStart(OperatonExecutionEvent(execution))
 
         verify(parentExecution).setVariableLocal("VTM_callDepth", 2)
         verify(execution).setVariableLocal("VTM_callDepth", 3)

--- a/backend/plugin-valtimo/src/main/kotlin/com/ritense/valtimo/processlink/ProcessLinkCallActivityStartListener.kt
+++ b/backend/plugin-valtimo/src/main/kotlin/com/ritense/valtimo/processlink/ProcessLinkCallActivityStartListener.kt
@@ -21,7 +21,7 @@ import com.ritense.plugin.repository.PluginProcessLinkRepository
 import com.ritense.plugin.service.PluginService
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
-import org.operaton.bpm.engine.delegate.DelegateExecution
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
@@ -33,11 +33,12 @@ class ProcessLinkCallActivityStartListener(
 ) {
 
     @EventListener(
-        condition = """#execution.bpmnModelElementInstance != null
-            && #execution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).CALL_ACTIVITY
-            && #execution.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START"""
+        condition = """#event.delegateExecution.bpmnModelElementInstance != null
+            && #event.delegateExecution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).CALL_ACTIVITY
+            && #event.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START"""
     )
-    fun notify(execution: DelegateExecution) {
+    fun notify(event: OperatonExecutionEvent) {
+        val execution = event.delegateExecution
         withLoggingContext("com.ritense.document.domain.impl.JsonSchemaDocument", execution.processBusinessKey) {
             val pluginProcessLinks = pluginProcessLinkRepository.findByProcessDefinitionIdAndActivityIdAndActivityType(
                 execution.processDefinitionId,

--- a/backend/plugin-valtimo/src/main/kotlin/com/ritense/valtimo/processlink/ProcessLinkServiceTaskStartListener.kt
+++ b/backend/plugin-valtimo/src/main/kotlin/com/ritense/valtimo/processlink/ProcessLinkServiceTaskStartListener.kt
@@ -21,7 +21,7 @@ import com.ritense.plugin.repository.PluginProcessLinkRepository
 import com.ritense.plugin.service.PluginService
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
-import org.operaton.bpm.engine.delegate.DelegateExecution
+import com.ritense.valtimo.event.OperatonExecutionEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -35,11 +35,12 @@ class ProcessLinkServiceTaskStartListener(
 
     @Transactional
     @EventListener(
-        condition = """#execution.bpmnModelElementInstance != null
-            && #execution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_SERVICE
-            && #execution.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START"""
+        condition = """#event.delegateExecution.bpmnModelElementInstance != null
+            && #event.delegateExecution.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_SERVICE
+            && #event.eventName == T(org.operaton.bpm.engine.delegate.ExecutionListener).EVENTNAME_START"""
     )
-    fun notify(execution: DelegateExecution) {
+    fun notify(event: OperatonExecutionEvent) {
+        val execution = event.delegateExecution
         withLoggingContext("com.ritense.document.domain.impl.JsonSchemaDocument", execution.processBusinessKey) {
             val pluginProcessLinks = pluginProcessLinkRepository.findByProcessDefinitionIdAndActivityIdAndActivityType(
                 execution.processDefinitionId,

--- a/backend/plugin-valtimo/src/main/kotlin/com/ritense/valtimo/processlink/ProcessLinkUserTaskCreateListener.kt
+++ b/backend/plugin-valtimo/src/main/kotlin/com/ritense/valtimo/processlink/ProcessLinkUserTaskCreateListener.kt
@@ -21,7 +21,7 @@ import com.ritense.plugin.repository.PluginProcessLinkRepository
 import com.ritense.plugin.service.PluginService
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
-import org.operaton.bpm.engine.delegate.DelegateTask
+import com.ritense.valtimo.event.OperatonTaskEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -35,11 +35,12 @@ open class ProcessLinkUserTaskCreateListener(
 
     @Transactional
     @EventListener(
-        condition = """#delegateTask.bpmnModelElementInstance != null
-            && #delegateTask.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_USER_TASK
-            && #delegateTask.eventName == T(org.operaton.bpm.engine.delegate.TaskListener).EVENTNAME_CREATE"""
+        condition = """#event.delegateTask.bpmnModelElementInstance != null
+            && #event.delegateTask.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_USER_TASK
+            && #event.eventName == T(org.operaton.bpm.engine.delegate.TaskListener).EVENTNAME_CREATE"""
     )
-    fun notify(delegateTask: DelegateTask) {
+    fun notify(event: OperatonTaskEvent) {
+        val delegateTask = event.delegateTask
         withLoggingContext(
             "com.ritense.document.domain.impl.JsonSchemaDocument",
             delegateTask.execution.processBusinessKey

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/listener/CaseAssigneeTaskCreatedListener.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/listener/CaseAssigneeTaskCreatedListener.kt
@@ -24,9 +24,9 @@ import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.authentication.UserManagementService
 import com.ritense.valtimo.contract.document.CaseDocumentResolutionException
 import com.ritense.valtimo.contract.document.CaseDocumentResolver
+import com.ritense.valtimo.event.OperatonTaskEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.operaton.bpm.engine.TaskService
-import org.operaton.bpm.engine.delegate.DelegateTask
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -43,11 +43,12 @@ open class CaseAssigneeTaskCreatedListener(
 ) {
 
     @EventListener(
-        condition = """#delegateTask.bpmnModelElementInstance != null
-            && #delegateTask.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_USER_TASK
-            && #delegateTask.eventName == T(org.operaton.bpm.engine.delegate.TaskListener).EVENTNAME_CREATE"""
+        condition = """#event.delegateTask.bpmnModelElementInstance != null
+            && #event.delegateTask.bpmnModelElementInstance.elementType.typeName == T(org.operaton.bpm.engine.ActivityTypes).TASK_USER_TASK
+            && #event.eventName == T(org.operaton.bpm.engine.delegate.TaskListener).EVENTNAME_CREATE"""
     )
-    fun notify(delegateTask: DelegateTask) {
+    fun notify(event: OperatonTaskEvent) {
+        val delegateTask = event.delegateTask
         val documentId = UUID.fromString(delegateTask.execution.businessKey)
 
         try {

--- a/backend/zgw/portaaltaak/src/main/kotlin/com/ritense/portaaltaak/PortaaltaakPlugin.kt
+++ b/backend/zgw/portaaltaak/src/main/kotlin/com/ritense/portaaltaak/PortaaltaakPlugin.kt
@@ -233,7 +233,7 @@ class PortaaltaakPlugin(
 
         val initiator = requireNotNull(
             zakenPlugin.getZaakRollen(zaakUrl, RolTypeGeneriekeBeschrijving.INITIATOR).firstOrNull()
-        ) { "No initiator role found for zaak with URL $zaakUrl" }
+        ) { "No role found for zaak with URL $zaakUrl that has omschrijvingGeneriek 'Initiator'" }
 
         return requireNotNull(
             initiator.betrokkeneIdentificatie.let {

--- a/backend/zgw/portaaltaak/src/test/kotlin/com/ritense/portaaltaak/PortaaltaakPluginTest.kt
+++ b/backend/zgw/portaaltaak/src/test/kotlin/com/ritense/portaaltaak/PortaaltaakPluginTest.kt
@@ -421,7 +421,7 @@ internal class PortaaltaakPluginTest {
             portaaltaakPlugin.getZaakinitiator(delegateTask)
         }
         assertEquals(
-            "No initiator role found for zaak with URL ${getZaakInstanceLink().zaakInstanceUrl}",
+            "No role found for zaak with URL ${getZaakInstanceLink().zaakInstanceUrl} that has omschrijvingGeneriek 'Initiator'",
             result.message
         )
     }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -941,7 +941,7 @@ class ZakenApiPlugin(
         key = "start-hersteltermijn",
         title = "Start hersteltermijn",
         description = "Start the recovery period for a case",
-        activityTypes = [SERVICE_TASK_START, USER_TASK_CREATE]
+        activityTypes = [SERVICE_TASK_START]
     )
     fun startHersteltermijn(
         execution: DelegateExecution,

--- a/documentation/release-notes/13.x.x/13.19.0/README.md
+++ b/documentation/release-notes/13.x.x/13.19.0/README.md
@@ -19,4 +19,4 @@ This improvement helps case handlers working on multiple cases to quickly distin
 
 ## Bugfixes
 
-* New bugfix.
+* Fixed a bug where a process link on a User Task was sometimes not executed.


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/601

A bug was fixed where Spring `@EventListener` methods listening to `DelegateTask` or `DelegateExecution` were sometimes skipped. This happened because the event name in the delegate could be modified by other listeners, causing subsequent listener conditions to fail. These listeners have been migrated to use `OperatonTaskEvent` and `OperatonExecutionEvent` to ensure the original event name is preserved.
