### PR TITLE
Expandable fields and table widgets

### DIFF
--- a/backend/case/src/main/kotlin/com/ritense/case_/widget/fields/FieldsWidgetProperties.kt
+++ b/backend/case/src/main/kotlin/com/ritense/case_/widget/fields/FieldsWidgetProperties.kt
@@ -31,6 +31,7 @@ data class FieldsWidgetProperties (
         @field:NotBlank val key: String,
         val title: String,
         @field:NotBlank val value: String,
-        @field:Valid val displayProperties: FieldDisplayProperties? = null
+        @field:Valid val displayProperties: FieldDisplayProperties? = null,
+        val showInPopup: Boolean? = null
     )
 }

--- a/backend/case/src/main/kotlin/com/ritense/case_/widget/table/TableWidgetProperties.kt
+++ b/backend/case/src/main/kotlin/com/ritense/case_/widget/table/TableWidgetProperties.kt
@@ -28,13 +28,15 @@ data class TableWidgetProperties (
     @field:NotBlank val collection: String,
     @field:Min(1) val defaultPageSize: Int,
     @field:NotEmpty val columns: List<@Valid Column>,
-    val firstColumnAsTitle: Boolean = false
+    val firstColumnAsTitle: Boolean = false,
+    val displayMode: String? = null
 ) {
     @JsonInclude(Include.NON_NULL)
     data class Column (
         @field:NotBlank val key: String,
         val title: String,
         @field:NotBlank val value: String,
-        @field:Valid val displayProperties: FieldDisplayProperties? = null
+        @field:Valid val displayProperties: FieldDisplayProperties? = null,
+        val visible: Boolean? = null
     )
 }

--- a/backend/case/src/main/kotlin/com/ritense/case_/widget/table/TableWidgetProperties.kt
+++ b/backend/case/src/main/kotlin/com/ritense/case_/widget/table/TableWidgetProperties.kt
@@ -24,6 +24,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 
+@JsonInclude(Include.NON_NULL)
 data class TableWidgetProperties (
     @field:NotBlank val collection: String,
     @field:Min(1) val defaultPageSize: Int,

--- a/backend/widget/src/main/kotlin/com/ritense/widget/fields/FieldsWidgetProperties.kt
+++ b/backend/widget/src/main/kotlin/com/ritense/widget/fields/FieldsWidgetProperties.kt
@@ -31,6 +31,7 @@ data class FieldsWidgetProperties(
         @field:NotBlank val key: String,
         val title: String,
         @field:NotBlank val value: String,
-        @field:Valid val displayProperties: FieldDisplayProperties? = null
+        @field:Valid val displayProperties: FieldDisplayProperties? = null,
+        val showInPopup: Boolean? = null
     )
 }

--- a/backend/widget/src/main/kotlin/com/ritense/widget/table/TableWidgetProperties.kt
+++ b/backend/widget/src/main/kotlin/com/ritense/widget/table/TableWidgetProperties.kt
@@ -28,13 +28,15 @@ data class TableWidgetProperties(
     @field:NotBlank val collection: String,
     @field:Min(1) val defaultPageSize: Int,
     @field:NotEmpty val columns: List<@Valid Column>,
-    val firstColumnAsTitle: Boolean = false
+    val firstColumnAsTitle: Boolean = false,
+    val displayMode: String? = null
 ) {
     @JsonInclude(Include.NON_NULL)
     data class Column(
         @field:NotBlank val key: String,
         val title: String?,
         @field:NotBlank val value: String,
-        @field:Valid val displayProperties: FieldDisplayProperties? = null
+        @field:Valid val displayProperties: FieldDisplayProperties? = null,
+        val visible: Boolean? = null
     )
 }

--- a/backend/widget/src/main/kotlin/com/ritense/widget/table/TableWidgetProperties.kt
+++ b/backend/widget/src/main/kotlin/com/ritense/widget/table/TableWidgetProperties.kt
@@ -24,6 +24,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 
+@JsonInclude(Include.NON_NULL)
 data class TableWidgetProperties(
     @field:NotBlank val collection: String,
     @field:Min(1) val defaultPageSize: Int,

--- a/frontend/projects/valtimo/case/src/lib/components/case-detail/tab/widgets/components/table/case-widget-table.component.html
+++ b/frontend/projects/valtimo/case/src/lib/components/case-detail/tab/widgets/components/table/case-widget-table.component.html
@@ -17,7 +17,9 @@
 <valtimo-widget-table
   [widgetData]="widgetData$ | async"
   [widgetConfiguration]="widgetConfiguration"
+  [allWidgetData]="allWidgetData$ | async"
   (paginationEvent)="onPaginationEvent($event)"
+  (showAllClick)="onShowAllClick()"
 >
   @if (widgetConfiguration?.actions?.length === 1) {
     @if (widgetConfiguration.actions[0].processDefinitionKey) {

--- a/frontend/projects/valtimo/case/src/lib/components/case-detail/tab/widgets/components/table/case-widget-table.component.ts
+++ b/frontend/projects/valtimo/case/src/lib/components/case-detail/tab/widgets/components/table/case-widget-table.component.ts
@@ -33,6 +33,7 @@ import {
   of,
   startWith,
   switchMap,
+  take,
   tap,
 } from 'rxjs';
 import {CaseTabService, CaseWidgetsApiService} from '../../../../../../services';
@@ -145,8 +146,29 @@ export class CaseWidgetTableComponent extends WidgetProcess {
     super(documentService, permissionService);
   }
 
+  public readonly allWidgetData$ = new BehaviorSubject<Page<CarbonListItem> | null>(null);
+
   public onPaginationEvent(event: PaginationModel): void {
     this._queryParams$.next(`page=${event.currentPage - 1}&size=${event.pageLength}`);
+  }
+
+  public onShowAllClick(): void {
+    combineLatest([this.tabKey$, this._documentId$])
+      .pipe(
+        take(1),
+        switchMap(([tabKey, documentId]) =>
+          this.caseWidgetsApiService.getWidgetData(
+            documentId,
+            tabKey,
+            this.widgetConfiguration.key,
+            'page=0&size=9999'
+          )
+        ),
+        catchError(() => of(null))
+      )
+      .subscribe(data => {
+        this.allWidgetData$.next(data as Page<CarbonListItem>);
+      });
   }
 
   public onProcessStartClick(process: WidgetAction): void {

--- a/frontend/projects/valtimo/components/src/lib/components/mdi-icon-selector/mdi-icon-selector.component.html
+++ b/frontend/projects/valtimo/components/src/lib/components/mdi-icon-selector/mdi-icon-selector.component.html
@@ -22,7 +22,7 @@
   </v-input-label>
 
   <div class="mdi-icon-selector">
-    <span class="mdi-icon-preview mdi" [ngClass]="(value$ | async) || 'mdi-minus'"></span>
+    <span *ngIf="value$ | async as icon" class="mdi-icon-preview mdi" [ngClass]="icon"></span>
 
     <cds-combo-box
       [items]="(items$ | async) || []"

--- a/frontend/projects/valtimo/components/src/lib/components/mdi-icon-selector/mdi-icon-selector.component.scss
+++ b/frontend/projects/valtimo/components/src/lib/components/mdi-icon-selector/mdi-icon-selector.component.scss
@@ -18,7 +18,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  width: 350px;
+  width: 100%;
 
   cds-combo-box {
     flex: 1 1 auto;

--- a/frontend/projects/valtimo/components/src/lib/components/value-path-selector/value-path-selector.component.scss
+++ b/frontend/projects/valtimo/components/src/lib/components/value-path-selector/value-path-selector.component.scss
@@ -43,7 +43,8 @@
   }
 
   ::ng-deep cds-dropdown,
-  ::ng-deep cds-combo-box {
+  ::ng-deep cds-combo-box,
+  ::ng-deep input.cds--text-input {
     width: 100%;
     min-width: 0;
   }

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-block/widget-block.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-block/widget-block.component.html
@@ -23,6 +23,7 @@
   [style.--widget-layer-color]="widgetColors?.layer"
   [style.--widget-text-color]="widgetColors?.text"
   [style.--widget-accent-color]="widgetColors?.accent"
+  [style.--widget-border-color]="widgetColors?.border"
 >
   <div #widgetBlockContent class="widget-block__content">
     <ng-template #widgetComponent></ng-template>

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-block/widget-block.component.scss
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-block/widget-block.component.scss
@@ -28,7 +28,6 @@
   background-color: var(--widget-background-color, var(--cds-layer-01));
   background-clip: content-box;
   color: var(--widget-text-color, var(--cds-text-primary));
-
   &__not-available {
     padding: 16px;
   }

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-block/widget-block.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-block/widget-block.component.ts
@@ -91,6 +91,8 @@ export class WidgetBlockComponent implements AfterViewInit, OnDestroy {
       const blockHeight = Math.ceil((contentHeight + 16) / WIDGET_HEIGHT_1X) * WIDGET_HEIGHT_1X;
 
       this.renderer.setStyle(viewRef.element.nativeElement, 'height', `${blockHeight}px`);
+      viewRef.element.nativeElement.style.setProperty('--widget-available-height', `${blockHeight - 16}px`);
+
       this.widgetLayoutService.triggerMuuriLayout();
     })
   );

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-field/widget-field.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-field/widget-field.component.html
@@ -18,6 +18,8 @@
   *ngIf="{
     widgetConfiguration: widgetConfiguration$ | async,
     widgetPropertyValue: widgetPropertyValue$ | async,
+    mainWidgetPropertyValue: mainWidgetPropertyValue$ | async,
+    hasPopupFields: hasPopupFields$ | async,
     widgetData: widgetData$ | async,
     isEmptyWidgetData: isEmptyWidgetData$ | async,
     noVisibleFields: noVisibleFields$ | async,
@@ -65,7 +67,7 @@
           [smallPadding]="true"
         ></valtimo-no-results>
       } @else {
-        @for (column of obs?.widgetPropertyValue; track column.key) {
+        @for (column of obs?.mainWidgetPropertyValue; track column.key) {
           <div class="valtimo-widget-field__column">
             @for (property of column; track property) {
               <div
@@ -98,5 +100,61 @@
         }
       }
     </div>
+
+    @if (obs.hasPopupFields) {
+      <button
+        cdsButton="tertiary"
+        size="sm"
+        class="valtimo-widget-field__show-more"
+        (click)="popupModalOpen.set(true)"
+      >
+        {{ 'widgets.showMore' | translate }}
+        <svg cdsIcon="arrow--right" size="16" class="cds--btn__icon"></svg>
+      </button>
+    }
   }
 </ng-container>
+
+<valtimo-render-in-body>
+  <cds-modal
+    [open]="popupModalOpen()"
+    (overlaySelected)="popupModalOpen.set(false)"
+    (close)="popupModalOpen.set(false)"
+  >
+    <cds-modal-header [showCloseButton]="true" (closeSelect)="popupModalOpen.set(false)">
+      <h3 cdsModalHeaderHeading>
+        {{ (widgetConfiguration$ | async)?.title }}
+      </h3>
+    </cds-modal-header>
+
+    <div cdsModalContent class="valtimo-widget-field__popup-modal-content">
+      @for (column of (popupFieldColumns$ | async); track column) {
+        <div class="valtimo-widget-field__popup-column">
+          @for (property of column; track property) {
+            <div
+              *ngIf="
+                (property?.value !== null &&
+                  property?.value !== '-' &&
+                  property?.hideWhenEmpty) ||
+                !property?.hideWhenEmpty
+              "
+              class="valtimo-widget-field__field"
+            >
+              <label class="valtimo-widget-field__field-label" [attr.title]="property?.title">
+                {{ property?.title }}</label
+              >
+
+              <div [attr.title]="property?.value" class="valtimo-widget-field__field-value">
+                @if (property?.isRawValue) {
+                  <div [innerHTML]="property?.value"></div>
+                } @else {
+                  {{ property?.value | valtimoEllipsis: property?.ellipsisCharacterLimit }}
+                }
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  </cds-modal>
+</valtimo-render-in-body>

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-field/widget-field.component.scss
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-field/widget-field.component.scss
@@ -23,7 +23,15 @@
     justify-content: space-between;
   }
 
-  &,
+  & {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    min-height: var(--widget-available-height, auto);
+    box-sizing: border-box;
+  }
+
   &__column {
     display: flex;
     flex-direction: column;
@@ -70,7 +78,7 @@
     &-value {
       color: var(--widget-text-color, var(--cds-text-primary));
       padding: 8px 16px;
-      border-bottom: 1px solid var(--cds-border-subtle-01);
+      border-bottom: 1px solid var(--widget-border-color, var(--cds-border-subtle-01));
       font-size: 14px;
 
       cds-skeleton-text {
@@ -90,6 +98,32 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  > valtimo-render-in-body {
+    display: contents;
+  }
+
+  &__show-more {
+    align-self: flex-end;
+    margin-top: auto;
+    --cds-button-tertiary: var(--widget-text-color, var(--cds-interactive));
+    --cds-button-tertiary-hover: var(--widget-text-color, var(--cds-interactive));
+    --cds-button-tertiary-active: var(--widget-text-color, var(--cds-interactive));
+    --cds-text-on-color: var(--widget-background-color, #ffffff);
+  }
+
+  &__popup-modal-content {
+    display: flex;
+    flex-direction: row;
+    gap: 32px;
+  }
+
+  &__popup-column {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 16px;
   }
 
   &__render {
@@ -118,7 +152,7 @@
     .valtimo-widget-field {
       &__column {
         gap: 8px;
-        border-left: 1px solid var(--widget-accent-color, var(--cds-border-subtle-01));
+        border-left: 1px solid var(--widget-border-color, var(--cds-border-subtle-01));
         padding-left: 16px;
       }
 
@@ -140,7 +174,7 @@
 
       &__render > * {
         padding-left: 16px;
-        border-left: 1px solid var(--widget-accent-color, var(--cds-border-subtle-01));
+        border-left: 1px solid var(--widget-border-color, var(--cds-border-subtle-01));
       }
     }
   }

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-field/widget-field.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-field/widget-field.component.ts
@@ -33,10 +33,20 @@ import {
   CarbonListModule,
   EllipsisPipe,
   MdiIconViewerComponent,
+  RenderInBodyComponent,
   ViewContentService,
   ViewType,
 } from '@valtimo/components';
-import {ButtonModule, InputModule, LayerModule, SkeletonModule} from 'carbon-components-angular';
+import {ArrowRight16} from '@carbon/icons';
+import {
+  ButtonModule,
+  IconModule,
+  IconService,
+  InputModule,
+  LayerModule,
+  ModalModule,
+  SkeletonModule,
+} from 'carbon-components-angular';
 import {BehaviorSubject, combineLatest, map, Observable, tap} from 'rxjs';
 import {FieldsWidget} from '../../models';
 import {WidgetTextDisplayType} from '../../models/widget-display.model';
@@ -58,7 +68,10 @@ import {WidgetActionButtonComponent} from '../widget-action-button/widget-action
     ButtonModule,
     WidgetActionButtonComponent,
     MdiIconViewerComponent,
+    IconModule,
     LayerModule,
+    ModalModule,
+    RenderInBodyComponent,
     SkeletonModule,
   ],
 })
@@ -94,6 +107,7 @@ export class WidgetFieldComponent implements AfterViewInit, OnDestroy {
       ellipsisCharacterLimit: number | null;
       hideWhenEmpty: boolean | false;
       isRawValue: boolean | false;
+      showInPopup: boolean;
     }[][]
   > = combineLatest([this.widgetConfiguration$, this.widgetData$]).pipe(
     map(([widget, widgetData]) =>
@@ -122,6 +136,7 @@ export class WidgetFieldComponent implements AfterViewInit, OnDestroy {
                       ...property.displayProperties,
                       viewType: property.displayProperties?.type ?? ViewType.TEXT,
                     }),
+                    showInPopup: property.showInPopup ?? false,
                   },
                 ]
               : []),
@@ -129,13 +144,40 @@ export class WidgetFieldComponent implements AfterViewInit, OnDestroy {
           []
         )
       )
-    ),
-    tap(columns => this.checkEmptyFields(columns))
+    )
   );
+
+  public readonly mainWidgetPropertyValue$ = this.widgetPropertyValue$.pipe(
+    map(columns =>
+      columns
+        ?.map(column => column.filter(field => !field.showInPopup))
+        .filter(column => column.length > 0)
+    ),
+    tap(columns => this.checkEmptyFields(columns ?? []))
+  );
+
+  public readonly hasPopupFields$ = this.widgetPropertyValue$.pipe(
+    map(columns => columns?.some(column => column.some(field => field.showInPopup)) ?? false)
+  );
+
+  public readonly popupFieldColumns$ = this.widgetPropertyValue$.pipe(
+    map(columns => {
+      const allFields = columns?.flatMap(column => column) ?? [];
+      const mid = Math.ceil(allFields.length / 2);
+      return allFields.length > 0 ? [allFields.slice(0, mid), allFields.slice(mid)] : [];
+    })
+  );
+
+  public readonly popupModalOpen = signal(false);
 
   private _observer!: ResizeObserver;
 
-  constructor(private readonly viewContentService: ViewContentService) {}
+  constructor(
+    private readonly iconService: IconService,
+    private readonly viewContentService: ViewContentService
+  ) {
+    this.iconService.register(ArrowRight16);
+  }
 
   public ngAfterViewInit(): void {
     if (this._widgetFieldRef) this.openWidthObserver();

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/column/widget-management-fields-column.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/column/widget-management-fields-column.component.html
@@ -423,6 +423,64 @@
       </cds-tag>
     </section>
 
+    <div
+      *ngIf="showInPopupCheckbox"
+      class="valtimo-widget-management-field-column__title-switcher"
+      (click)="$event.stopImmediatePropagation()"
+    >
+      <cds-content-switcher size="sm" class="cds--content-switcher--low-contrast" (selected)="onShowInPopupSwitcherChange(index, $event)">
+        <button
+          cdsContentOption
+          name="widget"
+          [active]="!formRows?.at(index).get('showInPopup')?.value"
+          [iconOnly]="true"
+          [description]="'widgetTabManagement.content.fields.displayWidget' | translate"
+          [title]="'widgetTabManagement.content.fields.displayWidgetTooltip' | translate"
+        >
+          <svg cdsIcon="view--filled" size="16"></svg>
+        </button>
+        <button
+          cdsContentOption
+          name="popup"
+          [active]="formRows?.at(index).get('showInPopup')?.value"
+          [iconOnly]="true"
+          [description]="'widgetTabManagement.content.fields.displayPopup' | translate"
+          [title]="'widgetTabManagement.content.fields.displayPopupTooltip' | translate"
+        >
+          <svg cdsIcon="view--off--filled" size="16"></svg>
+        </button>
+      </cds-content-switcher>
+    </div>
+
+    <div
+      *ngIf="showVisibilityToggle"
+      class="valtimo-widget-management-field-column__title-switcher"
+      (click)="$event.stopImmediatePropagation()"
+    >
+      <cds-content-switcher size="sm" class="cds--content-switcher--low-contrast" (selected)="onVisibilitySwitcherChange(index, $event)">
+        <button
+          cdsContentOption
+          name="visible"
+          [active]="formRows?.at(index).get('visible')?.value !== false"
+          [iconOnly]="true"
+          [description]="'widgetTabManagement.content.fields.columnVisible' | translate"
+          [title]="'widgetTabManagement.content.fields.columnVisibleTooltip' | translate"
+        >
+          <svg cdsIcon="view--filled" size="16"></svg>
+        </button>
+        <button
+          cdsContentOption
+          name="hidden"
+          [active]="formRows?.at(index).get('visible')?.value === false"
+          [iconOnly]="true"
+          [description]="'widgetTabManagement.content.fields.columnHidden' | translate"
+          [title]="'widgetTabManagement.content.fields.columnHiddenTooltip' | translate"
+        >
+          <svg cdsIcon="view--off--filled" size="16"></svg>
+        </button>
+      </cds-content-switcher>
+    </div>
+
     <button
       cdsButton="danger"
       [disabled]="count === 1"

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/column/widget-management-fields-column.component.scss
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/column/widget-management-fields-column.component.scss
@@ -58,6 +58,66 @@
     padding: 8px;
   }
 
+  &__title-switcher {
+    margin-left: auto;
+    margin-right: 8px;
+
+    // Low-contrast: gray pill via inner wrapper, not per-button borders
+    .cds--content-switcher--low-contrast .cds--content-switcher {
+      box-shadow: inset 0 0 0 1px var(--cds-border-strong) !important;
+      background-color: var(--cds-layer-accent-01) !important;
+      border-radius: 4px !important;
+    }
+
+    .cds--content-switcher--low-contrast .cds--content-switcher-btn {
+      inline-size: 2rem !important;
+      block-size: 2rem !important;
+      padding: 0 !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      border: none !important;
+      background-color: transparent !important;
+      color: var(--cds-icon-secondary) !important;
+    }
+
+    // Hide ::before separator between buttons
+    .cds--content-switcher--low-contrast .cds--content-switcher-btn::before {
+      display: none !important;
+    }
+
+    // Selected chip: white chip via ::after with dark inset border
+    .cds--content-switcher--low-contrast .cds--content-switcher-btn.cds--content-switcher--selected {
+      background-color: transparent !important;
+      color: var(--cds-icon-primary) !important;
+
+      &::after {
+        border-radius: 4px !important;
+        background-color: var(--cds-layer-01) !important;
+        box-shadow: inset 0 0 0 1px var(--cds-border-inverse) !important;
+        block-size: 100% !important;
+        inline-size: 100% !important;
+        transform: scaleY(1) !important;
+        transform-origin: bottom !important;
+        inset-block-start: 0 !important;
+        inset-inline-start: 0 !important;
+      }
+    }
+
+    // Focus state: clean ring without white gap, correct border-radius
+    .cds--content-switcher--low-contrast .cds--content-switcher-btn:focus::after {
+      border-radius: 4px !important;
+      box-shadow: inset 0 0 0 2px var(--cds-focus) !important;
+    }
+
+    // Icon label needs position:relative so z-index:1 works above the ::after chip
+    .cds--content-switcher--low-contrast .cds--content-switcher__label {
+      position: relative !important;
+      z-index: 1 !important;
+      line-height: 0 !important;
+    }
+  }
+
   &__delete-button {
     display: flex;
     align-items: center;

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/column/widget-management-fields-column.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/column/widget-management-fields-column.component.ts
@@ -40,7 +40,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import {TrashCan16} from '@carbon/icons';
+import {TrashCan16, ViewFilled16, ViewOffFilled16} from '@carbon/icons';
 import {TranslateModule, TranslateService} from '@ngx-translate/core';
 import {
   CdsThemeService,
@@ -57,6 +57,7 @@ import {
   AccordionModule,
   ButtonModule,
   CheckboxModule,
+  ContentSwitcherModule,
   Dropdown,
   DropdownModule,
   IconModule,
@@ -64,10 +65,10 @@ import {
   InputModule,
   LayerModule,
   ListItem,
-  ToggleModule,
   TagModule,
+  ToggleModule,
 } from 'carbon-components-angular';
-import {debounceTime, map, Observable, startWith, Subscription, take, tap} from 'rxjs';
+import {map, Observable, startWith, Subscription, take, tap} from 'rxjs';
 import {WIDGET_MANAGEMENT_SERVICE} from '../../../../../constants';
 import {IWidgetManagementService} from '../../../../../interfaces';
 import {
@@ -107,6 +108,7 @@ import {WidgetFieldsService, WidgetWizardService} from '../../../../../services'
     SelectModule,
     TagModule,
     ToggleModule,
+    ContentSwitcherModule,
   ],
 })
 export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy {
@@ -116,7 +118,9 @@ export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy 
   @Input() public fieldWidthDropdown?: TemplateRef<Dropdown>;
   @Input() public selectedCollection?: ValuePathItem;
   @Input() public showHideWhenEmptyCheckbox = false;
+  @Input() public showInPopupCheckbox = false;
   @Input() public showSortableCheckbox = false;
+  @Input() public showVisibilityToggle = false;
 
   @Output() public columnUpdateEvent = new EventEmitter<{
     data: FieldsWidgetValue[];
@@ -184,6 +188,16 @@ export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy 
     private widgetManagementService: IWidgetManagementService<any>
   ) {
     this.iconService.register(TrashCan16);
+    this.iconService.register(ViewFilled16);
+    this.iconService.register(ViewOffFilled16);
+  }
+
+  public onShowInPopupSwitcherChange(index: number, option: {name: string}): void {
+    this.formRows?.at(index).patchValue({showInPopup: option.name === 'popup'});
+  }
+
+  public onVisibilitySwitcherChange(index: number, option: {name: string}): void {
+    this.formRows?.at(index).patchValue({visible: option.name !== 'hidden'});
   }
 
   public ngOnInit(): void {
@@ -192,6 +206,7 @@ export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy 
   }
 
   public ngOnDestroy(): void {
+    this.emitCurrentFormValue();
     this._subscriptions.unsubscribe();
     this.formGroup.reset();
   }
@@ -212,6 +227,8 @@ export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy 
           Validators.pattern('[1-9][0-9]*')
         ),
         hideWhenEmpty: this.fb.control<boolean>(false),
+        showInPopup: this.fb.control<boolean>(false),
+        visible: this.fb.control<boolean>(true),
         sortable: this.fb.control<boolean>(false),
         defaultSort: this.fb.control<Direction | null>({value: null, disabled: true}),
       })
@@ -227,7 +244,7 @@ export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy 
 
   public onTypeSelected(formRow: FormGroup, event: {item: ListItem}): void {
     this.widgetFieldsService.onDisplayTypeSelected(
-      ['title', 'content', 'type', 'hideWhenEmpty', 'sortable', 'defaultSort'],
+      ['title', 'content', 'type', 'hideWhenEmpty', 'sortable', 'defaultSort', 'showInPopup', 'visible'],
       formRow,
       event
     );
@@ -290,6 +307,8 @@ export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy 
       hideWhenEmpty: this.fb.control(
         (row.displayProperties as WidgetTextDisplayType)?.hideWhenEmpty ?? false
       ),
+      showInPopup: this.fb.control<boolean>(row.showInPopup ?? false),
+      visible: this.fb.control<boolean>(row.visible ?? true),
       ...([WidgetDisplayTypeKey.NUMBER, WidgetDisplayTypeKey.PERCENT].includes(
         row.displayProperties?.type as WidgetDisplayTypeKey
       ) && {
@@ -351,34 +370,42 @@ export class WidgetManagementFieldsColumnComponent implements OnInit, OnDestroy 
     this.columnUpdateEvent.emit({data: this.columnData, valid: true});
   }
 
+  private emitCurrentFormValue(): void {
+    if (!this.formRows) return;
+    const rows = this.formRows.getRawValue();
+    const mappedRows: FieldsWidgetValue[] = rows.map((row: any | null) => ({
+      key: row.title.replace(/\W+/g, '-').replace(/\-$/, '').toLowerCase(),
+      title: row.title,
+      value: row.content,
+      ...(row.sortable !== undefined && {sortable: row.sortable}),
+      ...(row.defaultSort && row.sortable && {defaultSort: row.defaultSort}),
+      ...(!!row?.showInPopup && {showInPopup: row.showInPopup}),
+      ...(row?.visible === false && {visible: false}),
+      ...(!!row?.type.id && {
+        displayProperties: {
+          type: row.type.id,
+          ...(!!row?.ellipsisCharacterLimit && {
+            ellipsisCharacterLimit: row.ellipsisCharacterLimit,
+          }),
+          ...(!!row?.hideWhenEmpty && {hideWhenEmpty: row.hideWhenEmpty}),
+          ...(!!row?.currencyCode && {currencyCode: row.currencyCode}),
+          ...(!!row?.display && {display: row.display}),
+          ...(!!row?.digitsInfo && {digitsInfo: row.digitsInfo}),
+          ...(!!row?.linkText && {linkText: row.linkText}),
+          ...(!!row?.format && {format: row.format}),
+          ...(!!row?.values && {
+            values: row.values?.reduce((acc, curr) => ({...acc, [curr.key]: curr.value}), {}),
+          }),
+        },
+      }),
+    }));
+    this.columnUpdateEvent.emit({data: mappedRows, valid: this.formGroup.valid});
+  }
+
   private openFormSubscription(): void {
     this._subscriptions.add(
-      this.formRows?.valueChanges.pipe(debounceTime(100)).subscribe((rows: any) => {
-        const mappedRows: FieldsWidgetValue[] = rows.map((row: any | null) => ({
-          key: row.title.replace(/\W+/g, '-').replace(/\-$/, '').toLowerCase(),
-          title: row.title,
-          value: row.content,
-          ...(row.sortable !== undefined && {sortable: row.sortable}),
-          ...(row.defaultSort && row.sortable && {defaultSort: row.defaultSort}),
-          ...(!!row?.type.id && {
-            displayProperties: {
-              type: row.type.id,
-              ...(!!row?.ellipsisCharacterLimit && {
-                ellipsisCharacterLimit: row.ellipsisCharacterLimit,
-              }),
-              ...(!!row?.hideWhenEmpty && {hideWhenEmpty: row.hideWhenEmpty}),
-              ...(!!row?.currencyCode && {currencyCode: row.currencyCode}),
-              ...(!!row?.display && {display: row.display}),
-              ...(!!row?.digitsInfo && {digitsInfo: row.digitsInfo}),
-              ...(!!row?.linkText && {linkText: row.linkText}),
-              ...(!!row?.format && {format: row.format}),
-              ...(!!row?.values && {
-                values: row.values?.reduce((acc, curr) => ({...acc, [curr.key]: curr.value}), {}),
-              }),
-            },
-          }),
-        }));
-        this.columnUpdateEvent.emit({data: mappedRows, valid: this.formGroup.valid});
+      this.formRows?.valueChanges.subscribe(() => {
+        this.emitCurrentFormValue();
       })
     );
   }

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/widget-management-fields.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/fields/widget-management-fields.component.html
@@ -52,7 +52,7 @@
     >
       <valtimo-widget-management-fields-column
         *ngIf="activeTab() === $index"
-        [isFieldWidget]="true"
+        [showInPopupCheckbox]="true"
         [columnData]="$selectedWidgetContent()?.[$index]"
         [showHideWhenEmptyCheckbox]="true"
         (columnUpdateEvent)="onColumnUpdateEvent($event, $index)"

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/table/widget-management-table.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/table/widget-management-table.component.html
@@ -18,6 +18,7 @@
   *ngIf="{theme: theme$ | async, params: params$ | async} as obs"
   [formGroup]="form"
   class="valtimo-widget-management-table__form"
+  [cdsLayer]="1"
 >
   <cds-text-label [attr.data-carbon-theme]="theme">
     <v-input-label
@@ -39,22 +40,7 @@
     formControlName="widgetIcon"
   ></valtimo-mdi-icon-selector>
 
-  <cds-text-label [attr.data-carbon-theme]="theme">
-    <v-input-label
-      [title]="'widgetTabManagement.content.table.defaultPageSize' | translate"
-      [tooltip]="'widgetTabManagement.content.table.defaultPageSizeTooltip' | translate"
-    >
-    </v-input-label>
-
-    <input
-      formControlName="defaultPageSize"
-      cdsText
-      [placeholder]="'widgetTabManagement.content.table.defaultPageSizePlaceholder' | translate"
-      type="text"
-    />
-  </cds-text-label>
-
-  <cds-text-label [attr.data-carbon-theme]="theme">
+  <div class="valtimo-widget-management-table__collection">
     <v-input-label
       [title]="'widgetTabManagement.content.table.collection' | translate"
       [tooltip]="collectionDataTooltip$ | async"
@@ -74,12 +60,58 @@
       <input
         formControlName="collection"
         cdsText
-        [attr.data-carbon-theme]="theme"
+        [attr.data-carbon-theme]="obs.theme"
         [placeholder]="'widgetTabManagement.content.table.collection' | translate"
         type="text"
       />
     }
-  </cds-text-label>
+  </div>
+
+  <div class="valtimo-widget-management-table__display-row">
+    <div class="valtimo-widget-management-table__display-mode">
+      <v-input-label
+        [title]="'widgetTabManagement.content.table.displayMode' | translate"
+        [tooltip]="'widgetTabManagement.content.table.displayModeTooltip' | translate"
+      ></v-input-label>
+
+      <div class="valtimo-widget-management-table__radio-wrapper">
+        <cds-radio-group
+          [attr.aria-label]="'widgetTabManagement.content.table.displayMode' | translate"
+          orientation="horizontal"
+        >
+          <cds-radio
+            value="paginated"
+            [checked]="$displayMode() === 'paginated'"
+            (change)="onDisplayModeChange('paginated')"
+          >
+            {{ 'widgetTabManagement.content.table.displayModePaginated' | translate }}
+          </cds-radio>
+          <cds-radio
+            value="popup"
+            [checked]="$displayMode() === 'popup'"
+            (change)="onDisplayModeChange('popup')"
+          >
+            {{ 'widgetTabManagement.content.table.displayModePopup' | translate }}
+          </cds-radio>
+        </cds-radio-group>
+      </div>
+    </div>
+
+    <cds-text-label [attr.data-carbon-theme]="obs.theme" class="valtimo-widget-management-table__page-size">
+      <v-input-label
+        [title]="($displayMode() === 'popup' ? 'widgetTabManagement.content.table.defaultPageSizePopup' : 'widgetTabManagement.content.table.defaultPageSize') | translate"
+        [tooltip]="($displayMode() === 'popup' ? 'widgetTabManagement.content.table.defaultPageSizePopupTooltip' : 'widgetTabManagement.content.table.defaultPageSizeTooltip') | translate"
+      >
+      </v-input-label>
+
+      <input
+        formControlName="defaultPageSize"
+        cdsText
+        [placeholder]="'widgetTabManagement.content.table.defaultPageSizePlaceholder' | translate"
+        type="text"
+      />
+    </cds-text-label>
+  </div>
 </form>
 
 <ng-content></ng-content>
@@ -94,6 +126,7 @@
   (columnUpdateEvent)="onColumnUpdateEvent($event)"
   [selectedCollection]="selectedCollection$ | async"
   [showSortableCheckbox]="sortableColumns"
+  [showVisibilityToggle]="true"
 ></valtimo-widget-management-fields-column>
 
 <section *ngIf="showFirstColumnOption" class="valtimo-widget-management-table__toggle">

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/table/widget-management-table.component.scss
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/table/widget-management-table.component.scss
@@ -44,8 +44,43 @@
     flex-direction: column;
   }
 
-  .cds--text-input,
-  .cds--list-box {
-    background: var(--cds-layer-02);
+  &__collection {
+    display: flex;
+    flex-direction: column;
   }
+
+  &__display-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    grid-column: span 2;
+  }
+
+  &__display-mode {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  &__radio-wrapper {
+    display: flex;
+    align-items: center;
+    height: 40px;
+    margin-top: 8px;
+
+    fieldset.cds--radio-button-group {
+      margin: 0;
+      padding: 0;
+      border: none;
+    }
+  }
+
+  &__page-size {
+    flex-shrink: 0;
+
+    .cds--text-input {
+      width: 160px;
+    }
+  }
+
 }

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/table/widget-management-table.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-content/table/widget-management-table.component.ts
@@ -40,8 +40,9 @@ import {
   ValuePathSelectorPrefix,
   ValuePathType,
 } from '@valtimo/components';
-import {ButtonModule, InputModule, LayerModule, ToggleModule} from 'carbon-components-angular';
+import {ButtonModule, IconModule, IconService, InputModule, LayerModule, RadioModule, ToggleModule} from 'carbon-components-angular';
 import {BehaviorSubject, debounceTime, map, Observable, Subscription, switchMap} from 'rxjs';
+import {ViewFilled16, ViewOffFilled16} from '@carbon/icons';
 import {WIDGET_MANAGEMENT_SERVICE} from '../../../../constants';
 import {IWidgetManagementService} from '../../../../interfaces';
 import {FieldsWidgetValue, WidgetContentProperties, WidgetTableContent} from '../../../../models';
@@ -66,8 +67,10 @@ import {toObservable} from '@angular/core/rxjs-interop';
     ButtonModule,
     InputLabelModule,
     LayerModule,
+    RadioModule,
     ValuePathSelectorComponent,
     MdiIconSelectorComponent,
+    IconModule,
   ],
 })
 export class WidgetManagementTableComponent implements OnInit, OnDestroy {
@@ -105,6 +108,10 @@ export class WidgetManagementTableComponent implements OnInit, OnDestroy {
     () =>
       (this.widgetWizardService.$widgetContent() as WidgetTableContent)?.firstColumnAsTitle || false
   );
+  public readonly $displayMode = computed(
+    () =>
+      (this.widgetWizardService.$widgetContent() as WidgetTableContent)?.displayMode ?? 'paginated'
+  );
 
   public readonly selectedCollection$ = new BehaviorSubject<ValuePathItem | null>(null);
 
@@ -129,11 +136,15 @@ export class WidgetManagementTableComponent implements OnInit, OnDestroy {
   constructor(
     private readonly cdsThemeService: CdsThemeService,
     private readonly fb: FormBuilder,
+    private readonly iconService: IconService,
     private readonly translateService: TranslateService,
     private readonly widgetWizardService: WidgetWizardService,
     @Inject(WIDGET_MANAGEMENT_SERVICE)
     private widgetManagementService: IWidgetManagementService<any>
-  ) {}
+  ) {
+    this.iconService.register(ViewFilled16);
+    this.iconService.register(ViewOffFilled16);
+  }
 
   public ngOnInit(): void {
     this.widgetWizardService.$widgetContentValid.set(false);
@@ -176,6 +187,13 @@ export class WidgetManagementTableComponent implements OnInit, OnDestroy {
     this.widgetWizardService.$widgetContent.update(
       (content: WidgetContentProperties | null) =>
         ({...content, firstColumnAsTitle}) as WidgetTableContent
+    );
+  }
+
+  public onDisplayModeChange(displayMode: 'paginated' | 'popup'): void {
+    this.widgetWizardService.$widgetContent.update(
+      (content: WidgetContentProperties | null) =>
+        ({...content, displayMode}) as WidgetTableContent
     );
   }
 

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-editor/widget-management-editor.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-editor/widget-management-editor.component.ts
@@ -245,6 +245,7 @@ export class WidgetManagementEditorComponent implements OnDestroy {
   }
 
   public editWidget(widget: Widget): void {
+    this.widgetWizardService.cancelPendingReset();
     if (widget.type === WidgetType.DIVIDER) {
       this.dividerDefinition$.next(widget);
       this.$dividerModalMode.set('edit');
@@ -292,6 +293,7 @@ export class WidgetManagementEditorComponent implements OnDestroy {
   }
 
   public openAddModal(): void {
+    this.widgetWizardService.cancelPendingReset();
     this.$isWizardOpen.set(true);
   }
 

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-wizard/widget-management-wizard.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-management/management-wizard/widget-management-wizard.component.ts
@@ -220,12 +220,13 @@ export class WidgetManagementWizardComponent implements OnDestroy {
         );
       }
 
+      const widgetToSave = this.widgetWizardService.$widgetsConfig();
       this.closeEvent.emit({
         type:
           this.editMode && !isDuplicateMode
             ? WidgetWizardCloseEventType.EDIT
             : WidgetWizardCloseEventType.CREATE,
-        widget: this.widgetWizardService.$widgetsConfig(),
+        widget: widgetToSave,
       });
 
       this.resetWizard();

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.html
@@ -53,23 +53,37 @@
       >
       </valtimo-carbon-list>
 
-      @if ($paginationModel() && $showPagination()) {
-        <cds-pagination-nav
-          class="valtimo-widget-table__pagination"
-          [model]="$paginationModel()"
-          (selectPage)="onSelectPage($event)"
-        >
-        </cds-pagination-nav>
-      } @else if (obs.widgetData === null) {
-        <div class="valtimo-widget-table__pagination">
-          <cds-skeleton-text
-            [lines]="1"
-            [maxLineWidth]="150"
-            [minLineWidth]="150"
-          ></cds-skeleton-text>
-        </div>
+      @if (!$isPopupMode()) {
+        @if ($paginationModel() && $showPagination()) {
+          <cds-pagination-nav
+            class="valtimo-widget-table__pagination"
+            [model]="$paginationModel()"
+            (selectPage)="onSelectPage($event)"
+          >
+          </cds-pagination-nav>
+        } @else if (obs.widgetData === null) {
+          <div class="valtimo-widget-table__pagination">
+            <cds-skeleton-text
+              [lines]="1"
+              [maxLineWidth]="150"
+              [minLineWidth]="150"
+            ></cds-skeleton-text>
+          </div>
+        }
       }
     </section>
+
+    @if ($isPopupMode() && $showPagination()) {
+      <button
+        cdsButton="tertiary"
+        size="sm"
+        class="valtimo-widget-table__show-all-btn"
+        (click)="onShowAllClick()"
+      >
+        {{ 'widgets.showMore' | translate }} ({{ $totalElements() }})
+        <svg cdsIcon="arrow--right" size="16" class="cds--btn__icon"></svg>
+      </button>
+    }
   } @else if (obs.widgetData !== null) {
     <valtimo-no-results
       [collapseVertically]="true"
@@ -78,3 +92,28 @@
     ></valtimo-no-results>
   }
 </cds-tile>
+
+<valtimo-render-in-body *ngIf="$showAllModal()">
+  <cds-modal
+    class="valtimo-widget-table__modal"
+    [open]="true"
+    [hasScrollingContent]="true"
+    size="lg"
+    (overlaySelected)="onModalClose()"
+  >
+    <cds-modal-header (closeSelect)="onModalClose()">
+      <h3 cdsModalHeaderHeading>{{ widgetConfiguration?.title }}</h3>
+    </cds-modal-header>
+
+    <section cdsModalContent>
+      <valtimo-carbon-list
+        [header]="false"
+        [hideToolbar]="true"
+        [fields]="allFields$ | async"
+        [items]="(allWidgetData$ | async) || []"
+        [loading]="(allWidgetData$ | async) === null"
+        [skeletonRowCount]="widgetConfiguration?.properties?.defaultPageSize || 5"
+      ></valtimo-carbon-list>
+    </section>
+  </cds-modal>
+</valtimo-render-in-body>

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.scss
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.scss
@@ -57,6 +57,11 @@
     align-items: center;
   }
 
+  &__show-all-btn {
+    align-self: flex-end;
+    margin-top: auto;
+  }
+
   .cds--data-table {
     & > thead {
       background: transparent !important;
@@ -82,6 +87,24 @@
     tr {
       gap: 16px;
     }
+  }
+
+  &__modal .cds--modal-content .cds--data-table-content {
+    overflow-x: visible;
+  }
+
+  &__modal .cds--modal-content .cds--data-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  &__modal .cds--modal-content .cds--data-table thead th {
+    background-color: var(--cds-layer-01) !important;
+  }
+
+  &__modal section.cds--modal-content {
+    padding-bottom: 32px;
   }
 
   &--compact .cds--data-table tr {

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.ts
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-table/widget-table.component.ts
@@ -30,11 +30,14 @@ import {
   CarbonListModule,
   ColumnConfig,
   MdiIconViewerComponent,
+  RenderInBodyComponent,
   ViewType,
 } from '@valtimo/components';
 import {Page} from '@valtimo/shared';
 import {
   ButtonModule,
+  IconModule,
+  ModalModule,
   PaginationModel,
   PaginationModule,
   SkeletonModule,
@@ -58,9 +61,12 @@ import {WidgetActionButtonComponent} from '../widget-action-button/widget-action
     TilesModule,
     TranslateModule,
     ButtonModule,
+    IconModule,
+    ModalModule,
     WidgetActionButtonComponent,
     MdiIconViewerComponent,
     SkeletonModule,
+    RenderInBodyComponent,
   ],
 })
 export class WidgetTableComponent {
@@ -72,35 +78,37 @@ export class WidgetTableComponent {
 
   @Input({required: true}) public set widgetConfiguration(value: TableWidget) {
     this._widgetConfiguration = value;
+    this.$isPopupMode.set(value.properties.displayMode === 'popup');
+
+    const toColumnConfig = (column: FieldsWidgetValue, index: number) => ({
+      key: column.key,
+      label: column.title,
+      viewType: column.displayProperties?.type ?? ViewType.TEXT,
+      className: `valtimo-widget-table--transparent ${index === 0 && value.properties.firstColumnAsTitle ? 'valtimo-widget-table--title' : ''}`,
+      ...(!!column.displayProperties?.['format'] && {format: column.displayProperties['format']}),
+      ...(!!column.displayProperties?.['digitsInfo'] && {digitsInfo: column.displayProperties['digitsInfo']}),
+      ...(!!column.displayProperties?.['display'] && {display: column.displayProperties['display']}),
+      ...(!!column.displayProperties?.['currencyCode'] && {currencyCode: column.displayProperties['currencyCode']}),
+      ...(!!column.displayProperties?.['values'] && {values: column.displayProperties['values']}),
+    });
 
     this.fields$.next(
-      value.properties.columns.map((column: FieldsWidgetValue, index: number) => ({
-        key: column.key,
-        label: column.title,
-        viewType: column.displayProperties?.type ?? ViewType.TEXT,
-        className: `valtimo-widget-table--transparent ${index === 0 && value.properties.firstColumnAsTitle ? 'valtimo-widget-table--title' : ''}`,
-        ...(!!column.displayProperties?.['format'] && {
-          format: column.displayProperties['format'],
-        }),
-        ...(!!column.displayProperties?.['digitsInfo'] && {
-          digitsInfo: column.displayProperties['digitsInfo'],
-        }),
-        ...(!!column.displayProperties?.['display'] && {
-          display: column.displayProperties['display'],
-        }),
-        ...(!!column.displayProperties?.['currencyCode'] && {
-          currencyCode: column.displayProperties['currencyCode'],
-        }),
-        ...(!!column.displayProperties?.['values'] && {
-          values: column.displayProperties['values'],
-        }),
-      }))
+      value.properties.columns
+        .filter(column => column.visible !== false)
+        .map((column, index) => toColumnConfig(column, index))
+    );
+
+    this.allFields$.next(
+      value.properties.columns.map((column, index) => toColumnConfig(column, index))
     );
 
     this.cdr.detectChanges();
   }
 
   public readonly $showPagination = signal<boolean>(false);
+  public readonly $isPopupMode = signal<boolean>(false);
+  public readonly $showAllModal = signal<boolean>(false);
+  public readonly $totalElements = signal<number>(0);
 
   public readonly widgetData$ = new BehaviorSubject<CarbonListItem[] | null>(null);
   public readonly resolvedData$ = new BehaviorSubject<object | null>(null);
@@ -116,6 +124,7 @@ export class WidgetTableComponent {
     }
 
     this.$showPagination.set(value.totalElements > value.size);
+    this.$totalElements.set(value.totalElements);
 
     if (!this._initialNumberOfElements) this._initialNumberOfElements = value.numberOfElements;
 
@@ -161,8 +170,16 @@ export class WidgetTableComponent {
   }
 
   @Output() public readonly paginationEvent = new EventEmitter<PaginationModel>();
+  @Output() public readonly showAllClick = new EventEmitter<void>();
 
   public readonly fields$ = new BehaviorSubject<ColumnConfig[]>([]);
+  public readonly allFields$ = new BehaviorSubject<ColumnConfig[]>([]);
+  public readonly allWidgetData$ = new BehaviorSubject<CarbonListItem[] | null>(null);
+
+  @Input() set allWidgetData(value: Page<CarbonListItem> | null) {
+    this.allWidgetData$.next(value ? value.content : null);
+    this.cdr.detectChanges();
+  }
 
   public readonly $paginationModel = signal<PaginationModel | null>(new PaginationModel());
 
@@ -172,5 +189,14 @@ export class WidgetTableComponent {
     const paginationModel = this.$paginationModel();
     if (!paginationModel) return;
     this.paginationEvent.emit({...paginationModel, currentPage: page});
+  }
+
+  public onShowAllClick(): void {
+    this.$showAllModal.set(true);
+    this.showAllClick.emit();
+  }
+
+  public onModalClose(): void {
+    this.$showAllModal.set(false);
   }
 }

--- a/frontend/projects/valtimo/layout/src/lib/constants/widget-color.constants.ts
+++ b/frontend/projects/valtimo/layout/src/lib/constants/widget-color.constants.ts
@@ -23,6 +23,7 @@ interface WidgetColorVariant {
   accent: string | null;
   background: string | null;
   layer: string | null;
+  border: string | null;
 }
 
 type WidgetColorTheme = Record<WidgetColorThemeVariant, WidgetColorVariant>;
@@ -42,8 +43,8 @@ const WIDGET_COLOR_ITEMS: WidgetColor[] = [
 ];
 
 const DEFAULT_WIDGET_COLOR_THEME: WidgetColorTheme = {
-  light: {text: null, accent: null, background: null, layer: null},
-  dark: {text: null, accent: null, background: null, layer: null},
+  light: {text: null, accent: null, background: null, layer: null, border: null},
+  dark: {text: null, accent: null, background: null, layer: null, border: null},
 };
 
 const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
@@ -54,12 +55,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#393939',
       background: '#161616',
       layer: '#262626',
+      border: '#393939',
     },
     dark: {
       text: '#161616',
       accent: '#C6C6C6',
       background: '#FFFFFF',
       layer: '#F4F4F4',
+      border: '#E0E0E0',
     },
   },
   [WidgetColor.BLUE]: {
@@ -68,12 +71,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#468CBEFF',
       background: '#E2EDF5FF',
       layer: '#F6FBFFFF',
+      border: '#468CBE66',
     },
     dark: {
       text: '#E2EDF5FF',
       accent: '#468CBEFF',
       background: '#314A5EFF',
       layer: '#1A2D3CFF',
+      border: '#468CBEFF',
     },
   },
   [WidgetColor.PERIWINKLE]: {
@@ -82,12 +87,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#4A42BEFF',
       background: '#D5D3F0FF',
       layer: '#EBEAFDFF',
+      border: '#4A42BE66',
     },
     dark: {
       text: '#D5D3F0FF',
       accent: '#4A42BEFF',
       background: '#1A146AFF',
       layer: '#0B0742FF',
+      border: '#4A42BEFF',
     },
   },
   [WidgetColor.PURPLE]: {
@@ -96,12 +103,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#B965BCFF',
       background: '#F4E6F4FF',
       layer: '#FBF5FBFF',
+      border: '#B965BC66',
     },
     dark: {
       text: '#F4E6F4FF',
       accent: '#B965BCFF',
       background: '#603361FF',
       layer: '#3F203FFF',
+      border: '#B965BCFF',
     },
   },
   [WidgetColor.TURQOISE]: {
@@ -110,12 +119,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#359C85FF',
       background: '#ECF8F6FF',
       layer: '#F8FFFEFF',
+      border: '#359C8566',
     },
     dark: {
       text: '#ECF8F6FF',
       accent: '#359C85FF',
       background: '#297063FF',
       layer: '#184A40FF',
+      border: '#359C85FF',
     },
   },
   [WidgetColor.GREEN]: {
@@ -124,12 +135,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#3F9C40FF',
       background: '#E8F3E8FF',
       layer: '#F8FFF8FF',
+      border: '#3F9C4066',
     },
     dark: {
       text: '#E8F3E8FF',
       accent: '#3F9C40FF',
       background: '#245B25FF',
       layer: '#153C15FF',
+      border: '#3F9C40FF',
     },
   },
   [WidgetColor.BROWN]: {
@@ -138,12 +151,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#A07837FF',
       background: '#ECE4D7FF',
       layer: '#F6F2EBFF',
+      border: '#A0783766',
     },
     dark: {
       text: '#ECE4D7FF',
       accent: '#A07837FF',
       background: '#6E5326FF',
       layer: '#493617FF',
+      border: '#A07837FF',
     },
   },
   [WidgetColor.RED]: {
@@ -152,12 +167,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#D34F51FF',
       background: '#F6DCDCFF',
       layer: '#FFEBEBFF',
+      border: '#D34F5166',
     },
     dark: {
       text: '#F6DCDCFF',
       accent: '#D34F51FF',
       background: '#7C2C2DFF',
       layer: '#561D1EFF',
+      border: '#D34F51FF',
     },
   },
   [WidgetColor.ORANGE]: {
@@ -166,12 +183,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#CC6300FF',
       background: '#FFE5CCFF',
       layer: '#FFF1E4FF',
+      border: '#CC630066',
     },
     dark: {
       text: '#FFE5CCFF',
       accent: '#CC6300FF',
       background: '#673D13FF',
       layer: '#41270CFF',
+      border: '#CC6300FF',
     },
   },
   [WidgetColor.YELLOW]: {
@@ -180,12 +199,14 @@ const WIDGET_COLOR_THEME_MAP: Record<WidgetColor, WidgetColorTheme> = {
       accent: '#FAD165FF',
       background: '#FEF6E0FF',
       layer: '#FFFBF1FF',
+      border: '#FAD16566',
     },
     dark: {
       text: '#FEF6E0FF',
       accent: '#FAD165FF',
       background: '#6F5C29FF',
       layer: '#483B17FF',
+      border: '#FAD165FF',
     },
   },
 };

--- a/frontend/projects/valtimo/layout/src/lib/models/widget-content.model.ts
+++ b/frontend/projects/valtimo/layout/src/lib/models/widget-content.model.ts
@@ -62,6 +62,7 @@ interface WidgetTableContent {
   collection: string;
   firstColumnAsTitle: boolean;
   defaultPageSize: number;
+  displayMode?: 'paginated' | 'popup';
 }
 
 interface WidgetInteractiveTableContent extends Omit<WidgetTableContent, 'firstColumnAsTitle'> {

--- a/frontend/projects/valtimo/layout/src/lib/models/widget.model.ts
+++ b/frontend/projects/valtimo/layout/src/lib/models/widget.model.ts
@@ -89,6 +89,8 @@ interface FieldsWidgetValue {
   displayProperties?: WidgetDisplayType;
   sortable?: boolean;
   defaultSort?: Direction;
+  showInPopup?: boolean;
+  visible?: boolean;
 }
 
 interface GeoJsonSource {

--- a/frontend/projects/valtimo/layout/src/lib/services/widget-wizard.service.ts
+++ b/frontend/projects/valtimo/layout/src/lib/services/widget-wizard.service.ts
@@ -177,8 +177,19 @@ export class WidgetWizardService {
 
   public readonly $availableWidgetTypes: WritableSignal<WidgetType[] | null> = signal(null);
 
+  private _resetTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  public cancelPendingReset(): void {
+    if (this._resetTimeoutId !== null) {
+      clearTimeout(this._resetTimeoutId);
+      this._resetTimeoutId = null;
+    }
+  }
+
   public resetWizard(): void {
-    setTimeout(() => {
+    this.cancelPendingReset();
+    this._resetTimeoutId = setTimeout(() => {
+      this._resetTimeoutId = null;
       this.$currentStepIndex.set(0);
       this.$currentStep.set(WidgetWizardStep.TYPE);
       this.$selectedWidget.set(null);

--- a/frontend/projects/valtimo/shared/assets/core/en.json
+++ b/frontend/projects/valtimo/shared/assets/core/en.json
@@ -916,6 +916,15 @@
       "widgetTitlePlaceholder": "Choose a short name",
       "widgetTitleTooltip": "Title that displays at the top of the widget",
       "hideWhenEmpty": "Hide when empty",
+      "showInPopup": "Only show in popup",
+      "displayWidget": "Widget",
+      "displayPopup": "Popup",
+      "displayWidgetTooltip": "Show in widget and pop-up",
+      "displayPopupTooltip": "Show only in pop-up",
+      "columnVisible": "Visible",
+      "columnHidden": "Hidden",
+      "columnVisibleTooltip": "Show column in widget",
+      "columnHiddenTooltip": "Hide column from widget",
       "column": "Column {{number}}",
       "fields": {
         "add": "Add field",
@@ -979,7 +988,13 @@
       "formio": {"selectForm": "Form definition", "placeholder": "Select a form definition"},
       "table": {
         "addColumn": "Add column",
+        "displayMode": "Display overflow as",
+        "displayModeTooltip": "Choose how to display data that does not fit in the widget",
+        "displayModePaginated": "Paginated",
+        "displayModePopup": "Pop-up",
         "defaultPageSize": "Rows per page",
+        "defaultPageSizePopup": "Rows to display in widget",
+        "defaultPageSizePopupTooltip": "Number of rows shown in the widget before the show all button appears",
         "defaultPageSizePlaceholder": "Choose amount of rows per page",
         "defaultPageSizeTooltip": "Number of entries displayed on each page",
         "collection": "Path to table data",
@@ -2086,6 +2101,10 @@
   "widgets": {
     "noData": "No data found",
     "emptyFields": "Nothing here",
+    "showMore": "Show all",
+    "popupModal": {
+      "close": "Close"
+    },
     "noWidgets": "No widgets",
     "noWidgetsDescription": "There are no widgets configured for this tab, or you don't have the rights to view them.",
     "noWidget": "Widget not found",

--- a/frontend/projects/valtimo/shared/assets/core/nl.json
+++ b/frontend/projects/valtimo/shared/assets/core/nl.json
@@ -938,6 +938,15 @@
       "widgetTitlePlaceholder": "Kies een korte naam",
       "widgetTitleTooltip": "Titel die bovenaan de widget wordt weergegeven",
       "hideWhenEmpty": "Verbergen indien leeg",
+      "showInPopup": "Alleen weergeven in popup",
+      "displayWidget": "Widget",
+      "displayPopup": "Popup",
+      "displayWidgetTooltip": "Weergeven in widget en pop-up",
+      "displayPopupTooltip": "Alleen weergeven in pop-up",
+      "columnVisible": "Zichtbaar",
+      "columnHidden": "Verborgen",
+      "columnVisibleTooltip": "Kolom weergeven in widget",
+      "columnHiddenTooltip": "Kolom verbergen in widget",
       "column": "Kolom {{number}}",
       "fields": {
         "add": "Veld toevoegen",
@@ -1004,7 +1013,13 @@
       },
       "table": {
         "addColumn": "Kolom toevoegen",
+        "displayMode": "Overflow weergeven als",
+        "displayModeTooltip": "Kies hoe gegevens worden weergegeven die niet in de widget passen",
+        "displayModePaginated": "Gepagineerd",
+        "displayModePopup": "Pop-up",
         "defaultPageSize": "Rijen per pagina",
+        "defaultPageSizePopup": "Rijen weergeven in widget",
+        "defaultPageSizePopupTooltip": "Aantal rijen dat in de widget wordt getoond voordat de knop ‘alles tonen’ verschijnt",
         "defaultPageSizePlaceholder": "Kies het aantal rijen per pagina",
         "defaultPageSizeTooltip": "Aantal vermeldingen weergegeven op elke pagina",
         "collection": "Pad naar tabeldata",
@@ -2119,6 +2134,10 @@
   "widgets": {
     "noData": "Geen data gevonden",
     "emptyFields": "Niets hier",
+    "showMore": "Laat alles zien",
+    "popupModal": {
+      "close": "Sluiten"
+    },
     "noWidgets": "Geen widgets",
     "noWidgetsDescription": "Er zijn geen widgets geconfigureerd voor dit tabblad, of je hebt niet de juiste rechten om deze te zien.",
     "noWidget": "Widget niet beschikbaar",


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: [#279](https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/279
)
- Created new functionality for the Fields and Table widget: It is now possible to 'hide' content from the main widget, and only display it in the pop-up.

- There are also some small UI theming and alignment fixes (added a 'border-color' for the default fields when using colors (it used to be default grey)).

**Functionality**
- There is a new content-switcher present in the header of the Fields and Table widget 'accordion' component, where a user can toggle between 'visible' and 'only show in pop-up'
- The 'show all' button will appear in the widget when 1 or more fields / columns in a widget are 'hidden'
- If all fields and/or rows are shown, no 'show all' button will appear
- For the Table widget, there is a new option to replace the pagination with a 'show all (amount of rows)' button, where you end up with a scrollable table. If table columns are hidden, they are present there as well. 

**How to test**
- Go to [https://pr479.product-development.test.k8s.ritense.com/cases/ev-laadpaal-subsidie](https://pr479.product-development.test.k8s.ritense.com/cases/ev-laadpaal-subsidie)
- Create a new case or open an existing one
- check the fields widget and table widgets
- Alter the configuration of the widgets in Admin -> EV Laadpaal Subsidieaanvraag -> Case details -> Gegevens and edit field widgets and the table widget.