### PR TITLE
enable open zaak to send notifications to open notifications

### DIFF
--- a/backend/app/gzac/docker-compose.yaml
+++ b/backend/app/gzac/docker-compose.yaml
@@ -100,28 +100,31 @@ services:
     # ZGW
 
     openzaak:
-        image: openzaak/open-zaak:1.20.0
+        image: openzaak/open-zaak:1.25.0
         container_name: gzac-docker-compose-openzaak
         platform: linux/amd64
         profiles:
             - zgw
             - openzaak
-        environment:
+        environment: &openzaak-env
             - DB_HOST=openzaak-database
-            - DB_POST=5433
+            - DB_PORT=5432
             - SECRET_KEY=veryRestrictedSecretKey
             - DB_USER=openzaak
             - DB_PASSWORD=openzaak
             - DB_NAME=openzaak
-            - CACHE_DEFAULT=openzaak-redis:6379/0
-            - CACHE_AXES=openzaak-redis:6379/0
             - DEBUG=true
             - ALLOWED_HOSTS=localhost,host.docker.internal,172.17.0.1,openzaak
             - OPENZAAK_SUPERUSER_USERNAME=admin
             - OPENZAAK_SUPERUSER_EMAIL=admin@admin.org
             - DJANGO_SUPERUSER_PASSWORD=admin
             - SENDFILE_BACKEND=django_sendfile.backends.simple
-            - NOTIFICATIONS_DISABLED=true
+            - NOTIFICATIONS_DISABLED=false
+            - CACHE_DEFAULT=openzaak-redis:6379/0
+            - CACHE_AXES=openzaak-redis:6379/0
+            - CELERY_BROKER_URL=redis://openzaak-redis:6379/0
+            - CELERY_RESULT_BACKEND=redis://openzaak-redis:6379/0
+            - REDIS_URL=redis://openzaak-redis:6379/0
             - DISABLE_2FA=True
         ports:
             - "8001:8000"
@@ -144,6 +147,22 @@ services:
             - "5433:5432"
         volumes:
             - ./imports/open-zaak:/docker-entrypoint-initdb.d
+
+    openzaak-celery:
+        image: openzaak/open-zaak:1.25.0
+        container_name: gzac-docker-compose-openzaak-celery
+        platform: linux/amd64
+        environment: *openzaak-env
+        command: /celery_worker.sh
+        profiles:
+            - zgw
+            - openzaak
+        healthcheck:
+            test: [ "CMD", "python", "/app/bin/check_celery_worker_liveness.py" ]
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 10s
 
     openzaak-redis:
         image: redis:7.4.3
@@ -326,8 +345,8 @@ services:
             - "15673:15672"
 
     open-notificaties-celery:
-        image: openzaak/open-notificaties:1.8.2
-        container_name: gzac-docker-compose-open-notificaties
+        image: openzaak/open-notificaties:1.13.0
+        container_name: gzac-docker-compose-open-notificaties-celery
         platform: linux/amd64
         profiles:
             - zgw
@@ -338,6 +357,7 @@ services:
             - CACHE_DEFAULT=open-notificaties-redis:6379/0
             - CACHE_AXES=open-notificaties-redis:6379/1
             - DB_PORT=5432
+            - LOG_NOTIFICATIONS_IN_DB=true
             - DB_HOST=open-notificaties-database
             - DB_NAME=notifications
             - DB_USER=notifications
@@ -358,8 +378,8 @@ services:
             - open-notificaties-redis
 
     open-notificaties:
-        image: openzaak/open-notificaties:1.8.1
-        container_name: gzac-docker-compose-open-notificaties-celery
+        image: openzaak/open-notificaties:1.13.0
+        container_name: gzac-docker-compose-open-notificaties
         platform: linux/amd64
         profiles:
             - zgw

--- a/backend/app/gzac/docker-compose.yaml
+++ b/backend/app/gzac/docker-compose.yaml
@@ -157,6 +157,9 @@ services:
         profiles:
             - zgw
             - openzaak
+        depends_on:
+            - openzaak-database
+            - openzaak-redis
         healthcheck:
             test: [ "CMD", "python", "/app/bin/check_celery_worker_liveness.py" ]
             interval: 30s

--- a/backend/app/gzac/imports/open-zaak/database/2-setup-opennotifications-service.sql
+++ b/backend/app/gzac/imports/open-zaak/database/2-setup-opennotifications-service.sql
@@ -1,0 +1,13 @@
+\set service_id 11
+--
+-- Data for Name: zgw_consumers_service; Type: TABLE DATA; Schema: public; Owner: openzaak
+--
+
+
+INSERT INTO public.zgw_consumers_service
+     VALUES (:service_id, 'Notificaties API', 'nrc', 'http://host.docker.internal:8002/api/v1/', 'openzaak', 'openzaak', 'zgw', '', '', '', '', '', NULL, NULL, '5c867a14-2ff4-4574-9451-5c23cc3f75a0', 10, '', 'notificaties-api', 43200);
+
+INSERT INTO public.notifications_api_common_notificationsconfig VALUES (1, :service_id, 5, 3, 48, 4)
+    ON CONFLICT (id)
+DO UPDATE SET
+    notifications_api_service_id = EXCLUDED.notifications_api_service_id;

--- a/documentation/release-notes/13.x.x/13.20.0/README.md
+++ b/documentation/release-notes/13.x.x/13.20.0/README.md
@@ -21,6 +21,11 @@
   - `view`: Allows viewing details of a single user.
   - `view_list`: Allows viewing a list of users or searching for users.
 
+* **Enabled Openzaak to send notifications to Open Notificatie**
+
+  This feature allows Openzaak to send notifications to Open Notificatie, ensuring that relevant parties are informed about
+  case updates and progress. Notifications are sent for various events such as case creation, document added to case.
+
 ## Bugfixes
 
 * Fixed a bug where task auto-assignment ignored permission restrictions. When auto-assign was enabled, the case assignee was automatically assigned to tasks regardless of whether their permissions allowed it.


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Github issue:
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/629

Code branch
story/openzaak-enable-notifications

An additional sql script is added to imports/openzaak to insert the service that enables notification communication with open notificaties

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [1] Create a case in GZAC
- [2] Check if there is a notification logged in Notificaties (http://localhost:8002/admin/datamodel/notificatie/)


### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
