### PR TITLE
Fixed issue where old audit event were no longer compatible.

### DIFF
--- a/backend/core/src/main/resources/config/liquibase/13-20-0/13-20-0-master.xml
+++ b/backend/core/src/main/resources/config/liquibase/13-20-0/13-20-0-master.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="1" author="Ritense">
+        <preConditions onFail="MARK_RAN">
+            <dbms type="postgresql"/>
+        </preConditions>
+        <sql>
+            UPDATE audit_record
+            SET audit_event = (
+                jsonb_set(
+                    audit_event::jsonb #- '{definitionId,caseDefinitionId}',
+                    '{definitionId,blueprintId}',
+                    jsonb_build_object(
+                        'blueprintType', 'CASE',
+                        'blueprintKey', audit_event->'definitionId'->'caseDefinitionId'->>'key',
+                        'blueprintVersionTag', audit_event->'definitionId'->'caseDefinitionId'->>'versionTag'
+                    )
+                )
+            )::json
+            WHERE audit_event::jsonb->'definitionId'->'caseDefinitionId' IS NOT NULL;
+        </sql>
+    </changeSet>
+
+    <changeSet id="2" author="Ritense">
+        <preConditions onFail="MARK_RAN">
+            <dbms type="mysql"/>
+        </preConditions>
+        <sql>
+            UPDATE audit_record
+            SET audit_event = JSON_REMOVE(
+                JSON_SET(
+                    audit_event,
+                    '$.definitionId.blueprintId',
+                    JSON_OBJECT(
+                        'blueprintType', 'CASE',
+                        'blueprintKey', JSON_UNQUOTE(JSON_EXTRACT(audit_event, '$.definitionId.caseDefinitionId.key')),
+                        'blueprintVersionTag', JSON_UNQUOTE(JSON_EXTRACT(audit_event, '$.definitionId.caseDefinitionId.versionTag'))
+                    )
+                ),
+                '$.definitionId.caseDefinitionId'
+            )
+            WHERE JSON_EXTRACT(audit_event, '$.definitionId.caseDefinitionId') IS NOT NULL;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/backend/core/src/main/resources/config/liquibase/changelog-master.xml
+++ b/backend/core/src/main/resources/config/liquibase/changelog-master.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ /*
-  ~  * Copyright 2015-2026 Ritense BV, the Netherlands.
-  ~  *
-  ~  * Licensed under EUPL, Version 1.2 (the "License");
-  ~  * you may not use this file except in compliance with the License.
-  ~  * You may obtain a copy of the License at
-  ~  *
-  ~  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
-  ~  *
-  ~  * Unless required by applicable law or agreed to in writing, software
-  ~  * distributed under the License is distributed on an "AS IS" basis,
-  ~  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~  * See the License for the specific language governing permissions and
-  ~  * limitations under the License.
-  ~  */
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <databaseChangeLog
@@ -26,6 +24,7 @@
     <include file="/13-15-0/13-15-0-master.xml" relativeToChangelogFile="true"/>
     <include file="/13-16-0/13-16-0-master.xml" relativeToChangelogFile="true"/>
     <include file="/13-18-0/13-18-0-master.xml" relativeToChangelogFile="true"/>
+    <include file="/13-20-0/13-20-0-master.xml" relativeToChangelogFile="true"/>
 
 
 </databaseChangeLog>

--- a/documentation/release-notes/13.x.x/13.20.0/README.md
+++ b/documentation/release-notes/13.x.x/13.20.0/README.md
@@ -18,4 +18,47 @@
 
 ## Bugfixes
 
-* New bugfix.
+* **Fixed error when viewing audit events for cases created before 13.15.0**
+
+  Opening the progress tab for a case that was created on an older version could result in an error. A database migration now automatically corrects the stored audit data on startup.
+
+  {% hint style="warning" %}
+  **Performance note:** This migration updates audit records that still use the old data format. On databases with a large number of audit records this can take a significant amount of time. If you prefer to run it during a maintenance window, you can execute the appropriate SQL below directly on your database **before** upgrading. The migration will then detect that no records need updating and complete instantly.
+  {% endhint %}
+
+  **PostgreSQL:**
+
+  ```sql
+  UPDATE audit_record
+  SET audit_event = (
+      jsonb_set(
+          audit_event::jsonb #- '{definitionId,caseDefinitionId}',
+          '{definitionId,blueprintId}',
+          jsonb_build_object(
+              'blueprintType', 'CASE',
+              'blueprintKey', audit_event->'definitionId'->'caseDefinitionId'->>'key',
+              'blueprintVersionTag', audit_event->'definitionId'->'caseDefinitionId'->>'versionTag'
+          )
+      )
+  )::json
+  WHERE audit_event::jsonb->'definitionId'->'caseDefinitionId' IS NOT NULL;
+  ```
+
+  **MySQL:**
+
+  ```sql
+  UPDATE audit_record
+  SET audit_event = JSON_REMOVE(
+      JSON_SET(
+          audit_event,
+          '$.definitionId.blueprintId',
+          JSON_OBJECT(
+              'blueprintType', 'CASE',
+              'blueprintKey', JSON_UNQUOTE(JSON_EXTRACT(audit_event, '$.definitionId.caseDefinitionId.key')),
+              'blueprintVersionTag', JSON_UNQUOTE(JSON_EXTRACT(audit_event, '$.definitionId.caseDefinitionId.versionTag'))
+          )
+      ),
+      '$.definitionId.caseDefinitionId'
+  )
+  WHERE JSON_EXTRACT(audit_event, '$.definitionId.caseDefinitionId') IS NOT NULL;
+  ```


### PR DESCRIPTION
Fixes: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/612

**As 612 will be released as a hot-fix to 13.17.1 created another ticket to reflect the same fix in the next minor (13.20.0):
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/276**

How to test:

- Start a valitmo version 13.12.0.
- Create some cases and complete some tasks.
- Start a valtimo with this version.
- Go to the progress tab.
- You should not get an error, and audit events should be visible.
