### PR TITLE
Fix task list breaks when selecting the same dropdown item twice

### DIFF
--- a/frontend/projects/valtimo/task/src/lib/components/task-list/task-list.component.ts
+++ b/frontend/projects/valtimo/task/src/lib/components/task-list/task-list.component.ts
@@ -381,7 +381,7 @@ export class TaskListComponent implements OnInit, OnDestroy {
   }
 
   public setCaseDefinition(definition: {item: {id: string}}): void {
-    if (definition.item.id) {
+    if (definition.item.id && definition.item.id !== this.taskListService.caseDefinitionKey) {
       this.taskListSortService.resetOverrideSortState();
       this.loadingTasks$.next(true);
       this.taskListService.setCaseDefinitionKey(definition.item.id);

--- a/frontend/projects/valtimo/task/src/lib/services/task-list.service.ts
+++ b/frontend/projects/valtimo/task/src/lib/services/task-list.service.ts
@@ -33,6 +33,10 @@ export class TaskListService {
     return this._selectedTaskType$.asObservable();
   }
 
+  public get caseDefinitionKey(): string | null {
+    return this._caseDefinitionKey$.getValue();
+  }
+
   public get selectedTaskType(): TaskListTab {
     return this._selectedTaskType$.getValue();
   }


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/615

Please verify that the task list is displayed correctly when selecting different items from the dropdown, as well as when selecting the same item twice.

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Navigate to task list
- [ ] Select different dropdown items on the top of the screen
- [ ] Verify that the task list is displayed correctly
- [ ] Select twice the same dropdown item
- [ ] Verify that the task list is displayed correctly and it is not reload, it just shows still the correct data

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
