### PR TITLE
Release notes for task breaking when selecting the same dropdown item…

### DIFF
--- a/documentation/release-notes/13.x.x/13.19.0/README.md
+++ b/documentation/release-notes/13.x.x/13.19.0/README.md
@@ -31,3 +31,4 @@ PBAC conditions for Resources (Case related documents on the Document API) allow
 * Fixed a bug where a process link on a User Task was sometimes not executed.
 * Fixed edge case where a document field could sometimes not be selected when configuring a case column.
 * Fixed an issue in the bulk assignment of cases where permission checks were not correctly applied per document.
+* Fixed an issue where selecting the same dropdown item twice in the task list would cause the task list to break.


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes 
Release notes for story https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/615
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/615

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
