### PR TITLE
story/152455-gh-issue-626

### DIFF
--- a/backend/app/gzac/src/main/resources/config/pbac/resource.permission.json
+++ b/backend/app/gzac/src/main/resources/config/pbac/resource.permission.json
@@ -1,5 +1,5 @@
 {
-    "changesetId": "resource-v2",
+    "changesetId": "resource-v3",
     "permissions": [
         {
             "resourceType": "com.ritense.resource.authorization.ResourcePermission",
@@ -29,12 +29,107 @@
         {
             "resourceType": "com.ritense.resource.authorization.ResourcePermission",
             "action": "view_list",
-            "roleKey": "ROLE_USER"
+            "roleKey": "ROLE_USER",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "operator": "in",
+                            "value": [
+                                "bezwaar"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resourceType": "com.ritense.resource.authorization.ResourcePermission",
+            "action": "view",
+            "roleKey": "ROLE_USER",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "operator": "in",
+                            "value": [
+                                "bezwaar"
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "resourceType": "com.ritense.resource.authorization.ResourcePermission",
             "action": "create",
-            "roleKey": "ROLE_USER"
+            "roleKey": "ROLE_USER",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "operator": "in",
+                            "value": [
+                                "bezwaar"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resourceType": "com.ritense.resource.authorization.ResourcePermission",
+            "action": "modify",
+            "roleKey": "ROLE_USER",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "operator": "in",
+                            "value": [
+                                "bezwaar"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resourceType": "com.ritense.resource.authorization.ResourcePermission",
+            "action": "delete",
+            "roleKey": "ROLE_USER",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "operator": "in",
+                            "value": [
+                                "bezwaar"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/backend/app/gzac/src/main/resources/config/pbac/resource.permission.json
+++ b/backend/app/gzac/src/main/resources/config/pbac/resource.permission.json
@@ -37,7 +37,7 @@
                     "conditions": [
                         {
                             "type": "field",
-                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "field": "documentDefinitionId.name",
                             "operator": "in",
                             "value": [
                                 "bezwaar"
@@ -58,7 +58,7 @@
                     "conditions": [
                         {
                             "type": "field",
-                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "field": "documentDefinitionId.name",
                             "operator": "in",
                             "value": [
                                 "bezwaar"
@@ -79,7 +79,7 @@
                     "conditions": [
                         {
                             "type": "field",
-                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "field": "documentDefinitionId.name",
                             "operator": "in",
                             "value": [
                                 "bezwaar"
@@ -100,7 +100,7 @@
                     "conditions": [
                         {
                             "type": "field",
-                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "field": "documentDefinitionId.name",
                             "operator": "in",
                             "value": [
                                 "bezwaar"
@@ -121,7 +121,7 @@
                     "conditions": [
                         {
                             "type": "field",
-                            "field": "documentDefinitionId.caseDefinitionId.key",
+                            "field": "documentDefinitionId.name",
                             "operator": "in",
                             "value": [
                                 "bezwaar"

--- a/backend/contract/src/main/kotlin/com/ritense/valtimo/contract/event/DocumentDeletedEvent.kt
+++ b/backend/contract/src/main/kotlin/com/ritense/valtimo/contract/event/DocumentDeletedEvent.kt
@@ -19,5 +19,5 @@ package com.ritense.valtimo.contract.event
 import java.util.UUID
 
 class DocumentDeletedEvent(
-    val documentId: UUID
+    val caseDocumentId: UUID
 )

--- a/backend/document/src/test/java/com/ritense/document/web/rest/JsonSchemaDocumentResourceIntegrationTest.java
+++ b/backend/document/src/test/java/com/ritense/document/web/rest/JsonSchemaDocumentResourceIntegrationTest.java
@@ -286,7 +286,7 @@ class JsonSchemaDocumentResourceIntegrationTest extends BaseIntegrationTest {
 
         assertEquals(1, events.stream(DocumentDeletedEvent.class).count());
         var applicationEvent = events.stream(DocumentDeletedEvent.class).findFirst().orElseThrow();
-        assertEquals(document.id().getId(), applicationEvent.getDocumentId());
+        assertEquals(document.id().getId(), applicationEvent.getCaseDocumentId());
 
         ArgumentCaptor<Supplier<BaseEvent>> outboxEventCaptor = ArgumentCaptor.forClass(Supplier.class);
         verify(outboxService, times(2)).send(outboxEventCaptor.capture());

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/ProcessDocumentDeletedEventListener.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/ProcessDocumentDeletedEventListener.kt
@@ -35,12 +35,12 @@ class ProcessDocumentDeletedEventListener(
 ) {
     @EventListener(DocumentDeletedEvent::class)
     fun handle(event: DocumentDeletedEvent) {
-        withLoggingContext(JsonSchemaDocument::class, event.documentId) {
-            logger.info { "Deleting all process instances for deleted document ${event.documentId}" }
+        withLoggingContext(JsonSchemaDocument::class, event.caseDocumentId) {
+            logger.info { "Deleting all process instances for deleted document ${event.caseDocumentId}" }
 
             runWithoutAuthorization {
                 runtimeService.createProcessInstanceQuery()
-                    .processInstanceBusinessKey(event.documentId.toString())
+                    .processInstanceBusinessKey(event.caseDocumentId.toString())
                     .rootProcessInstances()
                     .list()
                     .forEach {
@@ -53,10 +53,10 @@ class ProcessDocumentDeletedEventListener(
                             false
                         )
                         processDocumentAssociationService.getProcessDocumentInstanceResult(
-                            CamundaProcessJsonSchemaDocumentInstanceId.existingId(CamundaProcessInstanceId(it.processInstanceId), JsonSchemaDocumentId.existingId(event.documentId))
+                            CamundaProcessJsonSchemaDocumentInstanceId.existingId(CamundaProcessInstanceId(it.processInstanceId), JsonSchemaDocumentId.existingId(event.caseDocumentId))
                         )?.let { processDocumentInstance ->
                             if (processDocumentInstance.isError) {
-                                logger.debug { "Document ${event.documentId} is not related to process ${it.processInstanceId}. No ProcessDocumentInstance to delete." }
+                                logger.debug { "Document ${event.caseDocumentId} is not related to process ${it.processInstanceId}. No ProcessDocumentInstance to delete." }
                             } else {
                                 processDocumentInstance.resultingValue().map(ProcessDocumentInstance::processDocumentInstanceId)
                                     .ifPresent(processDocumentAssociationService::deleteProcessDocumentInstance)

--- a/backend/resource/src/main/kotlin/com/ritense/resource/authorization/ResourcePermission.kt
+++ b/backend/resource/src/main/kotlin/com/ritense/resource/authorization/ResourcePermission.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,8 @@
 
 package com.ritense.resource.authorization
 
-class ResourcePermission
+import java.util.UUID
+
+class ResourcePermission(
+    val caseDocumentId: UUID? = null
+)

--- a/backend/resource/src/main/kotlin/com/ritense/resource/authorization/ResourceSpecification.kt
+++ b/backend/resource/src/main/kotlin/com/ritense/resource/authorization/ResourceSpecification.kt
@@ -26,8 +26,8 @@ import jakarta.persistence.criteria.Root
 
 class ResourceSpecification(
     authRequest: AuthorizationRequest<ResourcePermission>,
-    permissions: List<Permission>,
-) : AuthorizationSpecification<ResourcePermission>(authRequest, permissions) {
+    permissionSupplier: () -> List<Permission>,
+) : AuthorizationSpecification<ResourcePermission>(authRequest, permissionSupplier) {
 
     override fun toPredicate(
         root: Root<ResourcePermission>,

--- a/backend/resource/src/main/kotlin/com/ritense/resource/authorization/ResourceSpecificationFactory.kt
+++ b/backend/resource/src/main/kotlin/com/ritense/resource/authorization/ResourceSpecificationFactory.kt
@@ -29,12 +29,12 @@ class ResourceSpecificationFactory : AuthorizationSpecificationFactory<ResourceP
 
     override fun create(
         request: AuthorizationRequest<ResourcePermission>,
-        permissions: List<Permission>
+        permissionSupplier: () -> List<Permission>
     ): AuthorizationSpecification<ResourcePermission> {
-        return ResourceSpecification(request, permissions)
+        return ResourceSpecification(request, permissionSupplier)
     }
 
-    override fun canCreate(request: AuthorizationRequest<*>, permissions: List<Permission>): Boolean {
+    override fun canCreate(request: AuthorizationRequest<*>, permissionSupplier: () -> List<Permission>): Boolean {
         return ResourcePermission::class.java == request.resourceType
     }
 }

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiAutoConfiguration.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiAutoConfiguration.kt
@@ -19,9 +19,11 @@ package com.ritense.documentenapi
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.authorization.AuthorizationService
 import com.ritense.catalogiapi.service.CatalogiService
+import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
 import com.ritense.document.service.DocumentDefinitionService
 import com.ritense.document.service.DocumentService
 import com.ritense.document.service.impl.JsonSchemaDocumentDefinitionService
+import com.ritense.documentenapi.authorization.ZgwResourceDocumentMapper
 import com.ritense.documentenapi.client.DocumentenApiClient
 import com.ritense.documentenapi.deployment.ZgwDocumentListColumnDeploymentService
 import com.ritense.documentenapi.deployment.ZgwDocumentUploadFieldsDeploymentService
@@ -68,6 +70,13 @@ import javax.sql.DataSource
 @EnableJpaRepositories(basePackages = ["com.ritense.documentenapi.repository"])
 @EntityScan("com.ritense.documentenapi.domain")
 class DocumentenApiAutoConfiguration {
+
+    @Bean
+    fun zgwResourceDocumentMapper(
+        documentRepository: JsonSchemaDocumentRepository
+    ): ZgwResourceDocumentMapper {
+        return ZgwResourceDocumentMapper(documentRepository)
+    }
 
     @Bean
     fun documentenApiClient(

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -202,8 +202,19 @@ class DocumentenApiPlugin(
             ?: throw IllegalStateException("Failed to download document. No process variable '$DOCUMENT_URL_PROCESS_VAR' found.")
         check(documentUrlString.startsWith(url.toASCIIString())) { "Failed to download document with url '$documentUrlString'. Document isn't part of Documenten API with url '$url'." }
         val documentUrl = URI(documentUrlString)
-        val metaData = client.getInformatieObject(authenticationPluginConfiguration, documentUrl)
-        val content = client.downloadInformatieObjectContent(authenticationPluginConfiguration, documentUrl)
+        val caseDocumentId = UUID.fromString(execution.businessKey)
+            ?: throw IllegalStateException("Failed to store document. Business key is null.")
+
+        val metaData = client.getInformatieObject(
+            authenticationPluginConfiguration,
+            caseDocumentId,
+            documentUrl
+        )
+        val content = client.downloadInformatieObjectContent(
+            authenticationPluginConfiguration,
+            caseDocumentId,
+            documentUrl
+        )
 
         val metaDataMap = objectMapper.convertValue<MutableMap<String, Any>>(metaData)
         metaDataMap[MetadataType.DOCUMENT_ID.key] = execution.businessKey
@@ -221,29 +232,36 @@ class DocumentenApiPlugin(
         return tempResourceId
     }
 
-    fun downloadInformatieObject(objectId: String): InputStream {
-        return client.downloadInformatieObjectContent(authenticationPluginConfiguration, url, objectId)
+    fun downloadInformatieObject(caseDocumentId: UUID?, objectId: String): InputStream {
+        return client.downloadInformatieObjectContent(authenticationPluginConfiguration, url, objectId, caseDocumentId)
     }
 
-    fun getInformatieObject(objectId: String): DocumentInformatieObject {
-        return client.getInformatieObject(authenticationPluginConfiguration, url, objectId)
+    fun getInformatieObject(objectId: String, caseDocumentId: UUID?): DocumentInformatieObject {
+        return client.getInformatieObject(authenticationPluginConfiguration, url, caseDocumentId, objectId)
     }
 
-    fun getInformatieObject(objectUrl: URI): DocumentInformatieObject {
-        return client.getInformatieObject(authenticationPluginConfiguration, objectUrl)
+    fun getInformatieObject(objectUrl: URI, caseDocumentId: UUID?): DocumentInformatieObject {
+        return client.getInformatieObject(authenticationPluginConfiguration, caseDocumentId, objectUrl)
     }
 
     fun getInformatieObjecten(
+        documentId: UUID,
         documentSearchRequest: DocumentSearchRequest,
         pageable: Pageable
     ): Page<DocumentInformatieObject> {
-        return client.getInformatieObjecten(authenticationPluginConfiguration, url, pageable, documentSearchRequest)
+        return client.getInformatieObjecten(
+            authenticationPluginConfiguration,
+            documentId,
+            url,
+            pageable,
+            documentSearchRequest
+        )
     }
 
-    fun deleteInformatieObject(objectUrl: URI) {
+    fun deleteInformatieObject(caseDocumentId: UUID?, objectUrl: URI) {
         logger.info { "Deleting informatie object from documenten API with url $objectUrl" }
-        documentDeleteHandlers.forEach { it.preDocumentDelete(objectUrl) }
-        client.deleteInformatieObject(authenticationPluginConfiguration, objectUrl)
+        documentDeleteHandlers.forEach { it.preDocumentDelete(objectUrl, caseDocumentId) }
+        client.deleteInformatieObject(authenticationPluginConfiguration, caseDocumentId, objectUrl)
     }
 
     fun createInformatieObjectUrl(objectId: String) = UriComponentsBuilder
@@ -252,7 +270,11 @@ class DocumentenApiPlugin(
         .build()
         .toUri()
 
-    fun modifyInformatieObject(documentUrl: URI, patchDocumentRequest: PatchDocumentRequest): DocumentInformatieObject {
+    fun modifyInformatieObject(
+        caseDocumentId: UUID?,
+        documentUrl: URI,
+        patchDocumentRequest: PatchDocumentRequest
+    ): DocumentInformatieObject {
         val documentLock = client.lockInformatieObject(authenticationPluginConfiguration, documentUrl)
         try {
             patchDocumentRequest.lock = documentLock.lock
@@ -260,14 +282,19 @@ class DocumentenApiPlugin(
             runWithoutAuthorization {
                 require(
                     documentenApiVersionService.getVersionByTag(apiVersion).supportsUpdatingDefinitiveDocument
-                        || getInformatieObject(documentUrl).status != DocumentStatusType.DEFINITIEF
+                        || getInformatieObject(documentUrl, caseDocumentId).status != DocumentStatusType.DEFINITIEF
                 ) {
                     "InformatieObject ${documentUrl.path.substringAfterLast("/")} with status 'definitief' cannot be updated in Documenten API with '$apiVersion'"
                 }
             }
 
             val modifiedDocument =
-                client.modifyInformatieObject(authenticationPluginConfiguration, documentUrl, patchDocumentRequest)
+                client.modifyInformatieObject(
+                    authenticationPluginConfiguration,
+                    documentUrl,
+                    patchDocumentRequest,
+                    caseDocumentId
+                )
             return modifiedDocument
         } finally {
             client.unlockInformatieObject(authenticationPluginConfiguration, documentUrl, documentLock)
@@ -303,6 +330,9 @@ class DocumentenApiPlugin(
         informatieobjecttype: String? = null,
         storedDocumentKey: String,
     ): CreateDocumentResult {
+        val caseDocumentId = execution.businessKey?.let { UUID.fromString(it) }
+            ?: throw IllegalStateException("Failed to store document. Business key is null.")
+
         val vertrouwelijkheidaanduidingEnum = Vertrouwelijkheid.fromKey(
             vertrouwelijkheidaanduiding ?: getUploadField(
                 metadata,
@@ -332,7 +362,13 @@ class DocumentenApiPlugin(
             trefwoorden = trefwoorden,
         )
         logger.info { "Store document $request" }
-        val documentCreateResult = client.storeDocument(authenticationPluginConfiguration, url, request)
+
+        val documentCreateResult = client.storeDocument(
+            authenticationPluginConfiguration,
+            url,
+            caseDocumentId,
+            request
+        )
 
         val event = DocumentCreated(
             documentCreateResult.url,

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/authorization/ZgwResourceDocumentMapper.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/authorization/ZgwResourceDocumentMapper.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.documentenapi.authorization
+
+import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthorization
+import com.ritense.authorization.AuthorizationEntityMapper
+import com.ritense.authorization.AuthorizationEntityMapperResult
+import com.ritense.document.domain.impl.JsonSchemaDocument
+import com.ritense.document.domain.impl.JsonSchemaDocumentId
+import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
+import com.ritense.resource.authorization.ResourcePermission
+import jakarta.persistence.criteria.AbstractQuery
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.Root
+
+class ZgwResourceDocumentMapper(
+    private val documentRepository: JsonSchemaDocumentRepository
+) : AuthorizationEntityMapper<ResourcePermission, JsonSchemaDocument> {
+
+    override fun mapRelated(
+        entity: ResourcePermission
+    ): List<JsonSchemaDocument> {
+        return runWithoutAuthorization {
+            entity.caseDocumentId?.let {
+                documentRepository.findById(JsonSchemaDocumentId.existingId(it))
+                .map { doc -> listOf(doc) }
+                .orElse(emptyList())
+            } ?: emptyList()
+        }
+    }
+
+    override fun mapQuery(
+        root: Root<ResourcePermission>,
+        query: AbstractQuery<*>,
+        criteriaBuilder: CriteriaBuilder,
+    ): AuthorizationEntityMapperResult<JsonSchemaDocument> {
+        throw UnsupportedOperationException("Mapping query for ResourcePermission to JsonSchemaDocument is not supported")
+    }
+
+    override fun supports(fromClass: Class<*>, toClass: Class<*>): Boolean {
+        return fromClass == ResourcePermission::class.java && toClass == JsonSchemaDocument::class.java
+    }
+}

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/DocumentenApiClient.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/DocumentenApiClient.kt
@@ -52,6 +52,7 @@ import org.springframework.web.util.UriBuilder
 import org.springframework.web.util.UriComponentsBuilder
 import java.io.InputStream
 import java.net.URI
+import java.util.UUID
 import kotlin.math.min
 
 @SkipComponentScan
@@ -67,6 +68,7 @@ class DocumentenApiClient(
     fun storeDocument(
         authentication: DocumentenApiAuthentication,
         baseUrl: URI,
+        caseDocumentId: UUID,
         request: CreateDocumentRequest
     ): CreateDocumentResult {
         if (authorizationEnabled) {
@@ -74,10 +76,11 @@ class DocumentenApiClient(
                 EntityAuthorizationRequest(
                     ResourcePermission::class.java,
                     ResourcePermissionActionProvider.CREATE,
-                    ResourcePermission()
+                    ResourcePermission(caseDocumentId)
                 )
             )
         }
+
         val result = restClient(authentication)
             .post()
             .uri {
@@ -132,13 +135,15 @@ class DocumentenApiClient(
     fun getInformatieObject(
         authentication: DocumentenApiAuthentication,
         baseUrl: URI,
+        caseDocumentId: UUID?,
         objectId: String,
     ): DocumentInformatieObject {
-        return getInformatieObject(authentication, toObjectUrl(baseUrl, objectId))
+        return getInformatieObject(authentication, caseDocumentId, toObjectUrl(baseUrl, objectId))
     }
 
     fun getInformatieObject(
         authentication: DocumentenApiAuthentication,
+        caseDocumentId: UUID?,
         objectUrl: URI
     ): DocumentInformatieObject {
         val result = restClient(authentication)
@@ -152,7 +157,7 @@ class DocumentenApiClient(
                 EntityAuthorizationRequest(
                     ResourcePermission::class.java,
                     ResourcePermissionActionProvider.VIEW_LIST,
-                    ResourcePermission()
+                    ResourcePermission(caseDocumentId)
                 )
             )
         }
@@ -169,6 +174,7 @@ class DocumentenApiClient(
 
     fun getInformatieObjecten(
         authentication: DocumentenApiAuthentication,
+        caseDocumentId: UUID,
         baseUrl: URI,
         pageable: Pageable,
         documentSearchRequest: DocumentSearchRequest,
@@ -182,7 +188,7 @@ class DocumentenApiClient(
             EntityAuthorizationRequest(
                 ResourcePermission::class.java,
                 ResourcePermissionActionProvider.VIEW_LIST,
-                ResourcePermission()
+                ResourcePermission(caseDocumentId)
             )
         )) {
             return org.springframework.data.domain.Page.empty(pageable)
@@ -247,13 +253,16 @@ class DocumentenApiClient(
         authentication: DocumentenApiAuthentication,
         baseUrl: URI,
         objectId: String,
+        caseDocumentId: UUID?
     ) = downloadInformatieObjectContent(
         authentication,
+        caseDocumentId,
         toObjectUrl(baseUrl, objectId)
     )
 
     fun downloadInformatieObjectContent(
         authentication: DocumentenApiAuthentication,
+        caseDocumentId: UUID?,
         objectUrl: URI
     ): InputStream {
         if (authorizationEnabled) {
@@ -261,7 +270,7 @@ class DocumentenApiClient(
                 EntityAuthorizationRequest(
                     ResourcePermission::class.java,
                     ResourcePermissionActionProvider.VIEW,
-                    ResourcePermission()
+                    ResourcePermission(caseDocumentId)
                 )
             )
         }
@@ -321,13 +330,13 @@ class DocumentenApiClient(
             .toBodilessEntity()
     }
 
-    fun deleteInformatieObject(authentication: DocumentenApiAuthentication, url: URI) {
+    fun deleteInformatieObject(authentication: DocumentenApiAuthentication, caseDocumentId: UUID?, url: URI) {
         if (authorizationEnabled) {
             authorizationService.requirePermission(
                 EntityAuthorizationRequest(
                     ResourcePermission::class.java,
                     ResourcePermissionActionProvider.DELETE,
-                    ResourcePermission()
+                    ResourcePermission(caseDocumentId)
                 )
             )
         }
@@ -344,7 +353,8 @@ class DocumentenApiClient(
     fun modifyInformatieObject(
         authentication: DocumentenApiAuthentication,
         documentUrl: URI,
-        patchDocumentRequest: PatchDocumentRequest
+        patchDocumentRequest: PatchDocumentRequest,
+        caseDocumentId: UUID? = null
     ): DocumentInformatieObject {
 
         if (authorizationEnabled) {
@@ -352,7 +362,7 @@ class DocumentenApiClient(
                 EntityAuthorizationRequest(
                     ResourcePermission::class.java,
                     ResourcePermissionActionProvider.MODIFY,
-                    ResourcePermission()
+                    ResourcePermission(caseDocumentId)
                 )
             )
         }

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/security/DocumentenApiHttpSecurityConfigurer.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/security/DocumentenApiHttpSecurityConfigurer.kt
@@ -35,6 +35,7 @@ class DocumentenApiHttpSecurityConfigurer : HttpSecurityConfigurer {
                     .requestMatchers(antMatcher(GET, "/api/v1/documenten-api/{pluginConfigurationId}/files/{documentId}/download")).authenticated()
                     .requestMatchers(antMatcher(PUT, "/api/v1/documenten-api/{pluginConfigurationId}/files/{documentId}")).authenticated()
                     .requestMatchers(antMatcher(DELETE, "/api/v1/documenten-api/{pluginConfigurationId}/files/{documentId}")).authenticated()
+
                     .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionName}/zgw-document-column")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionName}/documenten-api/version")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionName}/zgw-document/trefwoord")).authenticated()

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/service/DocumentenApiService.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/service/DocumentenApiService.kt
@@ -47,6 +47,7 @@ import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.service.PluginService
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.zgw.LoggingConstants.DOCUMENTEN_API
+import com.ritense.zgw.LoggingConstants.ZAKEN_API
 import mu.KLogger
 import mu.KotlinLogging
 import org.springframework.data.domain.Page
@@ -75,20 +76,22 @@ class DocumentenApiService(
 
     fun downloadInformatieObject(
         @LoggableResource(resourceType = PluginConfigurationId::class) pluginConfigurationId: String,
+        @LoggableResource(resourceTypeName = ZAKEN_API.ZAAK) caseDocumentId: UUID?,
         @LoggableResource(resourceTypeName = DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT) documentId: String
     ): InputStream {
         logger.info { "Download informatie object $documentId" }
         val documentApiPlugin = pluginService.createInstance<DocumentenApiPlugin>(pluginConfigurationId)
-        return documentApiPlugin.downloadInformatieObject(documentId)
+        return documentApiPlugin.downloadInformatieObject(caseDocumentId, documentId)
     }
 
     fun getInformatieObject(
         @LoggableResource(resourceType = PluginConfigurationId::class) pluginConfigurationId: String,
+        @LoggableResource(resourceTypeName = ZAKEN_API.ZAAK) caseDocumentId: UUID?,
         @LoggableResource(resourceTypeName = DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT) documentId: String
     ): DocumentInformatieObject {
         logger.debug { "Get informatie object $documentId" }
         val documentApiPlugin = pluginService.createInstance<DocumentenApiPlugin>(pluginConfigurationId)
-        return documentApiPlugin.getInformatieObject(documentId)
+        return documentApiPlugin.getInformatieObject(documentId, caseDocumentId)
     }
 
     fun getCaseInformatieObjecten(
@@ -108,11 +111,12 @@ class DocumentenApiService(
             check(version.sortableColumns.contains(sortColumn.property))
         }
         logger.debug { "Get Case Informatie Objecten $documentSearchRequest" }
-        return plugin.getInformatieObjecten(documentSearchRequest, pageable)
+        return plugin.getInformatieObjecten( documentId, documentSearchRequest, pageable)
     }
 
     fun modifyInformatieObject(
         @LoggableResource(resourceType = PluginConfigurationId::class) pluginConfigurationId: String,
+        @LoggableResource(resourceTypeName = ZAKEN_API.ZAAK) caseDocumentId: UUID?,
         @LoggableResource(resourceTypeName = DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT) documentId: String,
         modifyDocumentRequest: ModifyDocumentRequest
     ): RelatedFile? {
@@ -130,6 +134,7 @@ class DocumentenApiService(
         val documentUrl = documentApiPlugin.createInformatieObjectUrl(documentId)
         logger.info { "Modify Informatie Object $documentUrl $modifyDocumentRequest " }
         val informatieObject = documentApiPlugin.modifyInformatieObject(
+            caseDocumentId,
             documentUrl,
             PatchDocumentRequest(modifyDocumentRequest)
         )
@@ -137,22 +142,32 @@ class DocumentenApiService(
     }
 
     fun deleteInformatieObject(
-        @LoggableResource(resourceTypeName = DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT) documentUrl: URI
+        @LoggableResource(resourceTypeName = DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT) documentUrl: URI,
+        @LoggableResource(resourceTypeName = ZAKEN_API.ZAAK) caseId: UUID?
     ) {
         val documentApiPlugin: DocumentenApiPlugin = pluginService.createInstance(
             DocumentenApiPlugin::class.java,
             DocumentenApiPlugin.findConfigurationByUrl(documentUrl)
         ) ?: throw IllegalArgumentException("Trying to delete informatie object by url, but could not find ${DocumentenApiPlugin::class.simpleName} instance for informatieobjectUrl $documentUrl")
-        documentApiPlugin.deleteInformatieObject(documentUrl)
+        documentApiPlugin.deleteInformatieObject( caseId, documentUrl)
     }
 
     fun deleteInformatieObject(
         @LoggableResource(resourceType = PluginConfigurationId::class) pluginConfigurationId: String,
+        @LoggableResource(resourceTypeName = ZAKEN_API.ZAAK ) caseDocumentId: UUID?,
         @LoggableResource(resourceTypeName = DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT) documentId: String
     ) {
         val documentApiPlugin: DocumentenApiPlugin = pluginService.createInstance(pluginConfigurationId)
         val documentUrl = documentApiPlugin.createInformatieObjectUrl(documentId)
-        documentApiPlugin.deleteInformatieObject(documentUrl)
+        documentApiPlugin.deleteInformatieObject(caseDocumentId, documentUrl)
+    }
+
+    fun deleteInformatieObject(
+        @LoggableResource(resourceType = PluginConfigurationId::class) documentApiPlugin: DocumentenApiPlugin,
+        @LoggableResource(resourceTypeName = ZAKEN_API.ZAAK ) caseDocumentId: UUID?,
+        @LoggableResource(resourceTypeName = DOCUMENTEN_API.ENKELVOUDIG_INFORMATIE_OBJECT) documentUrl: URI
+    ) {
+        documentApiPlugin.deleteInformatieObject(caseDocumentId, documentUrl)
     }
 
     @Transactional(readOnly = true)

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/web/rest/DocumentenApiResource.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/web/rest/DocumentenApiResource.kt
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URLConnection
+import java.util.UUID
 
 @RestController
 @SkipComponentScan
@@ -47,14 +48,16 @@ class DocumentenApiResource(
     private val documentenApiService: DocumentenApiService,
     private val documentenApiVersionService: DocumentenApiVersionService
 ) {
+    @Deprecated("Will be removed in 14.0", ReplaceWith("ZaakDocumentResource.downloadDocument(pluginConfigurationId, caseDocumentId, documentId)"))
     @GetMapping("/v1/documenten-api/{pluginConfigurationId}/files/{documentId}/download")
     fun downloadDocument(
         @LoggableResource(resourceType = PluginConfiguration::class) @PathVariable(name = "pluginConfigurationId") pluginConfigurationId: String,
         @PathVariable(name = "documentId") documentId: String,
     ): ResponseEntity<InputStreamResource> {
 
-        val documentInputStream = documentenApiService.downloadInformatieObject(pluginConfigurationId, documentId)
-        val documentMetadata = documentenApiService.getInformatieObject(pluginConfigurationId, documentId)
+        val caseDocumentId: UUID? = null
+        val documentMetadata = documentenApiService.getInformatieObject(pluginConfigurationId, caseDocumentId,documentId)
+        val documentInputStream = documentenApiService.downloadInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
 
         val responseHeaders = HttpHeaders()
         responseHeaders.set("Content-Disposition", "attachment; filename=\"${documentMetadata.bestandsnaam}\"")
@@ -71,23 +74,34 @@ class DocumentenApiResource(
             .body(InputStreamResource(documentInputStream))
     }
 
+    @Deprecated("Will be removed in 14.0", ReplaceWith("ZaakDocumentResource.modifyDocument(pluginConfigurationId, caseDocumentId, documentId)"))
     @PutMapping("/v1/documenten-api/{pluginConfigurationId}/files/{documentId}")
     fun modifyDocument(
         @LoggableResource(resourceType = PluginConfiguration::class) @PathVariable(name = "pluginConfigurationId") pluginConfigurationId: String,
         @PathVariable(name = "documentId") documentId: String,
         @RequestBody modifyDocumentRequest: ModifyDocumentRequest,
     ): ResponseEntity<RelatedFile> {
+        val caseDocumentId: UUID? = null
         return ResponseEntity
             .ok()
-            .body(documentenApiService.modifyInformatieObject(pluginConfigurationId, documentId, modifyDocumentRequest))
+            .body(
+                documentenApiService.modifyInformatieObject(
+                    pluginConfigurationId,
+                    caseDocumentId,
+                    documentId,
+                    modifyDocumentRequest
+                )
+            )
     }
 
+    @Deprecated("Will be removed in 14.0", ReplaceWith("ZaakDocumentResource.deleteDocument(pluginConfigurationId, caseDocumentId, documentId)"))
     @DeleteMapping("/v1/documenten-api/{pluginConfigurationId}/files/{documentId}")
     fun deleteDocument(
         @LoggableResource(resourceType = PluginConfiguration::class) @PathVariable(name = "pluginConfigurationId") pluginConfigurationId: String,
         @PathVariable(name = "documentId") documentId: String,
     ): ResponseEntity<Unit> {
-        documentenApiService.deleteInformatieObject(pluginConfigurationId, documentId)
+        val caseDocumentId: UUID? = null
+        documentenApiService.deleteInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
         return ResponseEntity
             .noContent()
             .build()

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -85,6 +85,48 @@ internal class DocumentenApiPluginTest {
     }
 
     @Test
+    fun `should throw error when businessKey is null`() {
+        val storageService: TemporaryResourceStorageService = mock()
+        val applicationEventPublisher: ApplicationEventPublisher = mock()
+        val objectMapper = MapperSingleton.get()
+        val documentenApiVersionService: DocumentenApiVersionService = mock()
+        val executionMock = mock<DelegateExecution>()
+        val virusScanEnabledForDocumentenApiPlugin = false
+
+        whenever(executionMock.getVariable("localDocumentVariableName"))
+            .thenReturn("localDocumentLocation")
+        whenever(executionMock.businessKey).thenReturn(null)
+
+        val plugin = DocumentenApiPlugin(
+            client,
+            storageService,
+            applicationEventPublisher,
+            objectMapper,
+            mutableListOf(),
+            documentenApiVersionService,
+            pluginService
+        )
+        plugin.url = URI("http://some-url")
+        plugin.bronorganisatie = "123456789"
+
+        val exception = assertThrows<IllegalStateException> {
+            plugin.storeTemporaryDocument(
+                executionMock,
+                "test.ext",
+                Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
+                "title",
+                "description",
+                "localDocumentVariableName",
+                "storedDocumentVariableName",
+                "type",
+                "taal",
+                IN_BEWERKING
+            )
+        }
+        assertEquals("Failed to store document. Business key is null.", exception.message)
+    }
+
+    @Test
     fun `should call client to store file`() {
         val storageService: TemporaryResourceStorageService = mock()
         val applicationEventPublisher: ApplicationEventPublisher = mock()
@@ -108,9 +150,10 @@ internal class DocumentenApiPluginTest {
 
         whenever(executionMock.getVariable("localDocumentVariableName"))
             .thenReturn("localDocumentLocation")
+        whenever(executionMock.businessKey).thenReturn("123e4567-e89b-12d3-a456-426655440000")
         whenever(storageService.getResourceContentAsInputStream("localDocumentLocation"))
             .thenReturn(inputStream)
-        whenever(client.storeDocument(any(), any(), any())).thenReturn(result)
+        whenever(client.storeDocument(any(), any(), any(), any())).thenReturn(result)
 
         val plugin = DocumentenApiPlugin(
             client,
@@ -152,7 +195,7 @@ internal class DocumentenApiPluginTest {
 
         val apiRequestCaptor = argumentCaptor<CreateDocumentRequest>()
         val eventCaptor = argumentCaptor<DocumentCreated>()
-        verify(client).storeDocument(any(), any(), apiRequestCaptor.capture())
+        verify(client).storeDocument(any(), any(), any(), apiRequestCaptor.capture())
         verify(applicationEventPublisher).publishEvent(eventCaptor.capture())
         verify(executionMock).setVariable("storedDocumentVariableName", "returnedUrl")
 
@@ -219,8 +262,8 @@ internal class DocumentenApiPluginTest {
                     "informatieobjecttype" to "type"
                 )
             )
-        whenever(client.storeDocument(any(), any(), any())).thenReturn(result)
-
+        whenever(client.storeDocument(any(), any(), any(), any())).thenReturn(result)
+        whenever(executionMock.businessKey).thenReturn("123e4567-e89b-12d3-a456-426655440000")
         whenever(pluginConfiguration.id).thenReturn(pluginConfigurationId)
         whenever(pluginConfigurationId.id).thenReturn(UUID.randomUUID())
 
@@ -249,7 +292,7 @@ internal class DocumentenApiPluginTest {
         plugin.storeUploadedDocument(executionMock)
 
         val apiRequestCaptor = argumentCaptor<CreateDocumentRequest>()
-        verify(client).storeDocument(any(), any(), apiRequestCaptor.capture())
+        verify(client).storeDocument(any(), any(), any(), apiRequestCaptor.capture())
         verify(executionMock).setVariable(DOCUMENT_URL_PROCESS_VAR, "returnedUrl")
 
         val request = apiRequestCaptor.firstValue
@@ -292,6 +335,7 @@ internal class DocumentenApiPluginTest {
 
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR))
             .thenReturn("localDocumentLocation")
+        whenever(executionMock.businessKey).thenReturn("123e4567-e89b-12d3-a456-426655440000")
         whenever(storageService.getResourceContentAsInputStream("localDocumentLocation"))
             .thenReturn(inputStream)
         whenever(storageService.getResourceMetadata("localDocumentLocation"))
@@ -304,7 +348,7 @@ internal class DocumentenApiPluginTest {
                     "informatieobjecttype" to "type"
                 )
             )
-        whenever(client.storeDocument(any(), any(), any())).thenReturn(result)
+        whenever(client.storeDocument(any(), any(), any(), any())).thenReturn(result)
 
         val plugin = DocumentenApiPlugin(
             client,
@@ -334,7 +378,7 @@ internal class DocumentenApiPluginTest {
         plugin.storeUploadedDocument(executionMock)
 
         val apiRequestCaptor = argumentCaptor<CreateDocumentRequest>()
-        verify(client).storeDocument(any(), any(), apiRequestCaptor.capture())
+        verify(client).storeDocument(any(), any(), any(), apiRequestCaptor.capture())
         verify(executionMock).setVariable(DOCUMENT_URL_PROCESS_VAR, "returnedUrl")
 
         val request = apiRequestCaptor.firstValue
@@ -373,13 +417,19 @@ internal class DocumentenApiPluginTest {
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
         plugin.authenticationPluginConfiguration = authenticationMock
-
+        val caseDocumentId = UUID.randomUUID()
         val informatieObjectUrl = URI("http://some-url/informatie-object/123")
-        plugin.getInformatieObject(informatieObjectUrl)
+        plugin.getInformatieObject(informatieObjectUrl, caseDocumentId)
 
         val informatieObjectUrlCaptor = argumentCaptor<URI>()
         val authorizationCaptor = argumentCaptor<DocumentenApiAuthentication>()
-        verify(client).getInformatieObject(authorizationCaptor.capture(), informatieObjectUrlCaptor.capture())
+        val caseDocumentIdCaptor = argumentCaptor<UUID>()
+
+        verify(client).getInformatieObject(
+            authorizationCaptor.capture(),
+            caseDocumentIdCaptor.capture(),
+            informatieObjectUrlCaptor.capture()
+        )
 
         assertEquals(informatieObjectUrl, informatieObjectUrlCaptor.firstValue)
         assertEquals(authenticationMock, authorizationCaptor.firstValue)
@@ -392,6 +442,7 @@ internal class DocumentenApiPluginTest {
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val documentenApiVersionService: DocumentenApiVersionService = mock()
         val informatieObjectUrl = URI("http://some-url/informatie-object/123")
+        val caseDocumentId = UUID.randomUUID()
         val plugin = DocumentenApiPlugin(
             client,
             storageService,
@@ -407,7 +458,7 @@ internal class DocumentenApiPluginTest {
         plugin.apiVersion = "1.0.0"
         whenever(documentenApiVersionService.getVersionByTag(plugin.apiVersion)).thenReturn(MINIMUM_VERSION)
         whenever(client.lockInformatieObject(authenticationMock, informatieObjectUrl)).thenReturn(DocumentLock("lock"))
-        whenever( client.getInformatieObject(authenticationMock, informatieObjectUrl)).thenReturn(
+        whenever( client.getInformatieObject(authenticationMock, caseDocumentId, informatieObjectUrl)).thenReturn(
             DocumentInformatieObject(
                 url = informatieObjectUrl,
                 bronorganisatie = Rsin("000000000"),
@@ -422,6 +473,7 @@ internal class DocumentenApiPluginTest {
 
         val exception = assertThrows<Exception> {
             plugin.modifyInformatieObject(
+                caseDocumentId,
                 informatieObjectUrl,
                 PatchDocumentRequest(LocalDate.now(), "Nieuwe titel", "auteur", DEFINITIEF, "taal")
             )

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientIT.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientIT.kt
@@ -92,6 +92,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
         documentenApiClient.storeDocument(
             documentenApiPlugin.authenticationPluginConfiguration,
             documentenApiPlugin.url,
+            CASE_DOCUMENT_ID,
             CreateDocumentRequest(
                 bronorganisatie = documentenApiPlugin.bronorganisatie,
                 creatiedatum = LocalDate.now(),
@@ -113,6 +114,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
             documentenApiClient.storeDocument(
                 documentenApiPlugin.authenticationPluginConfiguration,
                 documentenApiPlugin.url,
+                CASE_DOCUMENT_ID,
                 CreateDocumentRequest(
                     bronorganisatie = documentenApiPlugin.bronorganisatie,
                     creatiedatum = LocalDate.now(),
@@ -129,6 +131,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
     fun `should allow document list`() {
+        val documentId = UUID.randomUUID()
         val permissions = listOf(
             Permission(
                 UUID.randomUUID(),
@@ -142,6 +145,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         val results = documentenApiClient.getInformatieObjecten(
             documentenApiPlugin.authenticationPluginConfiguration,
+            documentId,
             documentenApiPlugin.url,
             Pageable.ofSize(10),
             DocumentSearchRequest(
@@ -155,8 +159,10 @@ internal class DocumentenApiClientIT @Autowired constructor(
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
     fun `should respond with empty zaak-document list when missing permission`() {
+        val documentId = UUID.randomUUID()
         val results = documentenApiClient.getInformatieObjecten(
             documentenApiPlugin.authenticationPluginConfiguration,
+            documentId,
             documentenApiPlugin.url,
             Pageable.ofSize(10),
             DocumentSearchRequest(
@@ -170,6 +176,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
     fun `should allow document download`() {
+        val documentId = UUID.randomUUID()
         val permissions = listOf(
             Permission(
                 UUID.randomUUID(),
@@ -181,11 +188,11 @@ internal class DocumentenApiClientIT @Autowired constructor(
         )
         permissionRepository.deleteByRoleKeyIn(listOf("ROLE_TEST"))
         permissionRepository.saveAllAndFlush(permissions)
-
         val stream = documentenApiClient.downloadInformatieObjectContent(
             documentenApiPlugin.authenticationPluginConfiguration,
             documentenApiPlugin.url,
-            "objectId"
+            "objectId",
+            documentId
         )
 
         assertNotNull(stream)
@@ -194,13 +201,15 @@ internal class DocumentenApiClientIT @Autowired constructor(
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
     fun `should not allow document download when missing permission`() {
+        val documentId = UUID.randomUUID()
         permissionRepository.deleteByRoleKeyIn(listOf("ROLE_TEST"))
 
         assertThrows<AccessDeniedException> {
             documentenApiClient.downloadInformatieObjectContent(
                 documentenApiPlugin.authenticationPluginConfiguration,
                 documentenApiPlugin.url,
-                "objectId"
+                "objectId",
+                documentId
             )
         }
     }
@@ -208,6 +217,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
     fun `should allow document delete`() {
+        val caseDocumentId = UUID.randomUUID()
         val permissions = listOf(
             Permission(
                 UUID.randomUUID(),
@@ -222,6 +232,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         documentenApiClient.deleteInformatieObject(
             documentenApiPlugin.authenticationPluginConfiguration,
+            caseDocumentId,
             URI(documentenApiPlugin.url.toString() + "enkelvoudiginformatieobjecten/objectId"),
         )
     }
@@ -229,11 +240,13 @@ internal class DocumentenApiClientIT @Autowired constructor(
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
     fun `should not allow document delete when missing permission`() {
+        val caseDocumentId = UUID.randomUUID()
         permissionRepository.deleteByRoleKeyIn(listOf("ROLE_TEST"))
 
         assertThrows<AccessDeniedException> {
             documentenApiClient.deleteInformatieObject(
                 documentenApiPlugin.authenticationPluginConfiguration,
+                caseDocumentId,
                 URI(documentenApiPlugin.url.toString() + "enkelvoudiginformatieobjecten/objectId"),
             )
         }
@@ -407,5 +420,10 @@ internal class DocumentenApiClientIT @Autowired constructor(
            }
         """.trimIndent()
         return mockResponse(body)
+    }
+
+    companion object {
+        val CASE_DOCUMENT_ID: UUID =
+            UUID.fromString("123e4567-e89b-12d3-a456-426655440000")
     }
 }

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
@@ -107,7 +107,6 @@ DocumentenApiClientTest {
     fun `should send request and parse response`() {
         val restClientBuilder = RestClient.builder()
         val client = DocumentenApiClient(restClientBuilder, outboxService, objectMapper, mock(), authorizationService)
-
         val responseBody = """
             {
               "url": "http://example.com",
@@ -162,6 +161,7 @@ DocumentenApiClientTest {
         val result = client.storeDocument(
             TestAuthentication(),
             mockDocumentenApi.url("/").toUri(),
+            CASE_DOCUMENT_ID,
             request
         )
 
@@ -288,6 +288,7 @@ DocumentenApiClientTest {
         val result = client.storeDocument(
             TestAuthentication(),
             mockDocumentenApi.url("/").toUri(),
+            CASE_DOCUMENT_ID,
             request
         )
 
@@ -328,6 +329,7 @@ DocumentenApiClientTest {
             client.storeDocument(
                 TestAuthentication(),
                 mockDocumentenApi.url("/").toUri(),
+                CASE_DOCUMENT_ID,
                 request
             )
         }
@@ -383,6 +385,7 @@ DocumentenApiClientTest {
 
         val result = client.getInformatieObject(
             TestAuthentication(),
+            CASE_DOCUMENT_ID,
             mockDocumentenApi.url("/zaakobjects").toUri(),
         )
 
@@ -458,6 +461,7 @@ DocumentenApiClientTest {
 
         val result = client.getInformatieObject(
             TestAuthentication(),
+            CASE_DOCUMENT_ID,
             mockDocumentenApi.url("/zaakobjects").toUri(),
         )
 
@@ -484,6 +488,7 @@ DocumentenApiClientTest {
         assertThrows<HttpClientErrorException> {
             client.getInformatieObject(
                 TestAuthentication(),
+                CASE_DOCUMENT_ID,
                 mockDocumentenApi.url("/zaakobjects").toUri(),
             )
         }
@@ -506,11 +511,11 @@ DocumentenApiClientTest {
         mockDocumentenApi.enqueue(mockInputStreamResponse(buffer))
 
         val eventCapture = argumentCaptor<Supplier<BaseEvent>>()
-
         client.downloadInformatieObjectContent(
             TestAuthentication(),
             mockDocumentenApi.url("/").toUri(),
-            documentInformatieObjectId
+            documentInformatieObjectId,
+            CASE_DOCUMENT_ID
         )
 
         mockDocumentenApi.takeRequest()
@@ -539,7 +544,8 @@ DocumentenApiClientTest {
             client.downloadInformatieObjectContent(
                 TestAuthentication(),
                 mockDocumentenApi.url("/").toUri(),
-                documentInformatieObjectId
+                documentInformatieObjectId,
+                CASE_DOCUMENT_ID
             )
         }
 
@@ -558,6 +564,7 @@ DocumentenApiClientTest {
 
         client.deleteInformatieObject(
             TestAuthentication(),
+            CASE_DOCUMENT_ID,
             mockDocumentenApi.url("/documenten/api/v1/enkelvoudiginformatieobjecten/123").toUri(),
         )
 
@@ -588,6 +595,7 @@ DocumentenApiClientTest {
         assertThrows<HttpClientErrorException> {
             client.deleteInformatieObject(
                 TestAuthentication(),
+                CASE_DOCUMENT_ID,
                 mockDocumentenApi.url("/zaakobjects").toUri(),
             )
         }
@@ -717,7 +725,8 @@ DocumentenApiClientTest {
                     ontvangstdatum = LocalDate.of(2020, 5, 3),
                     verzenddatum = LocalDate.of(2020, 5, 3),
                     indicatieGebruiksrecht = true
-                )
+                ),
+                CASE_DOCUMENT_ID
             )
         }
 
@@ -995,6 +1004,7 @@ DocumentenApiClientTest {
 
         val page = client.getInformatieObjecten(
             TestAuthentication(),
+            CASE_DOCUMENT_ID,
             mockDocumentenApi.url("/").toUri(),
             pageable,
             documentSearchRequest
@@ -1048,5 +1058,10 @@ DocumentenApiClientTest {
             }.build()
             return next.exchange(filteredRequest)
         }
+    }
+
+    companion object {
+        val CASE_DOCUMENT_ID: UUID =
+            UUID.fromString("123e4567-e89b-12d3-a456-426655440000")
     }
 }

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/service/DocumentenApiServiceTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/service/DocumentenApiServiceTest.kt
@@ -52,7 +52,6 @@ import java.util.UUID
 
 class DocumentenApiServiceTest {
     private lateinit var service: DocumentenApiService
-
     private lateinit var pluginService: PluginService
     private lateinit var catalogiService: CatalogiService
     private lateinit var documentenApiColumnRepository: DocumentenApiColumnRepository
@@ -90,13 +89,13 @@ class DocumentenApiServiceTest {
 
     @Test
     fun `getCaseInformatieObjecten should get informatieobjecten`() {
-        val documentId = UUID.randomUUID()
+        val caseDocumentId = UUID.randomUUID()
         val documentSearchRequest = DocumentSearchRequest()
         val pageable = Pageable.unpaged()
 
         val documentDefinitionId = JsonSchemaDocumentDefinitionId.existingId("some-document-name", 3)
         val document = mock<Document>()
-        whenever(valtimoDocumentService.get(documentId.toString())).thenReturn(document)
+        whenever(valtimoDocumentService.get(caseDocumentId.toString())).thenReturn(document)
         whenever(document.definitionId()).thenReturn(documentDefinitionId)
         val pluginConfigurationId = PluginConfigurationId.existingId(UUID.randomUUID())
         val pluginConfiguration = mock<PluginConfiguration>()
@@ -107,12 +106,12 @@ class DocumentenApiServiceTest {
         val plugin = mock<DocumentenApiPlugin>()
         val relatedFile = createDocumentInformatieObject()
         val page = PageImpl(listOf(relatedFile), pageable, 1)
-        whenever(plugin.getInformatieObjecten(documentSearchRequest, pageable)).thenReturn(page)
+        whenever(plugin.getInformatieObjecten(caseDocumentId, documentSearchRequest, pageable)).thenReturn(page)
         val version = DocumentenApiVersion("1.5.0-test-1.0.0", listOf("titel"), listOf("titel"))
         whenever(documentenApiVersionService.getPluginVersion("some-document-name"))
             .thenReturn(Triple(pluginConfiguration, plugin, version))
 
-        val resultPage = service.getCaseInformatieObjecten(documentId, documentSearchRequest, pageable)
+        val resultPage = service.getCaseInformatieObjecten(caseDocumentId, documentSearchRequest, pageable)
 
         assertEquals(1, resultPage.size)
         val firstResult = resultPage.content.first()
@@ -127,22 +126,24 @@ class DocumentenApiServiceTest {
 
     @Test
     fun `should call plugin to delete informatie object`() {
+        val caseDocumentId = UUID.randomUUID()
         val documentUrl = URI("http://some.url")
         val pluginInstance = mock<DocumentenApiPlugin>()
         whenever(pluginService.createInstance<DocumentenApiPlugin>(any(), any())).thenReturn(pluginInstance)
 
-        service.deleteInformatieObject(documentUrl)
+        service.deleteInformatieObject(documentUrl, caseDocumentId)
 
-        verify(pluginInstance).deleteInformatieObject(documentUrl)
+        verify(pluginInstance).deleteInformatieObject(caseDocumentId, documentUrl)
     }
 
     @Test
     fun `should throw exception when trying to delete informatie object but plugin does not exist`() {
+        val caseDocumentId = UUID.randomUUID()
         val documentUrl = URI("http://some.url")
         whenever(pluginService.createInstance<DocumentenApiPlugin>(any(), any())).thenReturn(null)
 
         val ex = assertThrows<IllegalArgumentException> {
-            service.deleteInformatieObject(documentUrl)
+            service.deleteInformatieObject(documentUrl, caseDocumentId)
         }
 
         assertEquals("Trying to delete informatie object by url, but could not find DocumentenApiPlugin instance for informatieobjectUrl http://some.url", ex.message)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ExtractUuid.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ExtractUuid.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 
-package com.ritense.documentenapi.service
+package com.ritense.zakenapi
 
 import java.net.URI
 import java.util.UUID
 
-interface DocumentDeleteHandler {
-    fun preDocumentDelete(documentUrl: URI, caseDocumentId: UUID?)
+object ExtractUuid {
+
+    fun extractUuidFromUri(uri: URI): UUID? {
+        return try {
+            val lastSegment = uri.path
+                ?.substringAfterLast("/")
+                ?.takeIf { it.isNotBlank() }
+
+            lastSegment?.let { UUID.fromString(it) }
+        } catch (e: Exception) {
+            null
+        }
+    }
 }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -128,10 +128,10 @@ class ZakenApiPlugin(
         ) {
             logger.debug { "Starting to link document with URL '$documentUrl' to zaak" }
 
-            val documentId = UUID.fromString(execution.businessKey)
-            val zaakUrl = zaakUrlProvider.getZaakUrl(documentId)
+            val caseDocumentId = UUID.fromString(execution.businessKey)
+            val zaakUrl = zaakUrlProvider.getZaakUrl(caseDocumentId)
 
-            if (getZaakInformatieObject(zaakUrl, URI(documentUrl)) != null) {
+            if (getZaakInformatieObject( caseDocumentId, zaakUrl, URI(documentUrl)) != null) {
                 logger.warn { "Skipping document-zaak-link creation. Link already exists between zaak '$zaakUrl' and document: '$documentUrl'." }
                 return
             }
@@ -143,7 +143,7 @@ class ZakenApiPlugin(
                 beschrijving
             )
 
-            client.linkDocument(authenticationPluginConfiguration, url, request)
+            client.linkDocument(authenticationPluginConfiguration, caseDocumentId, url, request)
 
             logger.info { "Document with URL '$documentUrl' linked successfully to zaak with URL '$zaakUrl'" }
         }
@@ -163,10 +163,10 @@ class ZakenApiPlugin(
         val resourceId = execution.getVariable(RESOURCE_ID_PROCESS_VAR) as String
         val metadata = storageService.getResourceMetadata(resourceId)
 
-        val documentId = UUID.fromString(execution.businessKey)
-        val zaakUrl = zaakUrlProvider.getZaakUrl(documentId)
+        val caseDocumentId = UUID.fromString(execution.businessKey)
+        val zaakUrl = zaakUrlProvider.getZaakUrl(caseDocumentId)
 
-        if (getZaakInformatieObject(zaakUrl, URI(documentUrl)) != null) {
+        if (getZaakInformatieObject(caseDocumentId, zaakUrl, URI(documentUrl)) != null) {
             logger.warn { "Skipping document-zaak-link creation. Link already exists between zaak '$zaakUrl' and document: '$documentUrl'." }
             return
         }
@@ -177,7 +177,12 @@ class ZakenApiPlugin(
             metadata["title"] as String?,
             metadata["description"] as String?,
         )
-        client.linkDocument(authenticationPluginConfiguration, url, request)
+        client.linkDocument(
+            authenticationPluginConfiguration,
+            caseDocumentId,
+            url,
+            request
+        )
         logger.info { "Linked uploaded document with URL '$documentUrl' to zaak with URL '$zaakUrl'" }
     }
 
@@ -226,10 +231,10 @@ class ZakenApiPlugin(
         withLoggingContext(
             CATALOGI_API.ZAAKTYPE to zaaktypeUrl.toString()
         ) {
-            val documentId = UUID.fromString(execution.businessKey)
+            val caseDocumentId = UUID.fromString(execution.businessKey)
 
             createZaak(
-                documentId,
+                caseDocumentId,
                 rsin,
                 zaaktypeUrl,
                 description,
@@ -237,12 +242,12 @@ class ZakenApiPlugin(
                 finalDeliveryDate?.let { LocalDate.parse(it) },
             )
 
-            logger.info { "Zaak of zaaktype with URL '$zaaktypeUrl' created for document with id '$documentId'" }
+            logger.info { "Zaak of zaaktype with URL '$zaaktypeUrl' created for document with id '$caseDocumentId'" }
         }
     }
 
     fun createZaak(
-        documentId: UUID,
+        caseDocumentId: UUID,
         rsin: Rsin,
         zaaktypeUrl: URI,
         description: String? = null,
@@ -251,13 +256,13 @@ class ZakenApiPlugin(
     ) {
         withLoggingContext(
             CATALOGI_API.ZAAKTYPE to zaaktypeUrl.toString(),
-            "com.ritense.document.domain.impl.JsonSchemaDocument" to documentId.toString(),
+            "com.ritense.document.domain.impl.JsonSchemaDocument" to caseDocumentId.toString(),
         ) {
-            logger.debug { "Starting creation of zaak of zaaktype with URL '$zaaktypeUrl' for document with id '$documentId'" }
-            val zaakInstanceLink = zaakInstanceLinkRepository.findByDocumentId(documentId)
+            logger.debug { "Starting creation of zaak of zaaktype with URL '$zaaktypeUrl' for document with id '$caseDocumentId'" }
+            val zaakInstanceLink = zaakInstanceLinkRepository.findByDocumentId(caseDocumentId)
 
             if (zaakInstanceLink != null) {
-                logger.warn { "Skipping zaak creation. Zaak already exists for document with id '$documentId'. Zaak URL: '${zaakInstanceLink.zaakInstanceUrl}'." }
+                logger.warn { "Skipping zaak creation. Zaak already exists for document with id '$caseDocumentId'. Zaak URL: '${zaakInstanceLink.zaakInstanceUrl}'." }
                 return
             }
 
@@ -275,7 +280,7 @@ class ZakenApiPlugin(
                     startdatum = startdatum,
                     uiterlijkeEinddatumAfdoening = uiterlijkeEinddatumAfdoening,
                     omschrijving = description,
-                    einddatumGepland = plannedEndDate,
+                    einddatumGepland = plannedEndDate
                 )
             )
 
@@ -284,12 +289,12 @@ class ZakenApiPlugin(
                     ZaakInstanceLinkId(UUID.randomUUID()),
                     zaak.url,
                     zaak.uuid,
-                    documentId,
+                    caseDocumentId,
                     zaak.zaaktype
                 )
             )
 
-            logger.info { "Zaak with URL '${zaak.url}' created successfully for document with id '$documentId''" }
+            logger.info { "Zaak with URL '${zaak.url}' created successfully for document with id '$caseDocumentId'" }
         }
     }
 
@@ -1001,28 +1006,31 @@ class ZakenApiPlugin(
         )
     }
 
-    fun getZaakInformatieObjecten(zaakUrl: URI): List<ZaakInformatieObject> {
+    fun getZaakInformatieObjecten(documentId: UUID, zaakUrl: URI): List<ZaakInformatieObject> {
         logger.debug { "Fetching zaak informatie objecten for zaak with URL '$zaakUrl'" }
         return client.getZaakInformatieObjecten(
             authentication = authenticationPluginConfiguration,
+            documentId,
             baseUrl = url,
             zaakUrl = zaakUrl
         )
     }
 
-    fun getZaakInformatieObjectenByInformatieobjectUrl(informatieobjectUrl: URI): List<ZaakInformatieObject> {
+    fun getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId: UUID?, informatieobjectUrl: URI): List<ZaakInformatieObject> {
         logger.debug { "Fetching zaak informatie objecten by informatieobject URL '$informatieobjectUrl'" }
         return client.getZaakInformatieObjecten(
             authentication = authenticationPluginConfiguration,
+            caseDocumentId,
             baseUrl = url,
             informatieobjectUrl = informatieobjectUrl
         )
     }
 
-    fun getZaakInformatieObject(zaakUrl: URI, informatieobjectUrl: URI): ZaakInformatieObject? {
+    fun getZaakInformatieObject(caseDocumentId: UUID, zaakUrl: URI, informatieobjectUrl: URI): ZaakInformatieObject? {
         logger.debug { "Fetching zaak informatie object by '$zaakUrl' and '$informatieobjectUrl'" }
         val results = client.getZaakInformatieObjecten(
             authentication = authenticationPluginConfiguration,
+            caseDocumentId,
             baseUrl = url,
             zaakUrl = zaakUrl,
             informatieobjectUrl = informatieobjectUrl,
@@ -1030,12 +1038,13 @@ class ZakenApiPlugin(
         return results.singleOrNull()
     }
 
-    fun deleteZaakInformatieobject(zaakInformatieobjectUrl: URI) {
+    fun deleteZaakInformatieobject(zaakInformatieobjectUrl: URI, caseDocumentId: UUID?) {
         logger.debug { "Deleting zaak informatie object for URL '$zaakInformatieobjectUrl'" }
         client.deleteZaakInformatieObject(
             authentication = authenticationPluginConfiguration,
             baseUrl = url,
-            zaakInformatieobjectUrl = zaakInformatieobjectUrl
+            zaakInformatieobjectUrl = zaakInformatieobjectUrl,
+            caseDocumentId
         )
         logger.info { "Deleted zaak informatie object with URL '$zaakInformatieobjectUrl'" }
     }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
@@ -91,6 +91,7 @@ class ZakenApiClient(
 ) {
     fun linkDocument(
         authentication: ZakenApiAuthentication,
+        caseDocumentId: UUID,
         baseUrl: URI,
         request: LinkDocumentRequest
     ): LinkDocumentResult {
@@ -99,7 +100,7 @@ class ZakenApiClient(
                 EntityAuthorizationRequest(
                     ResourcePermission::class.java,
                     ResourcePermissionActionProvider.CREATE,
-                    ResourcePermission()
+                    ResourcePermission(caseDocumentId)
                 )
             )
         }
@@ -168,6 +169,7 @@ class ZakenApiClient(
 
     fun getZaakInformatieObjecten(
         authentication: ZakenApiAuthentication,
+        caseDocumentId: UUID?,
         baseUrl: URI,
         zaakUrl: URI? = null,
         informatieobjectUrl: URI? = null,
@@ -176,9 +178,10 @@ class ZakenApiClient(
             EntityAuthorizationRequest(
                 ResourcePermission::class.java,
                 ResourcePermissionActionProvider.VIEW_LIST,
-                ResourcePermission()
+                ResourcePermission(caseDocumentId)
             )
-        )) {
+        )
+            ) {
             return emptyList()
         }
 
@@ -609,7 +612,12 @@ class ZakenApiClient(
         return result
     }
 
-    fun deleteZaakInformatieObject(authentication: ZakenApiAuthentication, baseUrl: URI, zaakInformatieobjectUrl: URI) {
+    fun deleteZaakInformatieObject(
+        authentication: ZakenApiAuthentication,
+        baseUrl: URI,
+        zaakInformatieobjectUrl: URI,
+        caseDocumentId: UUID?
+    ) {
         require(zaakInformatieobjectUrl.toString().startsWith(baseUrl.toString())) {
             "zaakInformatieobjectUrl '$zaakInformatieobjectUrl' does not start with baseUrl '$baseUrl'"
         }
@@ -618,7 +626,7 @@ class ZakenApiClient(
                 EntityAuthorizationRequest(
                     ResourcePermission::class.java,
                     ResourcePermissionActionProvider.DELETE,
-                    ResourcePermission()
+                    ResourcePermission(caseDocumentId)
                 )
             )
         }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/config/ZakenApiAutoConfiguration.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/config/ZakenApiAutoConfiguration.kt
@@ -130,12 +130,14 @@ class ZakenApiAutoConfiguration {
         catalogiService: CatalogiService,
         documentenApiService: DocumentenApiService,
         documentenApiVersionService: DocumentenApiVersionService,
+        authorizationService: AuthorizationService,
     ) = ZaakDocumentService(
         zaakUrlProvider,
         pluginService,
         catalogiService,
         documentenApiService,
         documentenApiVersionService,
+        authorizationService
     )
 
     @Bean

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/link/ZaakInstanceLinkService.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/link/ZaakInstanceLinkService.kt
@@ -58,10 +58,10 @@ class  ZaakInstanceLinkService(
 
     @Throws(ZaakInstanceLinkNotFoundException::class)
     fun getByDocumentId(
-        @LoggableResource(resourceType = JsonSchemaDocument::class) documentId: UUID
+        @LoggableResource(resourceType = JsonSchemaDocument::class) caseDocumentId: UUID
     ): ZaakInstanceLink {
-        return zaakInstanceLinkRepository.findByDocumentId(documentId)
-            ?: throw ZaakInstanceLinkNotFoundException("No ZaakInstanceLink found for document id $documentId")
+        return zaakInstanceLinkRepository.findByDocumentId(caseDocumentId)
+            ?: throw ZaakInstanceLinkNotFoundException("No ZaakInstanceLink found for case document id $caseDocumentId")
     }
 
     @Throws(ZaakInstanceLinkNotFoundException::class)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZakenApiHttpSecurityConfigurer.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZakenApiHttpSecurityConfigurer.kt
@@ -22,6 +22,7 @@ import com.ritense.valtimo.contract.security.config.HttpSecurityConfigurer
 import org.springframework.http.HttpMethod.DELETE
 import org.springframework.http.HttpMethod.GET
 import org.springframework.http.HttpMethod.POST
+import org.springframework.http.HttpMethod.PUT
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher
 
@@ -33,6 +34,9 @@ class ZakenApiHttpSecurityConfigurer : HttpSecurityConfigurer {
                 requests.requestMatchers(antMatcher(GET, "/api/v1/zaken-api/document/{documentId}/files")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/v2/zaken-api/document/{documentId}/files")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/v1/zaken-api/document/{documentId}/zaak")).authenticated()
+                    .requestMatchers(antMatcher(PUT, "/api/v1/zaken-api/{pluginConfigurationId}/case-document/{caseDocumentId}/files/{documentId}")).authenticated()
+                    .requestMatchers(antMatcher(DELETE, "/api/v1/zaken-api/{pluginConfigurationId}/case-document/{caseDocumentId}/files/{documentId}")).authenticated()
+                    .requestMatchers(antMatcher(GET, "/api/v1/zaken-api/{pluginConfigurationId}/case-document/{caseDocumentId}/files/{documentId}/download")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/management/v1/zaak-type-link/{documentDefinitionName}")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(GET, "/api/management/v1/zaak-type-link/process/{processDefinitionKey}")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(POST, "/api/management/v1/zaak-type-link")).hasAuthority(ADMIN)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
@@ -16,7 +16,10 @@
 
 package com.ritense.zakenapi.service
 
+import com.ritense.authorization.AuthorizationService
+import com.ritense.authorization.request.EntityAuthorizationRequest
 import com.ritense.catalogiapi.service.CatalogiService
+import com.ritense.document.domain.RelatedFile
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.documentenapi.DocumentenApiPlugin
 import com.ritense.documentenapi.client.DocumentInformatieObject
@@ -32,11 +35,16 @@ import com.ritense.documentenapi.service.DocumentenApiService
 import com.ritense.documentenapi.service.DocumentenApiVersionService
 import com.ritense.documentenapi.web.rest.dto.DocumentSearchRequest
 import com.ritense.documentenapi.web.rest.dto.DocumentenApiDocumentDto
+import com.ritense.documentenapi.web.rest.dto.ModifyDocumentRequest
 import com.ritense.documentenapi.web.rest.dto.RelatedFileDto
 import com.ritense.logging.LoggableResource
 import com.ritense.plugin.domain.PluginConfiguration
+import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.service.PluginService
+import com.ritense.resource.authorization.ResourcePermission
+import com.ritense.resource.authorization.ResourcePermissionActionProvider
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
+import com.ritense.zakenapi.ExtractUuid.extractUuidFromUri
 import com.ritense.zakenapi.ZaakUrlProvider
 import com.ritense.zakenapi.ZakenApiPlugin
 import com.ritense.zakenapi.domain.ZaakInformatieObject
@@ -60,12 +68,13 @@ class ZaakDocumentService(
     private val catalogiService: CatalogiService,
     private val documentenApiService: DocumentenApiService,
     private val documentenApiVersionService: DocumentenApiVersionService,
+    private val authorizationService: AuthorizationService,
 ) {
 
     fun getInformatieObjectenAsRelatedFiles(
-        @LoggableResource(resourceType = JsonSchemaDocument::class) documentId: UUID
+        @LoggableResource(resourceType = JsonSchemaDocument::class) caseDocumentId: UUID,
     ): List<RelatedFileDto> {
-        val zaakUri = zaakUrlProvider.getZaakUrl(documentId)
+        val zaakUri = zaakUrlProvider.getZaakUrl(caseDocumentId)
 
         val zakenApiPlugin = checkNotNull(
             pluginService.createInstance(
@@ -74,17 +83,17 @@ class ZaakDocumentService(
             )
         ) { "Could not find ${ZakenApiPlugin::class.simpleName} configuration for zaak with url: $zaakUri" }
 
-        return zakenApiPlugin.getZaakInformatieObjecten(zaakUri)
+        return zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakUri)
             .map { getRelatedFiles(it) }
     }
 
     fun getInformatieObjectenAsRelatedFilesPage(
-        @LoggableResource(resourceType = JsonSchemaDocument::class) documentId: UUID,
+        @LoggableResource(resourceType = JsonSchemaDocument::class) caseDocumentId: UUID,
         documentSearchRequest: DocumentSearchRequest,
         pageable: Pageable,
     ): Page<DocumentenApiDocumentDto> {
-        val zaakUri = zaakUrlProvider.getZaakUrl(documentId)
-        val version = documentenApiVersionService.getVersionByDocumentId(documentId)
+        val zaakUri = zaakUrlProvider.getZaakUrl(caseDocumentId)
+        val version = documentenApiVersionService.getVersionByDocumentId(caseDocumentId)
         check(documentSearchRequest.informatieobjecttype != null, INFORMATIEOBJECTTYPE_OMSCHRIJVING, version)
         check(documentSearchRequest.titel != null, TITEL, version)
         check(documentSearchRequest.vertrouwelijkheidaanduiding != null, VERTROUWELIJKHEIDAANDUIDING, version)
@@ -97,22 +106,35 @@ class ZaakDocumentService(
                 "Unsupported field 'trefwoorden' on Documenten API version '$version'"
             }
         }
+
+        if (!authorizationService.hasPermission(
+                EntityAuthorizationRequest(
+                    ResourcePermission::class.java,
+                    ResourcePermissionActionProvider.VIEW_LIST,
+                    ResourcePermission(caseDocumentId)
+                )
+            )
+        ) {
+            return Page.empty(pageable)
+        }
+
         return if (version.supportsFilterableColumns() && version.supportsSortableColumns()) {
             documentenApiService.getCaseInformatieObjecten(
-                documentId,
+                caseDocumentId,
                 documentSearchRequest.copy(zaakUrl = zaakUri),
                 pageable
             ).map { mapDocumentenApiDocument(it, version) }
         } else {
             val zakenApiPlugin = getZakenApiPlugin(zaakUri)
-            val documenten = zakenApiPlugin.getZaakInformatieObjecten(zaakUri)
+            val documenten = zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakUri)
                 .map { mapDocumentenApiDocument(it, version) }
-            return toPage(documenten, pageable)
+            toPage(documenten, pageable)
         }
     }
 
     fun deleteRelatedInformatieObjecten(
-        @LoggableResource(resourceType = JsonSchemaDocument::class) zaakInstanceUrl: URI
+        @LoggableResource(resourceType = JsonSchemaDocument::class) caseDocumentId: UUID,
+        zaakInstanceUrl: URI,
     ) {
         val zakenApiPlugin = checkNotNull(
             pluginService.createInstance(
@@ -121,8 +143,20 @@ class ZaakDocumentService(
             )
         ) { "Could not find ${ZakenApiPlugin::class.simpleName} configuration for zaak with url: $zaakInstanceUrl" }
 
-        zakenApiPlugin.getZaakInformatieObjecten(zaakInstanceUrl)
-            .map { documentenApiService.deleteInformatieObject(it.informatieobject) }
+        zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakInstanceUrl).forEach { zaakInformatieobject ->
+            if (zakenApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(
+                    caseDocumentId,
+                    zaakInformatieobject.informatieobject
+                ).size == 1
+            ) {
+                documentenApiService.deleteInformatieObject(
+                    zaakInformatieobject.informatieobject,
+                    caseDocumentId
+                )
+            } else {
+                zakenApiPlugin.deleteZaakInformatieobject(zaakInformatieobject.url, caseDocumentId)
+            }
+        }
     }
 
     private fun check(shouldCheck: Boolean, columnKey: DocumentenApiColumnKey, version: DocumentenApiVersion) {
@@ -143,7 +177,8 @@ class ZaakDocumentService(
     private fun getRelatedFiles(zaakInformatieObject: ZaakInformatieObject): RelatedFileDto {
         val pluginConfiguration = getDocumentenApiPluginByInformatieobjectUrl(zaakInformatieObject.informatieobject)
         val plugin = pluginService.createInstance(pluginConfiguration) as DocumentenApiPlugin
-        val informatieObject = plugin.getInformatieObject(zaakInformatieObject.informatieobject)
+        val caseDocumentId = extractUuidFromUri(zaakInformatieObject.zaak) ?: throw IllegalStateException("Could not extract caseDocumentId from zaakInformatieObject.zaak: ${zaakInformatieObject.zaak}")
+        val informatieObject = plugin.getInformatieObject(zaakInformatieObject.informatieobject, caseDocumentId)
         return mapRelatedFile(informatieObject, pluginConfiguration)
     }
 
@@ -216,7 +251,8 @@ class ZaakDocumentService(
     ): DocumentenApiDocumentDto {
         val pluginConfiguration = getDocumentenApiPluginByInformatieobjectUrl(zaakInformatieObject.informatieobject)
         val plugin = pluginService.createInstance(pluginConfiguration) as DocumentenApiPlugin
-        val informatieObject = plugin.getInformatieObject(zaakInformatieObject.informatieobject)
+        val caseDocumentId = extractUuidFromUri(zaakInformatieObject.zaak) ?: throw IllegalStateException("Could not extract caseDocumentId from zaakInformatieObject.zaak: ${zaakInformatieObject.zaak}")
+        val informatieObject = plugin.getInformatieObject(zaakInformatieObject.informatieobject, caseDocumentId)
         val trefwoorden = if (version.supportsTrefwoorden) {
             informatieObject.trefwoorden
         } else {
@@ -260,11 +296,11 @@ class ZaakDocumentService(
 
     }
 
-    fun getZaakByDocumentId(
-        @LoggableResource(resourceType = JsonSchemaDocument::class) documentId: UUID
+    fun getZaakByCaseDocumentId(
+        @LoggableResource(resourceType = JsonSchemaDocument::class) caseDocumentId: UUID,
     ): ZaakResponse? {
         val url = try {
-            zaakUrlProvider.getZaakUrl(documentId)
+            zaakUrlProvider.getZaakUrl(caseDocumentId)
         } catch (e: ZaakInstanceLinkNotFoundException) {
             return null
         }
@@ -277,9 +313,9 @@ class ZaakDocumentService(
     }
 
     fun getZaakByDocumentIdOrThrow(
-        @LoggableResource(resourceType = JsonSchemaDocument::class) documentId: UUID
+        @LoggableResource(resourceType = JsonSchemaDocument::class) caseDocumentId: UUID,
     ): ZaakResponse {
-        val url = zaakUrlProvider.getZaakUrl(documentId)
+        val url = zaakUrlProvider.getZaakUrl(caseDocumentId)
         val plugin = pluginService.createInstance(
             ZakenApiPlugin::class.java,
             ZakenApiPlugin.findConfigurationByUrl(url)
@@ -297,4 +333,57 @@ class ZaakDocumentService(
         ) { "Could not find ${ZakenApiPlugin::class.simpleName} configuration for zaak with url: $zaakUri" }
     }
 
+    fun deleteInformatieObject(pluginConfigurationId: String, caseDocumentId: UUID, documentId: String) {
+
+        val (documentenApiPlugin, informatieobjectUrl) = getVerifiedInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
+        documentenApiService.deleteInformatieObject(documentenApiPlugin, caseDocumentId, informatieobjectUrl)
+    }
+
+    fun modifyInformatieObject(
+        pluginConfigurationId: String,
+        caseDocumentId: UUID,
+        documentId: String,
+        modifyDocumentRequest: ModifyDocumentRequest,
+    ): RelatedFile? {
+        getVerifiedInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
+        return documentenApiService.modifyInformatieObject(
+            pluginConfigurationId,
+            caseDocumentId,
+            documentId,
+            modifyDocumentRequest
+        )
+    }
+
+    private fun getVerifiedInformatieObject(
+        pluginConfigurationId: String,
+        caseDocumentId: UUID,
+        documentId: String,
+    ): Pair<DocumentenApiPlugin, URI> {
+        val zaakUrl = zaakUrlProvider.getZaakUrl(caseDocumentId)
+        val zakenApiPlugin = getZakenApiPlugin(zaakUrl)
+
+        val documentenApiPlugin = pluginService.createInstance(
+            PluginConfigurationId.existingId(UUID.fromString(pluginConfigurationId))
+        ) as DocumentenApiPlugin
+
+        val informatieobjectUrl = documentenApiPlugin.createInformatieObjectUrl(documentId)
+
+        val zaakInformatieObject = zakenApiPlugin.getZaakInformatieObject(
+            caseDocumentId,
+            zaakUrl,
+            informatieobjectUrl
+        )
+
+        if (zaakInformatieObject == null) {
+            throw IllegalArgumentException("InformatieObject is not related to this Zaak")
+        }
+
+        return Pair(documentenApiPlugin, informatieobjectUrl)
+    }
+
+    fun downloadInformatieObject(pluginConfigurationId: String, caseDocumentId: UUID, documentId: String) =
+        documentenApiService.downloadInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
+
+    fun getInformatieObject(pluginConfigurationId: String, caseDocumentId: UUID, documentId: String) =
+        documentenApiService.getInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
 }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZakenApiDocumentDeletedEventListener.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZakenApiDocumentDeletedEventListener.kt
@@ -37,18 +37,18 @@ class ZakenApiDocumentDeletedEventListener(
     @Transactional
     @EventListener(DocumentDeletedEvent::class)
     fun handle(event: DocumentDeletedEvent) {
-        withLoggingContext(JsonSchemaDocument::class, event.documentId) {
+        withLoggingContext(JsonSchemaDocument::class, event.caseDocumentId) {
             val link = try {
-                zaakInstanceService.getByDocumentId(event.documentId)
+                zaakInstanceService.getByDocumentId(event.caseDocumentId)
             } catch (e: Exception) {
-                logger.debug { "No zaak instance link found for document '${event.documentId}'. Not deleting any zaak information" }
+                logger.debug { "No zaak instance link found for document '${event.caseDocumentId}'. Not deleting any zaak information" }
                 null
             }
 
             link?.let {
-                logger.info { "Deleting all zaak information for deleted document ${event.documentId}" }
+                logger.info { "Deleting all zaak information for deleted document ${event.caseDocumentId}" }
                 //delete documents
-                zaakDocumentService.deleteRelatedInformatieObjecten(link.zaakInstanceUrl)
+                zaakDocumentService.deleteRelatedInformatieObjecten(event.caseDocumentId, link.zaakInstanceUrl)
 
                 //delete zaak
                 val plugin = pluginService.createInstance(

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZakenDocumentDeleteHandler.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZakenDocumentDeleteHandler.kt
@@ -20,18 +20,19 @@ import com.ritense.documentenapi.service.DocumentDeleteHandler
 import com.ritense.plugin.service.PluginService
 import com.ritense.zakenapi.ZakenApiPlugin
 import java.net.URI
+import java.util.UUID
 
 class ZakenDocumentDeleteHandler(
     private val pluginService: PluginService
 ) : DocumentDeleteHandler {
 
-    override fun preDocumentDelete(documentUrl: URI) {
+    override fun preDocumentDelete(documentUrl: URI, caseDocumentId: UUID?) {
         val pluginConfigurations = pluginService.findPluginConfigurations(ZakenApiPlugin::class.java)
         val exceptions = pluginConfigurations.map {
             val plugin = pluginService.createInstance(it.id) as ZakenApiPlugin
             try {
-                plugin.getZaakInformatieObjectenByInformatieobjectUrl(documentUrl).forEach { zaakInformatieObject ->
-                    plugin.deleteZaakInformatieobject(zaakInformatieObject.url)
+                plugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId,documentUrl).forEach { zaakInformatieObject ->
+                    plugin.deleteZaakInformatieobject(zaakInformatieObject.url, caseDocumentId)
                 }
                 null
             } catch (e: Exception) {

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/uploadprocess/ResourceUploadedToDocumentEventListener.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/uploadprocess/ResourceUploadedToDocumentEventListener.kt
@@ -25,6 +25,7 @@ import com.ritense.resource.domain.TemporaryResourceUploadedEvent
 import com.ritense.resource.service.TemporaryResourceStorageService
 import mu.KotlinLogging
 import org.springframework.context.event.EventListener
+import java.util.UUID
 
 class ResourceUploadedToDocumentEventListener(
     private val resourceService: TemporaryResourceStorageService,
@@ -38,21 +39,21 @@ class ResourceUploadedToDocumentEventListener(
         logger.debug { "Handling TemporaryResourceUploadedEvent with resourceId: ${event.resourceId}" }
 
         val metadata = resourceService.getResourceMetadata(event.resourceId)
-        val caseId = metadata[MetadataType.DOCUMENT_ID.key] as String?
+        val caseDocumentId = metadata[MetadataType.DOCUMENT_ID.key] as String?
 
-        if (caseId != null) {
+        if (caseDocumentId != null) {
             if (authorizationEnabled) {
                 authorizationService.requirePermission(
                     EntityAuthorizationRequest(
                         ResourcePermission::class.java,
                         CREATE,
-                        ResourcePermission()
+                        ResourcePermission(UUID.fromString(caseDocumentId))
                     )
                 )
             }
 
             logger.debug { "Uploading resource to document: ${event.resourceId}" }
-            uploadProcessService.startUploadResourceProcess(caseId, event.resourceId)
+            uploadProcessService.startUploadResourceProcess(caseDocumentId, event.resourceId)
         }
     }
 

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/web/rest/ZaakDocumentResource.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/web/rest/ZaakDocumentResource.kt
@@ -20,17 +20,29 @@ import com.ritense.document.domain.RelatedFile
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.documentenapi.web.rest.dto.DocumentSearchRequest
 import com.ritense.documentenapi.web.rest.dto.DocumentenApiDocumentDto
+import com.ritense.documentenapi.web.rest.dto.ModifyDocumentRequest
 import com.ritense.logging.LoggableResource
+import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.domain.ValtimoMediaType.APPLICATION_JSON_UTF8_VALUE
 import com.ritense.zakenapi.domain.ZaakResponse
 import com.ritense.zakenapi.service.ZaakDocumentService
+import mu.KotlinLogging
+import org.springframework.core.io.InputStreamResource
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URLConnection
+import org.springframework.http.ContentDisposition
 import java.util.UUID
 
 @RestController
@@ -60,6 +72,74 @@ class ZaakDocumentResource(
     fun getZaakMetadata(
         @LoggableResource(resourceType = JsonSchemaDocument::class) @PathVariable(name = "documentId") documentId: UUID
     ): ZaakResponse? {
-        return zaakDocumentService.getZaakByDocumentId(documentId)
+        return zaakDocumentService.getZaakByCaseDocumentId(documentId)
+    }
+
+    @DeleteMapping("/v1/zaken-api/{pluginConfigurationId}/case-document/{caseDocumentId}/files/{documentId}")
+    fun deleteDocument(
+        @LoggableResource(resourceType = PluginConfiguration::class) @PathVariable(name = "pluginConfigurationId") pluginConfigurationId: String,
+        @PathVariable(name = "caseDocumentId") caseDocumentId: UUID,
+        @PathVariable(name = "documentId") documentId: String,
+    ): ResponseEntity<Unit> {
+        zaakDocumentService.deleteInformatieObject(
+            pluginConfigurationId,
+            caseDocumentId,
+            documentId
+        )
+        return ResponseEntity
+            .noContent()
+            .build()
+    }
+
+    @PutMapping("/v1/zaken-api/{pluginConfigurationId}/case-document/{caseDocumentId}/files/{documentId}")
+    fun modifyDocument(
+        @PathVariable(name = "caseDocumentId") caseDocumentId: UUID,
+        @LoggableResource(resourceType = PluginConfiguration::class) @PathVariable(name = "pluginConfigurationId") pluginConfigurationId: String,
+        @PathVariable(name = "documentId") documentId: String,
+        @RequestBody modifyDocumentRequest: ModifyDocumentRequest,
+    ): ResponseEntity<RelatedFile> {
+        return ResponseEntity
+            .ok()
+            .body(
+                zaakDocumentService.modifyInformatieObject(
+                    pluginConfigurationId,
+                    caseDocumentId,
+                    documentId,
+                    modifyDocumentRequest
+                )
+            )
+    }
+
+    @GetMapping("/v1/zaken-api/{pluginConfigurationId}/case-document/{caseDocumentId}/files/{documentId}/download")
+    fun downloadDocument(
+        @PathVariable(name = "caseDocumentId") caseDocumentId: UUID,
+        @LoggableResource(resourceType = PluginConfiguration::class) @PathVariable(name = "pluginConfigurationId") pluginConfigurationId: String,
+        @PathVariable(name = "documentId") documentId: String,
+    ): ResponseEntity<InputStreamResource> {
+
+        val documentMetadata =
+            zaakDocumentService.getInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
+        val documentInputStream =
+            zaakDocumentService.downloadInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
+
+        val responseHeaders = HttpHeaders()
+        val contentDisposition = ContentDisposition.attachment().filename(documentMetadata.bestandsnaam).build()
+        responseHeaders.contentDisposition = contentDisposition
+
+        val documentMediaType = try {
+            MediaType.valueOf(URLConnection.guessContentTypeFromName(documentMetadata.bestandsnaam))
+        } catch (exception: RuntimeException) {
+            logger.debug{"Could not determine media type for '${documentMetadata.bestandsnaam}', falling back to APPLICATION_OCTET_STREAM $exception" }
+            MediaType.APPLICATION_OCTET_STREAM
+        }
+        return ResponseEntity
+            .ok()
+            .headers(responseHeaders)
+            .contentType(documentMediaType)
+            .body(InputStreamResource(documentInputStream))
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger { }
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginIT.kt
@@ -175,7 +175,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         val document = createDocument()
 
         zakenApiPlugin.createZaak(
-            documentId = document.id().id,
+            caseDocumentId = document.id().id,
             rsin = Rsin("155539620"),
             zaaktypeUrl = ZAAKTYPE_URL
         )
@@ -192,7 +192,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         val plannedEndDate = LocalDate.now().plusDays(10)
 
         zakenApiPlugin.createZaak(
-            documentId = document.id().id,
+            caseDocumentId = document.id().id,
             rsin = Rsin("155539620"),
             zaaktypeUrl = ZAAKTYPE_URL,
             description = description,
@@ -215,7 +215,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         val document = createDocument()
 
         zakenApiPlugin.createZaak(
-            documentId = document.id().id,
+            caseDocumentId = document.id().id,
             rsin = Rsin("155539620"),
             zaaktypeUrl = ZAAKTYPE_URL,
         )

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -99,7 +99,7 @@ internal class ZakenApiPluginTest {
         plugin.linkDocumentToZaak(executionMock, "https://document.url", "titel", "beschrijving")
 
         val captor = argumentCaptor<LinkDocumentRequest>()
-        verify(zakenApiClient).linkDocument(any(), any(), captor.capture())
+        verify(zakenApiClient).linkDocument(any(), any(),any(), captor.capture())
 
         val request = captor.firstValue
         assertEquals("https://document.url", request.informatieobject)
@@ -121,7 +121,7 @@ internal class ZakenApiPluginTest {
         whenever(executionMock.getVariable(DOCUMENT_URL_PROCESS_VAR)).thenReturn("https://document.url")
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR)).thenReturn("myResourceId")
         whenever(zaakUrlProvider.getZaakUrl(any())).thenReturn(URI("https://zaak.url"))
-        whenever(zakenApiClient.linkDocument(any(), any(), any())).thenReturn(mock())
+        whenever(zakenApiClient.linkDocument(any(), any(), any(), any())).thenReturn(mock())
         whenever(storageService.getResourceMetadata("myResourceId")).thenReturn(
             mapOf(
                 "title" to "titel",
@@ -139,7 +139,7 @@ internal class ZakenApiPluginTest {
         plugin.linkUploadedDocumentToZaak(executionMock)
 
         val captor = argumentCaptor<LinkDocumentRequest>()
-        verify(zakenApiClient).linkDocument(any(), any(), captor.capture())
+        verify(zakenApiClient).linkDocument(any(), any(), any(), captor.capture())
 
         val request = captor.firstValue
         assertEquals("https://document.url", request.informatieobject)
@@ -353,7 +353,6 @@ internal class ZakenApiPluginTest {
         assertEquals("innNnpId", betrokkeneIdentificatie.innNnpId)
     }
 
-
     @Test
     fun `should create zaak`() {
         val zakenApiClient: ZakenApiClient = mock()
@@ -547,7 +546,6 @@ internal class ZakenApiPluginTest {
         assertEquals("Status description", request.statustoelichting)
     }
 
-
     @Test
     fun `should create zaak resultaat`() {
         val zakenApiClient: ZakenApiClient = mock()
@@ -626,7 +624,6 @@ internal class ZakenApiPluginTest {
 
     @Test
     fun `should update zaakopschorting and verlenging`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
@@ -665,7 +662,6 @@ internal class ZakenApiPluginTest {
 
     @Test
     fun `should start hersteltermijn`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
@@ -714,14 +710,12 @@ internal class ZakenApiPluginTest {
 
     @Test
     fun `should not start hersteltermijn twice`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
         val zaakHersteltermijnRepository: ZaakHersteltermijnRepository = mock()
         val executionMock = mock<DelegateExecution>()
         val authenticationMock = mock<ZakenApiAuthentication>()
-
         val documentId = UUID.randomUUID()
         val zaakUrl = URI("https://example.com/zaken/1234")
 
@@ -762,7 +756,6 @@ internal class ZakenApiPluginTest {
 
     @Test
     fun `should end hersteltermijn`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
@@ -815,12 +808,11 @@ internal class ZakenApiPluginTest {
         val request = captor.firstValue
         assertEquals(LocalDate.now().plusDays(50 - 17 + 8), request.uiterlijkeEinddatumAfdoening)
         assertFalse(request.opschorting!!.indicatie)
-        assertEquals("", request.opschorting?.reden)
+        assertEquals("", request.opschorting.reden)
     }
 
     @Test
     fun `should create zaakeigenschap`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
@@ -868,7 +860,6 @@ internal class ZakenApiPluginTest {
 
     @Test
     fun `should update zaakeigenschap`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
@@ -918,7 +909,6 @@ internal class ZakenApiPluginTest {
 
     @Test
     fun `should delete zaakeigenschap`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
@@ -961,7 +951,6 @@ internal class ZakenApiPluginTest {
 
     @Test
     fun `should relateer zaken`() {
-
         // given
         val zakenApiClient: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()
@@ -1014,8 +1003,9 @@ internal class ZakenApiPluginTest {
         val zaakUrlProvider: ZaakUrlProvider = mock()
         val authenticationMock = mock<ZakenApiAuthentication>()
 
-        val documentId = UUID.randomUUID()
+        val caseDocumentId = UUID.randomUUID()
         whenever(zaakUrlProvider.getZaakUrl(any())).thenReturn(URI("https://zaak.url"))
+        whenever(zaakUrlProvider.getZaakUrl(any())).thenReturn(zaakUri())
 
         val plugin = zakenApiPlugin(
             zaakUrlProvider = zaakUrlProvider,
@@ -1027,7 +1017,7 @@ internal class ZakenApiPluginTest {
             URI.create("https://zaak.url"),
             URI.create("https://object.url"),
             "zaakdetails",
-            documentId
+            caseDocumentId
         )
 
         val captor = argumentCaptor<ZaakObjectRequest>()
@@ -1103,7 +1093,7 @@ internal class ZakenApiPluginTest {
         val objectMapper = MapperSingleton.get()
         val resultProcessVariable = "resultVariable"
 
-        val documentId = UUID.randomUUID()
+        val caseDocumentId = UUID.randomUUID()
         val zaakUrl = zaakUri()
 
         val relatedFiles = listOf(
@@ -1129,9 +1119,9 @@ internal class ZakenApiPluginTest {
             )
         )
 
-        whenever(executionMock.businessKey).thenReturn(documentId.toString())
-        whenever(zaakUrlProvider.getZaakUrl(documentId)).thenReturn(zaakUrl)
-        whenever(zaakDocumentService.getInformatieObjectenAsRelatedFiles(documentId)).thenReturn(relatedFiles)
+        whenever(executionMock.businessKey).thenReturn(caseDocumentId.toString())
+        whenever(zaakUrlProvider.getZaakUrl(caseDocumentId)).thenReturn(zaakUrl)
+        whenever(zaakDocumentService.getInformatieObjectenAsRelatedFiles(caseDocumentId)).thenReturn(relatedFiles)
 
         val plugin = zakenApiPlugin(
             zaakUrlProvider = zaakUrlProvider,
@@ -1143,8 +1133,8 @@ internal class ZakenApiPluginTest {
         plugin.getZaakInformatieobjecten(executionMock, resultProcessVariable)
 
         // then
-        verify(zaakUrlProvider).getZaakUrl(documentId)
-        verify(zaakDocumentService).getInformatieObjectenAsRelatedFiles(documentId)
+        verify(zaakUrlProvider).getZaakUrl(caseDocumentId)
+        verify(zaakDocumentService).getInformatieObjectenAsRelatedFiles(caseDocumentId)
 
         val captor = argumentCaptor<Any>()
         verify(executionMock).setVariable(eq(resultProcessVariable), captor.capture())

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
@@ -74,7 +74,7 @@ internal class ZakenApiClientIT @Autowired constructor(
     fun `should allow zaak-document link`() {
         val permissions = listOf(
             Permission(
-                id = UUID.randomUUID(),
+                id = CASE_DOCUMENT_ID,
                 resourceType = ResourcePermission::class.java,
                 actions = mutableListOf(ResourcePermissionActionProvider.VIEW_LIST),
                 conditionContainer = ConditionContainer(),
@@ -87,6 +87,7 @@ internal class ZakenApiClientIT @Autowired constructor(
 
         zakenApiClient.linkDocument(
             zakenApiPlugin.authenticationPluginConfiguration,
+            CASE_DOCUMENT_ID,
             zakenApiPlugin.url,
             LinkDocumentRequest(
                 informatieobject = "https://localhost:56273/documenten/informatieobject/1234",
@@ -103,6 +104,7 @@ internal class ZakenApiClientIT @Autowired constructor(
         assertThrows<AccessDeniedException> {
             zakenApiClient.linkDocument(
                 zakenApiPlugin.authenticationPluginConfiguration,
+                CASE_DOCUMENT_ID,
                 zakenApiPlugin.url,
                 LinkDocumentRequest(
                     informatieobject = "https://localhost:56273/documenten/informatieobject/1234",
@@ -119,7 +121,7 @@ internal class ZakenApiClientIT @Autowired constructor(
     fun `should allow zaak-document list`() {
         val permissions = listOf(
             Permission(
-                id = UUID.randomUUID(),
+                id = CASE_DOCUMENT_ID,
                 resourceType = ResourcePermission::class.java,
                 actions = mutableListOf(ResourcePermissionActionProvider.VIEW_LIST),
                 conditionContainer = ConditionContainer(),
@@ -132,6 +134,7 @@ internal class ZakenApiClientIT @Autowired constructor(
 
         val results = zakenApiClient.getZaakInformatieObjecten(
             authentication = zakenApiPlugin.authenticationPluginConfiguration,
+            CASE_DOCUMENT_ID,
             baseUrl = zakenApiPlugin.url,
             zaakUrl = ZAAK_URL
         )
@@ -144,6 +147,7 @@ internal class ZakenApiClientIT @Autowired constructor(
     fun `should respond with empty zaak-document list when missing permission`() {
         val results = zakenApiClient.getZaakInformatieObjecten(
             authentication = zakenApiPlugin.authenticationPluginConfiguration,
+            CASE_DOCUMENT_ID,
             baseUrl = zakenApiPlugin.url,
             zaakUrl = ZAAK_URL
         )
@@ -202,6 +206,7 @@ internal class ZakenApiClientIT @Autowired constructor(
         private const val ZAAK_ID = "57f66ff6-db7f-43bc-84ef-6847640d3609"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
         private const val ZAKEN_API_URL = "http://localhost:56273$ZAKEN_API_PATH"
+        val CASE_DOCUMENT_ID: UUID = UUID.fromString(ZAAK_ID)
 
         private val ZAAK_URL = URI("${ZAKEN_API_URL}/zaken/$ZAAK_ID")
     }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,6 +138,7 @@ internal class ZakenApiClientTest {
 
         val result = client.linkDocument(
             TestAuthentication(),
+            UUID.randomUUID(),
             URI(mockApi.url("/").toString()),
             LinkDocumentRequest(
                 "https://example.com",
@@ -222,6 +223,7 @@ internal class ZakenApiClientTest {
 
         client.linkDocument(
             TestAuthentication(),
+            UUID.randomUUID(),
             URI(mockApi.url("/").toString()),
             LinkDocumentRequest(
                 "https://example.com",
@@ -256,6 +258,7 @@ internal class ZakenApiClientTest {
         assertThrows<HttpClientErrorException> {
             client.linkDocument(
                 TestAuthentication(),
+                UUID.randomUUID(),
                 URI(mockApi.url("/").toString()),
                 LinkDocumentRequest(
                     "https://example.com",
@@ -422,6 +425,7 @@ internal class ZakenApiClientTest {
 
         val result = client.getZaakInformatieObjecten(
             TestAuthentication(),
+            UUID.randomUUID(),
             URI(mockApi.url("/").toString()),
             URI("https://example.com")
         )
@@ -477,6 +481,7 @@ internal class ZakenApiClientTest {
 
         val result = client.getZaakInformatieObjecten(
             TestAuthentication(),
+            UUID.randomUUID(),
             URI(mockApi.url("/").toString()),
             URI("https://example.com")
         )
@@ -505,6 +510,7 @@ internal class ZakenApiClientTest {
         assertThrows<HttpClientErrorException> {
             client.getZaakInformatieObjecten(
                 TestAuthentication(),
+                UUID.randomUUID(),
                 URI(mockApi.url("/").toString()),
                 URI("https://example.com")
             )
@@ -926,7 +932,6 @@ internal class ZakenApiClientTest {
 
         val firstEventValue = eventCapture.firstValue.get()
         val mappedFirstEventResult: Rol = objectMapper.readValue(firstEventValue.result.toString())
-
 
         assertThat(firstEventValue).isInstanceOf(ZaakRolCreated::class.java)
         assertThat(result.url.toString()).isEqualTo(firstEventValue.resultId.toString())

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/link/ZaakInstanceLinkServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/link/ZaakInstanceLinkServiceTest.kt
@@ -32,13 +32,13 @@ class ZaakInstanceLinkServiceTest {
 
     @Test
     fun `getByDocumentId should throw exception when no link is found`() {
-        val documentId = UUID.randomUUID()
-        whenever(zaakInstanceLinkRepository.findByDocumentId(documentId)).thenReturn(null)
+        val caseDocumentId = UUID.randomUUID()
+        whenever(zaakInstanceLinkRepository.findByDocumentId(caseDocumentId)).thenReturn(null)
 
         val exception = assertThrows<ZaakInstanceLinkNotFoundException> {
-            service.getByDocumentId(documentId)
+            service.getByDocumentId(caseDocumentId)
         }
 
-        assertEquals("No ZaakInstanceLink found for document id $documentId", exception.message)
+        assertEquals("No ZaakInstanceLink found for case document id $caseDocumentId", exception.message)
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.zakenapi.service
 
+import com.ritense.authorization.AuthorizationService
 import com.ritense.catalogiapi.service.CatalogiService
 import com.ritense.documentenapi.DocumentenApiPlugin
 import com.ritense.documentenapi.client.DocumentInformatieObject
@@ -24,6 +25,8 @@ import com.ritense.documentenapi.service.DocumentenApiService
 import com.ritense.documentenapi.service.DocumentenApiVersionService
 import com.ritense.documentenapi.service.DocumentenApiVersionService.Companion.MINIMUM_VERSION
 import com.ritense.documentenapi.web.rest.dto.DocumentSearchRequest
+import com.ritense.documentenapi.web.rest.dto.DocumentenApiDocumentDto
+import com.ritense.documentenapi.web.rest.dto.ModifyDocumentRequest
 import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.service.PluginService
@@ -61,6 +64,8 @@ class ZaakDocumentServiceTest {
     lateinit var catalogiService: CatalogiService
     lateinit var documentenApiService: DocumentenApiService
     lateinit var documentenApiVersionService: DocumentenApiVersionService
+    lateinit var authorizationService: AuthorizationService
+    lateinit var modifyDocumentRequest: ModifyDocumentRequest
 
     @BeforeEach
     fun init() {
@@ -69,20 +74,22 @@ class ZaakDocumentServiceTest {
         catalogiService = mock()
         documentenApiService = mock()
         documentenApiVersionService = mock()
+        authorizationService = mock()
         service = ZaakDocumentService(
             zaakUrlProvider,
             pluginService,
             catalogiService,
             documentenApiService,
-            documentenApiVersionService
+            documentenApiVersionService,
+            authorizationService
         )
     }
 
     @Test
     fun `should get informatieobjecten for document`() {
-        val documentId = UUID.randomUUID()
-        val zaakUrl = URI("https://example.com/1")
-        whenever(zaakUrlProvider.getZaakUrl(documentId)).thenReturn(zaakUrl)
+        val caseId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/$caseId")
+        whenever(zaakUrlProvider.getZaakUrl(caseId)).thenReturn(zaakUrl)
 
         val zakenApiPlugin = mock<ZakenApiPlugin>()
         whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
@@ -90,7 +97,7 @@ class ZaakDocumentServiceTest {
 
 
         val zaakInformatieObjects = createZaakInformatieObjecten(zaakUrl)
-        whenever(zakenApiPlugin.getZaakInformatieObjecten(zaakUrl)).thenReturn(
+        whenever(zakenApiPlugin.getZaakInformatieObjecten(caseId, zaakUrl)).thenReturn(
             zaakInformatieObjects
         )
 
@@ -102,13 +109,13 @@ class ZaakDocumentServiceTest {
             .doReturn(PluginConfigurationId(UUID.randomUUID()))
         whenever(pluginService.createInstance(eq(documentenApiPluginConfiguration)))
             .doReturn(documentenApiPlugin)
-        whenever(documentenApiPlugin.getInformatieObject(any<URI>())).doAnswer { answer ->
+        whenever(documentenApiPlugin.getInformatieObject(any<URI>(), any())).doAnswer { answer ->
             val uri = answer.getArgument(0) as URI
 
             createDocumentInformatieObject(uri)
         }
 
-        val relatedFiles = service.getInformatieObjectenAsRelatedFiles(documentId)
+        val relatedFiles = service.getInformatieObjectenAsRelatedFiles(caseId)
 
         assertEquals(5, relatedFiles.size)
         relatedFiles.forEachIndexed { index, relatedFile ->
@@ -120,7 +127,7 @@ class ZaakDocumentServiceTest {
 
     @Test
     fun `should get zaak by document id`() {
-        val documentId = UUID.randomUUID()
+        val caseDocumentId = UUID.randomUUID()
         val zaakId = UUID.randomUUID()
         val zaak = ZaakResponse(
             url = URI("http://localhost/$zaakId"),
@@ -130,26 +137,40 @@ class ZaakDocumentServiceTest {
             verantwoordelijkeOrganisatie = Rsin("002564440"),
             startdatum = LocalDate.now()
         )
-        doReturn(zaak.url).whenever(zaakUrlProvider).getZaakUrl(documentId)
+        doReturn(zaak.url).whenever(zaakUrlProvider).getZaakUrl(caseDocumentId)
         val zakenApiPlugin = mock<ZakenApiPlugin>()
         doReturn(zakenApiPlugin).whenever(pluginService).createInstance(eq(ZakenApiPlugin::class.java), any())
         doReturn(zaak).whenever(zakenApiPlugin).getZaak(zaak.url)
 
-        val result = service.getZaakByDocumentId(documentId)
+        val result = service.getZaakByCaseDocumentId(caseDocumentId)
 
         assertEquals(zaak, result)
     }
 
     @Test
     fun `should get InformatieObjecten Page for zaak`() {
-        val documentId = UUID.randomUUID()
-        val zaakUrl = URI("https://example.com/1")
-        whenever(zaakUrlProvider.getZaakUrl(documentId)).thenReturn(zaakUrl)
+        val caseDocumentId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/$caseDocumentId")
+        whenever(zaakUrlProvider.getZaakUrl(caseDocumentId)).thenReturn(zaakUrl)
 
         val documentSearchRequestCaptor = argumentCaptor<DocumentSearchRequest>()
         val pageable = mock<Pageable>()
         val documentSearchRequest = DocumentSearchRequest()
-        val resultPage = PageImpl(listOf<DocumentInformatieObject>())
+        val documentInformatieObject = createDocumentInformatieObject(URI("http://localhost/doc/${UUID.randomUUID()}"))
+        val resultPage = PageImpl(listOf(documentInformatieObject))
+
+        val pluginConfiguration = mock<PluginConfiguration>()
+        whenever(pluginConfiguration.id).thenReturn(PluginConfigurationId(UUID.randomUUID()))
+        whenever(pluginService.findPluginConfiguration(eq(DocumentenApiPlugin::class.java), any()))
+            .thenReturn(pluginConfiguration)
+
+        val version = DocumentenApiVersion("1.5.0-test-1.0.0", listOf("titel"), listOf("titel"), true)
+        whenever(documentenApiVersionService.getVersionByDocumentId(caseDocumentId))
+            .thenReturn(version)
+
+        whenever(
+            authorizationService.hasPermission<Any>(any())
+        ).thenReturn(true)
 
         whenever(
             documentenApiService.getCaseInformatieObjecten(
@@ -158,31 +179,57 @@ class ZaakDocumentServiceTest {
                 any()
             )
         ).thenReturn(resultPage)
-        whenever(documentenApiVersionService.getVersionByDocumentId(documentId))
-            .thenReturn(DocumentenApiVersion("1.5.0-test-1.0.0", listOf("titel"), listOf("titel")))
 
-        val page = service.getInformatieObjectenAsRelatedFilesPage(documentId, documentSearchRequest, pageable)
+        val page = service.getInformatieObjectenAsRelatedFilesPage(caseDocumentId, documentSearchRequest, pageable)
 
-        assertEquals(resultPage, page)
+        val expectedPage = resultPage.map { it ->
+            DocumentenApiDocumentDto(
+                fileId = UUID.fromString(it.url.path.substringAfterLast("/")),
+                pluginConfigurationId = pluginConfiguration.id.id,
+                bestandsnaam = it.bestandsnaam,
+                bestandsomvang = it.bestandsomvang,
+                creatiedatum = it.creatiedatum.atStartOfDay(),
+                auteur = it.auteur,
+                titel = it.titel,
+                status = it.status?.key,
+                taal = it.taal,
+                identificatie = it.identificatie,
+                beschrijving = it.beschrijving,
+                informatieobjecttype = it.informatieobjecttype,
+                informatieobjecttypeOmschrijving = null,
+                trefwoorden = it.trefwoorden,
+                formaat = it.formaat,
+                verzenddatum = it.verzenddatum,
+                ontvangstdatum = it.ontvangstdatum,
+                vertrouwelijkheidaanduiding = it.vertrouwelijkheidaanduiding?.key,
+                versie = it.versie,
+                indicatieGebruiksrecht = it.indicatieGebruiksrecht
+            )
+        }
+
+        assertEquals(expectedPage.content.toString(), page.content.toString())
+        assertEquals(expectedPage.totalElements, page.totalElements)
+        assertEquals(expectedPage.number, page.number)
+        assertEquals(expectedPage.size, page.size)
         // Check if the zaakUrl is set in the DocumentSearchRequest
         assertEquals(zaakUrl, documentSearchRequestCaptor.firstValue.zaakUrl)
     }
 
     @Test
     fun `should throw when get InformatieObjecten Page for zaak does not support filtering`() {
-        val documentId = UUID.randomUUID()
+        val caseDocumentId = UUID.randomUUID()
         val zaakUrl = URI("https://example.com/1")
-        whenever(zaakUrlProvider.getZaakUrl(documentId)).thenReturn(zaakUrl)
+        whenever(zaakUrlProvider.getZaakUrl(caseDocumentId)).thenReturn(zaakUrl)
 
         val pageable = PageRequest.of(0, 10)
         val documentSearchRequest = DocumentSearchRequest(titel = "The Ritensions")
 
-        whenever(documentenApiVersionService.getVersionByDocumentId(documentId)).thenReturn(MINIMUM_VERSION)
+        whenever(documentenApiVersionService.getVersionByDocumentId(caseDocumentId)).thenReturn(MINIMUM_VERSION)
         whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
             .thenReturn(mock<ZakenApiPlugin>())
 
         val exception = assertThrows<IllegalStateException> {
-            service.getInformatieObjectenAsRelatedFilesPage(documentId, documentSearchRequest, pageable)
+            service.getInformatieObjectenAsRelatedFilesPage(caseDocumentId, documentSearchRequest, pageable)
         }
 
         assertEquals("Unsupported filter 'titel' on Documenten API with version 1.0.0", exception.message)
@@ -190,7 +237,8 @@ class ZaakDocumentServiceTest {
 
     @Test
     fun `should delete all informatie objecten for zaak`() {
-        val documentUrl = URI("http://localhost/zaak/1")
+        val caseDocumentId = UUID.randomUUID()
+        val documentUrl = URI("http://localhost/zaak/$caseDocumentId")
         val zaakApiPlugin = mock<ZakenApiPlugin>()
 
         whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
@@ -198,18 +246,50 @@ class ZaakDocumentServiceTest {
         val doc1 = mock<ZaakInformatieObject>()
         val doc2 = mock<ZaakInformatieObject>()
 
-        whenever(zaakApiPlugin.getZaakInformatieObjecten(documentUrl)).thenReturn(listOf(doc1, doc2))
+        whenever(zaakApiPlugin.getZaakInformatieObjecten(caseDocumentId, documentUrl)).thenReturn(listOf(doc1, doc2))
 
         whenever(doc1.informatieobject).thenReturn(URI("http://localhost/doc/1"))
         whenever(doc2.informatieobject).thenReturn(URI("http://localhost/doc/2"))
 
-        service.deleteRelatedInformatieObjecten(documentUrl)
+        whenever(zaakApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId, URI("http://localhost/doc/1")))
+            .thenReturn(listOf(doc1))
+        whenever(zaakApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId, URI("http://localhost/doc/2")))
+            .thenReturn(listOf(doc2))
+
+        service.deleteRelatedInformatieObjecten(caseDocumentId, documentUrl)
 
         val zaakDocumentCaptor = argumentCaptor<URI>()
-        verify(documentenApiService, times(2)).deleteInformatieObject(zaakDocumentCaptor.capture())
+        verify(documentenApiService, times(2)).deleteInformatieObject(zaakDocumentCaptor.capture(), any())
 
         assertEquals(URI("http://localhost/doc/1"), zaakDocumentCaptor.firstValue)
         assertEquals(URI("http://localhost/doc/2"), zaakDocumentCaptor.secondValue)
+    }
+
+    @Test
+    fun `should only delete the link between informatie object and zaak when the informatie object is linked to multiple zaken`() {
+        val caseDocumentId = UUID.randomUUID()
+        val documentUrl = URI("http://localhost/zaak/$caseDocumentId")
+        val zaakApiPlugin = mock<ZakenApiPlugin>()
+
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .thenReturn(zaakApiPlugin)
+        val doc1 = mock<ZaakInformatieObject>()
+        val otherZaakDoc = mock<ZaakInformatieObject>()
+
+        whenever(zaakApiPlugin.getZaakInformatieObjecten(caseDocumentId, documentUrl)).thenReturn(listOf(doc1))
+
+        val doc1Url = URI("http://localhost/doc/1")
+        val relationUrl = URI("http://localhost/zaak-informatieobject/1")
+        whenever(doc1.informatieobject).thenReturn(doc1Url)
+        whenever(doc1.url).thenReturn(relationUrl)
+
+        whenever(zaakApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId, doc1Url))
+            .thenReturn(listOf(doc1, otherZaakDoc))
+
+        service.deleteRelatedInformatieObjecten(caseDocumentId, documentUrl)
+
+        verify(documentenApiService, times(0)).deleteInformatieObject(any(), any())
+        verify(zaakApiPlugin).deleteZaakInformatieobject(relationUrl, caseDocumentId)
     }
 
     private fun createZaakInformatieObjecten(zaakUrl: URI, count: Int = 5): List<ZaakInformatieObject> {
@@ -241,4 +321,69 @@ class ZaakDocumentServiceTest {
         versie = 1,
         informatieobjecttype = "http://localhost/informatieobjecttype",
     )
+
+    @Test
+    fun `should throw exception when deleting informatieObject that is not related to zaak`() {
+        val caseDocumentId = UUID.randomUUID()
+        val pluginConfigurationId = UUID.randomUUID()
+        val documentId = UUID.randomUUID().toString()
+        val zaakUrl = URI("https://example.com/zaken/$caseDocumentId")
+        val informatieobjectUrl = URI("https://example.com/enkelvoudiginformatieobjecten/$documentId")
+
+        whenever(zaakUrlProvider.getZaakUrl(caseDocumentId)).thenReturn(zaakUrl)
+
+        val zakenApiPlugin = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .thenReturn(zakenApiPlugin)
+
+        val documentenApiPlugin = mock<DocumentenApiPlugin>()
+        whenever(pluginService.createInstance(eq(PluginConfigurationId.existingId(pluginConfigurationId))))
+            .thenReturn(documentenApiPlugin)
+        whenever(documentenApiPlugin.createInformatieObjectUrl(documentId))
+            .thenReturn(informatieobjectUrl)
+
+        // Return null to indicate no relation exists
+        whenever(zakenApiPlugin.getZaakInformatieObject(caseDocumentId, zaakUrl, informatieobjectUrl))
+            .thenReturn(null)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            service.deleteInformatieObject(pluginConfigurationId.toString(), caseDocumentId, documentId)
+        }
+
+        assertEquals("InformatieObject is not related to this Zaak", exception.message)
+        verify(documentenApiService, times(0)).deleteInformatieObject(any<String>(), any<UUID>(), any<String>())
+    }
+
+    @Test
+    fun `should throw exception when modifying informatieObject that is not related to zaak`() {
+        val caseDocumentId = UUID.randomUUID()
+        val pluginConfigurationId = UUID.randomUUID()
+        val documentId = UUID.randomUUID().toString()
+        val zaakUrl = URI("https://example.com/zaken/$caseDocumentId")
+        val informatieobjectUrl = URI("https://example.com/enkelvoudiginformatieobjecten/$documentId")
+        modifyDocumentRequest = mock()
+
+        whenever(zaakUrlProvider.getZaakUrl(caseDocumentId)).thenReturn(zaakUrl)
+
+        val zakenApiPlugin = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .thenReturn(zakenApiPlugin)
+
+        val documentenApiPlugin = mock<DocumentenApiPlugin>()
+        whenever(pluginService.createInstance(eq(PluginConfigurationId.existingId(pluginConfigurationId))))
+            .thenReturn(documentenApiPlugin)
+        whenever(documentenApiPlugin.createInformatieObjectUrl(documentId))
+            .thenReturn(informatieobjectUrl)
+
+        // Return null to indicate no relation exists
+        whenever(zakenApiPlugin.getZaakInformatieObject(caseDocumentId, zaakUrl, informatieobjectUrl))
+            .thenReturn(null)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            service.modifyInformatieObject(pluginConfigurationId.toString(), caseDocumentId, documentId, modifyDocumentRequest)
+        }
+
+        assertEquals("InformatieObject is not related to this Zaak", exception.message)
+        verify(documentenApiService, times(0)).modifyInformatieObject(any<String>(), any(), any<String>(), any())
+    }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZakenApiDocumentDeletedEventListenerTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZakenApiDocumentDeletedEventListenerTest.kt
@@ -42,30 +42,29 @@ class ZakenApiDocumentDeletedEventListenerTest {
 
     @Test
     fun `should delete zaak when one is linked`() {
-        val documentId = UUID.fromString("d1f1b3ed-7575-45bb-a02b-18f378ddc34d")
-
+        val caseDocumentId = UUID.fromString("d1f1b3ed-7575-45bb-a02b-18f378ddc34d")
         val zaakInstanceUrl = URI("http://zaaak.url")
         val zaakInstanceLink = mock<ZaakInstanceLink>()
 
-        whenever(zaakInstanceService.getByDocumentId(documentId)).thenReturn(zaakInstanceLink)
+        whenever(zaakInstanceService.getByDocumentId(caseDocumentId)).thenReturn(zaakInstanceLink)
         whenever(zaakInstanceLink.zaakInstanceUrl).thenReturn(zaakInstanceUrl)
 
         val pluginInstance = mock<ZakenApiPlugin>()
         whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any())).thenReturn(pluginInstance)
 
-        listener.handle(DocumentDeletedEvent(documentId))
+        listener.handle(DocumentDeletedEvent(caseDocumentId))
 
-        verify(zaakDocumentService).deleteRelatedInformatieObjecten(zaakInstanceUrl)
+        verify(zaakDocumentService).deleteRelatedInformatieObjecten(caseDocumentId, zaakInstanceUrl)
         verify(pluginInstance).deleteZaak(zaakInstanceUrl)
     }
 
     @Test
     fun `should not throw exception when no zaak is linked`() {
-        val documentId = UUID.fromString("d1f1b3ed-7575-45bb-a02b-18f378ddc34d")
+        val caseDocumentId = UUID.fromString("d1f1b3ed-7575-45bb-a02b-18f378ddc34d")
 
-        whenever(zaakInstanceService.getByDocumentId(documentId)).thenThrow(ZaakInstanceLinkNotFoundException("No link found"))
+        whenever(zaakInstanceService.getByDocumentId(caseDocumentId)).thenThrow(ZaakInstanceLinkNotFoundException("No link found"))
 
-        listener.handle(DocumentDeletedEvent(documentId))
+        listener.handle(DocumentDeletedEvent(caseDocumentId))
 
         verifyNoInteractions(zaakDocumentService)
         verifyNoInteractions(pluginService)

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakDocumentResourceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakDocumentResourceTest.kt
@@ -107,7 +107,7 @@ class ZaakDocumentResourceTest : BaseIntegrationTest() {
             verantwoordelijkeOrganisatie = Rsin("002564440"),
             startdatum = LocalDate.now()
         )
-        doReturn(zaak).whenever(zaakDocumentService).getZaakByDocumentId(documentId)
+        doReturn(zaak).whenever(zaakDocumentService).getZaakByCaseDocumentId(documentId)
 
         mockMvc.perform(
             MockMvcRequestBuilders.get("/api/v1/zaken-api/document/" +

--- a/documentation/features/access-control/configuring-conditions.md
+++ b/documentation/features/access-control/configuring-conditions.md
@@ -326,9 +326,9 @@ Access to a user task can be controlled based on properties inside the JsonSchem
 
 <details>
 
-<summary>Conditions for resources based on case definition</summary>
+<summary>Conditions for resources based on Case type</summary>
 
-For this role the metadata of the resources related to a case (related documents on the Document API) is only editable when casetype is included in the 'value' list
+For this role the metadata of the resources related to a case (related documents on the Document API) is only editable when case type is included in the 'value' list
 
 ```json
 {

--- a/documentation/features/access-control/configuring-conditions.md
+++ b/documentation/features/access-control/configuring-conditions.md
@@ -343,7 +343,7 @@ For this role the metadata of the resources related to a case (related documents
             "conditions": [
                 {
                     "type": "field",
-                    "field": "documentDefinitionId.caseDefinitionId.key",
+                     "field": "documentDefinitionId.name",
                     "operator": "in",
                     "value": [
                         "bezwaar"

--- a/documentation/features/access-control/configuring-conditions.md
+++ b/documentation/features/access-control/configuring-conditions.md
@@ -323,3 +323,36 @@ Access to a user task can be controlled based on properties inside the JsonSchem
 ```
 
 </details>
+
+<details>
+
+<summary>Conditions for resources based on case definition</summary>
+
+For this role the metadata of the resources related to a case (related documents on the Document API) is only editable when casetype is included in the 'value' list
+
+```json
+{
+    "resourceType": "com.ritense.resource.authorization.ResourcePermission",
+    "actions": [
+        "edit"
+    ],
+    "conditions": [
+        {
+            "type": "container",
+            "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+            "conditions": [
+                {
+                    "type": "field",
+                    "field": "documentDefinitionId.caseDefinitionId.key",
+                    "operator": "in",
+                    "value": [
+                        "bezwaar"
+                    ]
+                }
+            ]
+        }
+    ]
+}
+```
+
+</details>

--- a/documentation/release-notes/12.x.x/12.28.0/README.md
+++ b/documentation/release-notes/12.x.x/12.28.0/README.md
@@ -2,9 +2,9 @@
 
 ## New Features
 
-* **New feature title**
+* **Added PBAC conditions for Resources based on Case type**
 
-  New feature explanation.
+  PBAC conditions for Resources (Case related documents on the Document API) allow role-based filtering by case type
 
 ## Enhancements
 

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.ts
@@ -61,7 +61,7 @@ import {
   SupportedDocumentenApiFeatures,
 } from '../../models';
 import {DocumentenApiColumnService, DocumentenApiVersionService} from '../../services';
-import {DocumentenApiDocumentService} from '../../services/documenten-api-document.service';
+import {DocumentenApiDocumentService} from '../../services';
 import {DocumentenApiFilterComponent} from '../documenten-api-filter/documenten-api-filter.component';
 import {DocumentenApiMetadataModalComponent} from '../documenten-api-metadata-modal/documenten-api-metadata-modal.component';
 import {
@@ -347,16 +347,29 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit, 
 
   public registerPermissionSubscriptions(): void {
     this._subscriptions.add(
-      this.relatedFiles$
+      combineLatest([this.relatedFiles$, this.documentId$])
         .pipe(
-          switchMap(files =>
-            combineLatest({
+          switchMap(([files, documentId]) => {
+            const documentContext = {
+              resource: RESOURCE_PERMISSION_RESOURCE.jsonSchemaDocument,
+              identifier: documentId,
+            };
+
+            return combineLatest({
               files: of(files),
-              canView: this.getPermissions(files, CAN_VIEW_RESOURCE_PERMISSION),
-              canModify: this.getPermissions(files, CAN_MODIFY_RESOURCE_PERMISSION),
-              canDelete: this.getPermissions(files, CAN_DELETE_RESOURCE_PERMISSION),
-            })
-          )
+              canView: this.getPermissions(files, CAN_VIEW_RESOURCE_PERMISSION, documentContext),
+              canModify: this.getPermissions(
+                files,
+                CAN_MODIFY_RESOURCE_PERMISSION,
+                documentContext
+              ),
+              canDelete: this.getPermissions(
+                files,
+                CAN_DELETE_RESOURCE_PERMISSION,
+                documentContext
+              ),
+            });
+          })
         )
         .subscribe(permissions =>
           permissions.files.map(
@@ -381,9 +394,16 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit, 
   }
 
   public deleteDocument(): void {
-    this._itemsLoading$.next(true);
-    this.documentenApiDocumentService.deleteDocument(this.document).subscribe(() => {
-      this.refetchDocuments();
+    this.documentId$.pipe(take(1)).subscribe(documentId => {
+      this._itemsLoading$.next(true);
+      this.documentenApiDocumentService.deleteDocument(this.document, documentId).subscribe({
+        next: () => {
+          this.refetchDocuments();
+        },
+        error: () => {
+          this._itemsLoading$.next(false);
+        },
+      });
     });
   }
 
@@ -433,10 +453,15 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit, 
         tap(([file, documentId]) => {
           if (!file) return;
           if (this.isEditMode$.getValue()) {
-            this.documentenApiDocumentService.updateDocument(file, metadata).subscribe(() => {
-              this.refetchDocuments();
-              this.uploading$.next(false);
-              this.fileToBeUploaded$.next(null);
+            this.documentenApiDocumentService.updateDocument(file, metadata, documentId).subscribe({
+              next: () => {
+                this.refetchDocuments();
+                this.uploading$.next(false);
+                this.fileToBeUploaded$.next(null);
+              },
+              error: () => {
+                this.uploading$.next(false);
+              },
             });
           } else {
             this.uploadProviderService
@@ -537,11 +562,13 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit, 
   }
 
   private downloadDocument(relatedFile: DocumentenApiRelatedFile, forceDownload: boolean): void {
-    this.downloadService.downloadFile(
-      `${this.valtimoEndpointUri}v1/documenten-api/${relatedFile.pluginConfigurationId}/files/${relatedFile.fileId}/download`,
-      relatedFile.bestandsnaam ?? '',
-      forceDownload
-    );
+    this.documentId$.pipe(take(1)).subscribe(documentId => {
+      this.downloadService.downloadFile(
+        `${this.valtimoEndpointUri}v1/zaken-api/${relatedFile.pluginConfigurationId}/case-document/${documentId}/files/${relatedFile.fileId}/download`,
+        relatedFile.bestandsnaam ?? '',
+        forceDownload
+      );
+    });
   }
 
   private openQueryParamsSubscription(): void {
@@ -619,16 +646,20 @@ export class DossierDetailTabDocumentenApiDocumentsComponent implements OnInit, 
 
   private getPermissions(
     files: DocumentenApiRelatedFile[],
-    permissionRequest: PermissionRequest
+    permissionRequest: PermissionRequest,
+    context?: any
   ): Observable<{
     [key: string]: boolean;
   }> {
     return combineLatest(
       files.map(file =>
-        this.getPermission(permissionRequest, {
-          resource: RESOURCE_PERMISSION_RESOURCE.resourcePermission,
-          identifier: file.fileId,
-        }).pipe(map(available => ({[file.fileId]: available})))
+        this.getPermission(
+          permissionRequest,
+          context || {
+            resource: RESOURCE_PERMISSION_RESOURCE.resourcePermission,
+            identifier: file.fileId,
+          }
+        ).pipe(map(available => ({[file.fileId]: available})))
       )
     ).pipe(
       map(permissions => permissions.reduce((acc, permission) => ({...acc, ...permission}), {}))

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/services/documenten-api-document.service.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/services/documenten-api-document.service.ts
@@ -47,16 +47,23 @@ export class DocumentenApiDocumentService extends BaseApiService {
         );
   }
 
-  public updateDocument(file: any, metadata: any): Observable<void> {
+  public updateDocument(file: any, metadata: any, caseDocumentId: string): Observable<void> {
     return this.httpClient.put<void>(
-      this.getApiUrl(`/v1/documenten-api/${file.pluginConfigurationId}/files/${file.fileId}`),
+      this.getApiUrl(
+        `/v1/zaken-api/${file.pluginConfigurationId}/case-document/${caseDocumentId}/files/${file.fileId}`
+      ),
       metadata
     );
   }
 
-  public deleteDocument(file: DocumentenApiRelatedFile): Observable<DocumentenApiRelatedFile[]> {
+  public deleteDocument(
+    file: DocumentenApiRelatedFile,
+    caseDocumentId: string
+  ): Observable<DocumentenApiRelatedFile[]> {
     return this.httpClient.delete<DocumentenApiRelatedFile[]>(
-      this.getApiUrl(`/v1/documenten-api/${file.pluginConfigurationId}/files/${file.fileId}`)
+      this.getApiUrl(
+        `/v1/zaken-api/${file.pluginConfigurationId}/case-document/${caseDocumentId}/files/${file.fileId}`
+      )
     );
   }
 


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/626

Specify the code branch location: 
story/152455-gh-issue-626

Original PR: https://github.com/valtimo-platform/valtimo/pull/391 (released 13.19.0)

**Relevant comments:**
> 

### Breaking changes
Moved DocumentenApiResource resources from documenten-api to ZaakDocumentResource (module zaken-api)
com.ritense.documentenapi.web.rest.DocumentenApiResource#downloadDocument
com.ritense.documentenapi.web.rest.DocumentenApiResource#modifyDocument
com.ritense.documentenapi.web.rest.DocumentenApiResource#deleteDocument

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Describe the testing steps
- Make a case of type '**bezwaar**'
- Upload some files in **Documenten** tab
- Log in as '**James Vance**' (user/user)
- Verify that the User has full access (view_list, create, view/download, modify, delete) to the documents in a case instance with the existing resource.permission.json: https://github.com/valtimo-platform/valtimo/blob/story/152455-gh-issue-626/backend/app/gzac/src/main/resources/config/pbac/resource.permission.json
- Modify resource.permission.json to verify these additional scenarios:
	•	no modify permission
	•	no delete permission
	•	no view permission
        •       no view_list permission
	•	no create permission

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [x] Yes
- [ ] Not applicable

Valtimo access control checks have been implemented
- [x] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
