### PR TITLE
GH-413: fields missing in valtimo-value-path-selector dropdown

### DIFF
--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/resolver/CaseDocumentJsonValueResolverFactory.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/resolver/CaseDocumentJsonValueResolverFactory.kt
@@ -340,7 +340,14 @@ class CaseDocumentJsonValueResolverFactory(
     ): List<ValueResolverOption> {
         val options: MutableList<ValueResolverOption> = mutableListOf()
         if (node.has("type")) {
-            val propertyType = node["type"].asText()
+            val typeNode = node["type"]
+            val propertyType = if (typeNode.isArray && typeNode.size() == 2 && typeNode.any { it.asText() == "null" }) {
+                typeNode.firstOrNull { it.asText() != "null" }?.asText() ?: ""
+            } else if (typeNode.isArray) {
+                ""
+            } else {
+                typeNode.asText()
+            }
             if (isSimpleObject(propertyType)) {
                 options += ValueResolverOption(path, ValueResolverOptionType.FIELD)
             } else if (propertyType == "object") {
@@ -357,6 +364,12 @@ class CaseDocumentJsonValueResolverFactory(
                     ValueResolverOptionType.COLLECTION,
                     node["items"]?.let { getPropertyNamesFromObjectNode(definition, it as ObjectNode, "") }
                 )
+            }
+        } else if (node.has("oneOf") || node.has("anyOf")) {
+            val schemas = (node["oneOf"] ?: node["anyOf"])!!
+            val nonNullSchema = schemas.firstOrNull { it.has("type") && it["type"].asText() != "null" }
+            if (schemas.size() == 2 && schemas.any { it.has("type") && it["type"].asText() == "null" } && nonNullSchema != null) {
+                options += getPropertyNamesFromObjectNode(definition, nonNullSchema as ObjectNode, path)
             }
         } else if (node.has("\$ref")) {
             val internalDefinition = node["\$ref"].asText().substring(1)

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/resolver/DocumentJsonValueResolverTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/resolver/DocumentJsonValueResolverTest.kt
@@ -547,6 +547,51 @@ internal class DocumentJsonValueResolverTest {
         assertEquals("/object3/object4/text1", options[0].children?.get(0)?.path)
     }
 
+    @Test
+    fun `should include oneOf nullable string field as FIELD option`() {
+        mockDefinition("test")
+
+        val options = documentValueResolver.getResolvableKeyOptions("test")
+
+        assertThat(options).anyMatch { it.path == "doc:/string2" && it.type == ValueResolverOptionType.FIELD }
+    }
+
+    @Test
+    fun `should include union type nullable string field as FIELD option`() {
+        mockDefinition("test")
+
+        val options = documentValueResolver.getResolvableKeyOptions("test")
+
+        assertThat(options).anyMatch { it.path == "doc:/string3" && it.type == ValueResolverOptionType.FIELD }
+    }
+
+    @Test
+    fun `should include anyOf nullable string field as FIELD option`() {
+        mockDefinition("test")
+
+        val options = documentValueResolver.getResolvableKeyOptions("test")
+
+        assertThat(options).anyMatch { it.path == "doc:/string4" && it.type == ValueResolverOptionType.FIELD }
+    }
+
+    @Test
+    fun `should not include oneOf field with more than two schemas as FIELD option`() {
+        mockDefinition("test")
+
+        val options = documentValueResolver.getResolvableKeyOptions("test")
+
+        assertThat(options).noneMatch { it.path == "doc:/string5" }
+    }
+
+    @Test
+    fun `should not include union type field without null as FIELD option`() {
+        mockDefinition("test")
+
+        val options = documentValueResolver.getResolvableKeyOptions("test")
+
+        assertThat(options).noneMatch { it.path == "doc:/string6" }
+    }
+
     private fun mockDefinition(definitionName: String): JsonSchemaDocumentDefinition {
         val definition: JsonSchemaDocumentDefinition = definitionOf(definitionName)
         whenever(documentDefinitionService.findActiveByName(definitionName)).thenReturn(Optional.of(definition))

--- a/backend/process-document/src/test/resources/config/case/test/1-0-0/case/definition/test.case-definition.json
+++ b/backend/process-document/src/test/resources/config/case/test/1-0-0/case/definition/test.case-definition.json
@@ -1,0 +1,7 @@
+{
+    "key": "test",
+    "name": "test",
+    "versionTag": "1.0.0",
+    "canHaveAssignee": true,
+    "autoAssignTasks": true
+}

--- a/backend/process-document/src/test/resources/config/case/test/1-0-0/document/definition/test.schema.document-definition.json
+++ b/backend/process-document/src/test/resources/config/case/test/1-0-0/document/definition/test.schema.document-definition.json
@@ -1,0 +1,50 @@
+{
+    "$id": "test.schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "test",
+    "type": "object",
+    "properties": {
+        "string1": {
+            "type": "string",
+            "default": "default value"
+        },
+        "string2": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "null"}
+            ]
+        },
+        "string3": {
+            "type": ["string", "null"]
+        },
+        "string4": {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "null"}
+            ]
+        },
+        "string5": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "integer"},
+                {"type": "null"}
+            ]
+        },
+        "string6": {
+            "type": ["string", "integer"]
+        },
+        "enum1": {
+            "enum": ["DEBET", "CREDIT"],
+            "type": "string",
+            "default": "DEBET"
+        },
+        "enum2": {
+            "type": "array",
+            "items": {
+                "enum": ["BALIE", "TELEFONIE", "INTERNET", "POST"],
+                "type": "string"
+            },
+            "uniqueItems": true
+        }
+    }
+}

--- a/documentation/release-notes/13.x.x/13.19.0/README.md
+++ b/documentation/release-notes/13.x.x/13.19.0/README.md
@@ -28,3 +28,4 @@ PBAC conditions for Resources (Case related documents on the Document API) allow
 ## Bugfixes
 
 * Fixed a bug where a process link on a User Task was sometimes not executed.
+* Fixed edge case where a document field could sometimes not be selected when configuring a case column.


### PR DESCRIPTION
Added support for two specific types of fields in document definitions. These are:

- oneOf fields with only two types, one of which is `null`
- `type: [...]`,  where ... is only two types, one of which is `"null"`

https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/413