### PR TITLE
Maak het mogelijk om te achterhalen of een zaak nog actief is

### DIFF
--- a/backend/app/gzac/src/dev/resources/config/global/permission/zaken.permission.json
+++ b/backend/app/gzac/src/dev/resources/config/global/permission/zaken.permission.json
@@ -1,0 +1,15 @@
+[
+    {
+        "resourceType": "com.ritense.zakenapi.security.Zaak",
+        "action": "view_active_status",
+        "roleKey": "ROLE_ADMIN",
+        "conditions": [
+            {
+                "type": "field",
+                "field": "zaaktype",
+                "operator": "==",
+                "value": "http://localhost:8001/catalogi/api/v1/zaaktypen/744ca059-f412-49d4-8963-5800e4afd486"
+            }
+        ]
+    }
+]

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/config/ZakenApiAutoConfiguration.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/config/ZakenApiAutoConfiguration.kt
@@ -66,9 +66,13 @@ import com.ritense.zakenapi.service.ZaakNotitieService
 import com.ritense.zakenapi.service.ZaakTypeLinkService
 import com.ritense.zakenapi.listener.ZakenApiDocumentDeletedEventListener
 import com.ritense.zakenapi.listener.ZakenApiEventListener
+import com.ritense.zakenapi.security.ZaakActionProvider
+import com.ritense.zakenapi.security.ZaakSpecificationFactory
+import com.ritense.zakenapi.service.ZaakService
 import com.ritense.zakenapi.service.ZakenDocumentDeleteHandler
 import com.ritense.zakenapi.web.rest.DefaultZaakTypeLinkResource
 import com.ritense.zakenapi.web.rest.ZaakDocumentResource
+import com.ritense.zakenapi.web.rest.ZaakResource
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -383,6 +387,35 @@ class ZakenApiAutoConfiguration {
         pluginService,
         zaakNotitieService
     )
+
+    @Bean
+    @ConditionalOnMissingBean(ZaakSpecificationFactory::class)
+    fun zaakSpecificationFactory(): ZaakSpecificationFactory {
+        return ZaakSpecificationFactory()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ZaakActionProvider::class)
+    fun zaakActionProvider(): ZaakActionProvider {
+        return ZaakActionProvider()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ZaakService::class)
+    fun zaakService(
+        pluginService: PluginService,
+        authorizationService: AuthorizationService,
+    ): ZaakService {
+        return ZaakService(pluginService, authorizationService)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ZaakResource::class)
+    fun zaakResource(
+        zaakService: ZaakService,
+    ): ZaakResource {
+        return ZaakResource(zaakService)
+    }
 
     @Bean
     @ConditionalOnMissingBean(ZaakTypeLinkConfigurationIssueListener::class)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/exception/MultipleZakenFoundException.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/exception/MultipleZakenFoundException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.exception
+
+class MultipleZakenFoundException(message: String) : RuntimeException(message)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/exception/ZaakNotFoundException.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/exception/ZaakNotFoundException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.exception
+
+class ZaakNotFoundException(message: String) : RuntimeException(message)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/Zaak.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/Zaak.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.security
+
+class Zaak(
+    val zaaktype: String? = null
+)

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakActionProvider.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakActionProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.security
+
+import com.ritense.authorization.Action
+import com.ritense.authorization.ResourceActionProvider
+
+class ZaakActionProvider : ResourceActionProvider<Zaak> {
+    override fun getAvailableActions(): List<Action<Zaak>> {
+        return listOf(VIEW_ACTIVE_STATUS)
+    }
+
+    companion object {
+        val VIEW_ACTIVE_STATUS = Action<Zaak>("view_active_status")
+    }
+}

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakSpecification.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakSpecification.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.security
+
+import com.ritense.authorization.permission.Permission
+import com.ritense.authorization.request.AuthorizationRequest
+import com.ritense.authorization.specification.AuthorizationSpecification
+import jakarta.persistence.criteria.AbstractQuery
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
+
+class ZaakSpecification(
+    authRequest: AuthorizationRequest<Zaak>,
+    permissionSupplier: () -> List<Permission>,
+) : AuthorizationSpecification<Zaak>(authRequest, permissionSupplier) {
+
+    override fun toPredicate(
+        root: Root<Zaak>,
+        query: AbstractQuery<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        throw NotImplementedError("Zaak is not a JPA entity")
+    }
+
+    override fun identifierToEntity(identifier: String): Zaak {
+        throw NotImplementedError("Zaak is not a JPA entity")
+    }
+}

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakSpecificationFactory.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakSpecificationFactory.kt
@@ -29,12 +29,15 @@ class ZaakSpecificationFactory : AuthorizationSpecificationFactory<Zaak> {
 
     override fun create(
         request: AuthorizationRequest<Zaak>,
-        permissions: List<Permission>
+        permissionSupplier: () -> List<Permission>
     ): AuthorizationSpecification<Zaak> {
-        return ZaakSpecification(request, { permissions })
+        return ZaakSpecification(request, permissionSupplier)
     }
 
-    override fun canCreate(request: AuthorizationRequest<*>, permissions: List<Permission>): Boolean {
+    override fun canCreate(
+        request: AuthorizationRequest<*>,
+        permissionSupplier: () -> List<Permission>
+    ): Boolean {
         return Zaak::class.java == request.resourceType
     }
 }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakSpecificationFactory.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZaakSpecificationFactory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.security
+
+import com.ritense.authorization.permission.Permission
+import com.ritense.authorization.request.AuthorizationRequest
+import com.ritense.authorization.specification.AuthorizationSpecification
+import com.ritense.authorization.specification.AuthorizationSpecificationFactory
+import com.ritense.valtimo.contract.annotation.SkipComponentScan
+import org.springframework.stereotype.Component
+
+@Component
+@SkipComponentScan
+class ZaakSpecificationFactory : AuthorizationSpecificationFactory<Zaak> {
+
+    override fun create(
+        request: AuthorizationRequest<Zaak>,
+        permissions: List<Permission>
+    ): AuthorizationSpecification<Zaak> {
+        return ZaakSpecification(request, { permissions })
+    }
+
+    override fun canCreate(request: AuthorizationRequest<*>, permissions: List<Permission>): Boolean {
+        return Zaak::class.java == request.resourceType
+    }
+}

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZakenApiHttpSecurityConfigurer.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/security/ZakenApiHttpSecurityConfigurer.kt
@@ -32,6 +32,7 @@ class ZakenApiHttpSecurityConfigurer : HttpSecurityConfigurer {
         try {
             http.authorizeHttpRequests { requests ->
                 requests
+                    .requestMatchers(antMatcher(GET, "/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/v1/zaken-api/document/{documentId}/files")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/v2/zaken-api/document/{documentId}/files")).authenticated()
                     .requestMatchers(antMatcher(GET, "/api/v1/zaken-api/document/{documentId}/zaak")).authenticated()

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakService.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakService.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.service
+
+import com.ritense.authorization.AuthorizationService
+import com.ritense.authorization.request.EntityAuthorizationRequest
+import com.ritense.plugin.service.PluginService
+import com.ritense.zakenapi.ZakenApiPlugin
+import com.ritense.zakenapi.domain.Comparator
+import com.ritense.zakenapi.domain.SearchParameter
+import com.ritense.zakenapi.domain.ZaakResponse
+import com.ritense.zakenapi.exception.MultipleZakenFoundException
+import com.ritense.zakenapi.exception.ZaakNotFoundException
+import com.ritense.zakenapi.security.Zaak
+import com.ritense.zakenapi.security.ZaakActionProvider
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+open class ZaakService(
+    private val pluginService: PluginService,
+    private val authorizationService: AuthorizationService,
+) {
+
+    @Transactional
+    open fun getActiveStatus(zaakIdentificatie: String, zakenApiPluginId: UUID?): Boolean {
+        val zaakResponses = getZakenByIdentificatie(zaakIdentificatie, zakenApiPluginId)
+
+        val authorizedZaken = zaakResponses.filter { zaakResponse ->
+            authorizationService.hasPermission(
+                EntityAuthorizationRequest(
+                    Zaak::class.java,
+                    ZaakActionProvider.VIEW_ACTIVE_STATUS,
+                    Zaak(zaaktype = zaakResponse.zaaktype.toString())
+                )
+            )
+        }
+
+        if (authorizedZaken.isEmpty()) {
+            throw ZaakNotFoundException("No authorized zaak found for identificatie '$zaakIdentificatie'")
+        }
+        if (authorizedZaken.size > 1) {
+            throw MultipleZakenFoundException("More than one authorized zaak found for identificatie '$zaakIdentificatie'")
+        }
+
+        return authorizedZaken[0].einddatum == null
+    }
+
+    private fun getZakenByIdentificatie(zaakIdentificatie: String, zakenApiPluginId: UUID?): List<ZaakResponse> {
+        val searchParameters = listOf(
+            SearchParameter("identificatie", Comparator.EQUAL_TO, zaakIdentificatie)
+        )
+
+        return if (zakenApiPluginId != null) {
+            val plugin: ZakenApiPlugin = pluginService.createInstance(zakenApiPluginId)
+            plugin.searchZaken(searchParameters, Pageable.unpaged()).results
+        } else {
+            val pluginConfigurations = pluginService.findPluginConfigurations(ZakenApiPlugin::class.java)
+            check(pluginConfigurations.isNotEmpty()) { "No ZakenApiPlugin configurations found" }
+
+            pluginConfigurations.flatMap { config ->
+                val plugin: ZakenApiPlugin = pluginService.createInstance(config.id.id)
+                plugin.searchZaken(searchParameters, Pageable.unpaged()).results
+            }
+        }
+    }
+}

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/web/rest/ZaakResource.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/web/rest/ZaakResource.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.web.rest
+
+import com.ritense.valtimo.contract.annotation.SkipComponentScan
+import com.ritense.valtimo.contract.domain.ValtimoMediaType.APPLICATION_JSON_UTF8_VALUE
+import com.ritense.zakenapi.exception.MultipleZakenFoundException
+import com.ritense.zakenapi.exception.ZaakNotFoundException
+import com.ritense.zakenapi.service.ZaakService
+import java.util.UUID
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@SkipComponentScan
+@RequestMapping(value = ["/api"], produces = [APPLICATION_JSON_UTF8_VALUE])
+class ZaakResource(
+    private val zaakService: ZaakService
+) {
+
+    @GetMapping("/v1/zaken-api/zaak/{zaakIdentificatie}/actief")
+    fun getActiefStatus(
+        @PathVariable zaakIdentificatie: String,
+        @RequestParam(value = "zaken_api_plugin_id", required = false) zakenApiPluginId: UUID?,
+    ): ResponseEntity<Map<String, Any>> {
+        return try {
+            val actief = zaakService.getActiveStatus(zaakIdentificatie, zakenApiPluginId)
+            ResponseEntity.ok(mapOf("actief" to actief))
+        } catch (e: ZaakNotFoundException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                mapOf(
+                    "errorCode" to "ZAAK_NOT_FOUND",
+                    "errorMessage" to "No authorized zaak was found for the given identificatie."
+                )
+            )
+        } catch (e: MultipleZakenFoundException) {
+            ResponseEntity.status(HttpStatus.CONFLICT).body(
+                mapOf(
+                    "errorCode" to "MORE_THAN_ONE_ZAAK_FOUND",
+                    "errorMessage" to "More than one authorized zaak was found for the given identificatie."
+                )
+            )
+        }
+    }
+}

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakServiceTest.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.service
+
+import com.ritense.authorization.AuthorizationService
+import com.ritense.authorization.request.EntityAuthorizationRequest
+import com.ritense.plugin.domain.PluginConfiguration
+import com.ritense.plugin.domain.PluginConfigurationId
+import com.ritense.plugin.service.PluginService
+import com.ritense.zakenapi.ZakenApiPlugin
+import com.ritense.zakenapi.domain.ZaakResponse
+import com.ritense.zakenapi.exception.MultipleZakenFoundException
+import com.ritense.zakenapi.exception.ZaakNotFoundException
+import com.ritense.zakenapi.security.Zaak
+import com.ritense.zakenapi.security.ZaakActionProvider
+import com.ritense.zgw.Page
+import com.ritense.zgw.Rsin
+import java.net.URI
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class ZaakServiceTest {
+
+    private lateinit var pluginService: PluginService
+    private lateinit var authorizationService: AuthorizationService
+    private lateinit var zaakService: ZaakService
+    private lateinit var zakenApiPlugin: ZakenApiPlugin
+
+    @BeforeEach
+    fun setUp() {
+        pluginService = mock()
+        authorizationService = mock()
+        zakenApiPlugin = mock()
+        zaakService = ZaakService(pluginService, authorizationService)
+    }
+
+    @Test
+    fun `should return true when zaak has no einddatum`() {
+        val pluginId = UUID.randomUUID()
+        val zaaktype = URI("https://example.com/zaaktypen/123")
+        val zaak = createZaakResponse(zaaktype = zaaktype, einddatum = null)
+
+        whenever(pluginService.createInstance<ZakenApiPlugin>(pluginId)).thenReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.searchZaken(any(), any())).thenReturn(Page(1, results = listOf(zaak)))
+        whenever(authorizationService.hasPermission(any<EntityAuthorizationRequest<Zaak>>())).thenReturn(true)
+
+        val result = zaakService.getActiveStatus("ZAAK-001", pluginId)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should return false when zaak has einddatum`() {
+        val pluginId = UUID.randomUUID()
+        val zaaktype = URI("https://example.com/zaaktypen/123")
+        val zaak = createZaakResponse(zaaktype = zaaktype, einddatum = LocalDate.of(2025, 1, 1))
+
+        whenever(pluginService.createInstance<ZakenApiPlugin>(pluginId)).thenReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.searchZaken(any(), any())).thenReturn(Page(1, results = listOf(zaak)))
+        whenever(authorizationService.hasPermission(any<EntityAuthorizationRequest<Zaak>>())).thenReturn(true)
+
+        val result = zaakService.getActiveStatus("ZAAK-001", pluginId)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should filter unauthorized zaken`() {
+        val pluginId = UUID.randomUUID()
+        val authorizedZaaktype = URI("https://example.com/zaaktypen/authorized")
+        val unauthorizedZaaktype = URI("https://example.com/zaaktypen/unauthorized")
+        val authorizedZaak = createZaakResponse(zaaktype = authorizedZaaktype, einddatum = null)
+        val unauthorizedZaak = createZaakResponse(zaaktype = unauthorizedZaaktype, einddatum = null)
+
+        whenever(pluginService.createInstance<ZakenApiPlugin>(pluginId)).thenReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.searchZaken(any(), any())).thenReturn(
+            Page(2, results = listOf(authorizedZaak, unauthorizedZaak))
+        )
+        whenever(authorizationService.hasPermission(argThat<EntityAuthorizationRequest<Zaak>> {
+            entities.any { it.zaaktype == authorizedZaaktype.toString() }
+        })).thenReturn(true)
+        whenever(authorizationService.hasPermission(argThat<EntityAuthorizationRequest<Zaak>> {
+            entities.any { it.zaaktype == unauthorizedZaaktype.toString() }
+        })).thenReturn(false)
+
+        val result = zaakService.getActiveStatus("ZAAK-001", pluginId)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should throw when no authorized zaak found`() {
+        val pluginId = UUID.randomUUID()
+        val zaaktype = URI("https://example.com/zaaktypen/123")
+        val zaak = createZaakResponse(zaaktype = zaaktype)
+
+        whenever(pluginService.createInstance<ZakenApiPlugin>(pluginId)).thenReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.searchZaken(any(), any())).thenReturn(Page(1, results = listOf(zaak)))
+        whenever(authorizationService.hasPermission(any<EntityAuthorizationRequest<Zaak>>())).thenReturn(false)
+
+        assertThrows<ZaakNotFoundException> {
+            zaakService.getActiveStatus("ZAAK-001", pluginId)
+        }
+    }
+
+    @Test
+    fun `should throw when no zaken found at all`() {
+        val pluginId = UUID.randomUUID()
+
+        whenever(pluginService.createInstance<ZakenApiPlugin>(pluginId)).thenReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.searchZaken(any(), any())).thenReturn(Page(0, results = emptyList()))
+
+        assertThrows<ZaakNotFoundException> {
+            zaakService.getActiveStatus("ZAAK-001", pluginId)
+        }
+    }
+
+    @Test
+    fun `should throw when more than one authorized zaak found`() {
+        val pluginId = UUID.randomUUID()
+        val zaaktype = URI("https://example.com/zaaktypen/123")
+        val zaak1 = createZaakResponse(zaaktype = zaaktype)
+        val zaak2 = createZaakResponse(zaaktype = zaaktype)
+
+        whenever(pluginService.createInstance<ZakenApiPlugin>(pluginId)).thenReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.searchZaken(any(), any())).thenReturn(Page(2, results = listOf(zaak1, zaak2)))
+        whenever(authorizationService.hasPermission(any<EntityAuthorizationRequest<Zaak>>())).thenReturn(true)
+
+        assertThrows<MultipleZakenFoundException> {
+            zaakService.getActiveStatus("ZAAK-001", pluginId)
+        }
+    }
+
+    @Test
+    fun `should search across all plugin configurations when no plugin id specified`() {
+        val configId1 = UUID.randomUUID()
+        val configId2 = UUID.randomUUID()
+        val zaaktype = URI("https://example.com/zaaktypen/123")
+        val zaak = createZaakResponse(zaaktype = zaaktype, einddatum = null)
+
+        val config1 = mock<PluginConfiguration> {
+            on { id } doReturn PluginConfigurationId(configId1)
+        }
+        val config2 = mock<PluginConfiguration> {
+            on { id } doReturn PluginConfigurationId(configId2)
+        }
+
+        val plugin1 = mock<ZakenApiPlugin>()
+        val plugin2 = mock<ZakenApiPlugin>()
+
+        whenever(pluginService.findPluginConfigurations(ZakenApiPlugin::class.java)).thenReturn(listOf(config1, config2))
+        whenever(pluginService.createInstance<ZakenApiPlugin>(configId1)).thenReturn(plugin1)
+        whenever(pluginService.createInstance<ZakenApiPlugin>(configId2)).thenReturn(plugin2)
+        whenever(plugin1.searchZaken(any(), any())).thenReturn(Page(1, results = listOf(zaak)))
+        whenever(plugin2.searchZaken(any(), any())).thenReturn(Page(0, results = emptyList()))
+        whenever(authorizationService.hasPermission(any<EntityAuthorizationRequest<Zaak>>())).thenReturn(true)
+
+        val result = zaakService.getActiveStatus("ZAAK-001", null)
+
+        assertTrue(result)
+        verify(plugin1).searchZaken(any(), any())
+        verify(plugin2).searchZaken(any(), any())
+    }
+
+    @Test
+    fun `should throw when no plugin configurations found`() {
+        whenever(pluginService.findPluginConfigurations(ZakenApiPlugin::class.java)).thenReturn(emptyList())
+
+        val exception = assertThrows<IllegalStateException> {
+            zaakService.getActiveStatus("ZAAK-001", null)
+        }
+        assertTrue(exception.message!!.contains("No ZakenApiPlugin configurations found"))
+    }
+
+    @Test
+    fun `should pass zaaktype to authorization check`() {
+        val pluginId = UUID.randomUUID()
+        val zaaktype = URI("https://example.com/zaaktypen/specific-type")
+        val zaak = createZaakResponse(zaaktype = zaaktype, einddatum = null)
+
+        whenever(pluginService.createInstance<ZakenApiPlugin>(pluginId)).thenReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.searchZaken(any(), any())).thenReturn(Page(1, results = listOf(zaak)))
+        whenever(authorizationService.hasPermission(any<EntityAuthorizationRequest<Zaak>>())).thenReturn(true)
+
+        zaakService.getActiveStatus("ZAAK-001", pluginId)
+
+        verify(authorizationService).hasPermission(argThat<EntityAuthorizationRequest<Zaak>> {
+            resourceType == Zaak::class.java &&
+                action == ZaakActionProvider.VIEW_ACTIVE_STATUS &&
+                entities.size == 1 &&
+                entities[0].zaaktype == zaaktype.toString()
+        })
+    }
+
+    private fun createZaakResponse(
+        zaaktype: URI = URI("https://example.com/zaaktypen/default"),
+        einddatum: LocalDate? = null
+    ): ZaakResponse {
+        return ZaakResponse(
+            url = URI("https://example.com/zaken/${UUID.randomUUID()}"),
+            uuid = UUID.randomUUID(),
+            bronorganisatie = Rsin("002564440"),
+            zaaktype = zaaktype,
+            verantwoordelijkeOrganisatie = Rsin("002564440"),
+            startdatum = LocalDate.of(2024, 1, 1),
+            einddatum = einddatum
+        )
+    }
+}

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakResourceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakResourceTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -40,7 +41,7 @@ internal class ZaakResourceTest {
 
     @BeforeEach
     fun setUp() {
-        zaakService = org.mockito.kotlin.mock()
+        zaakService = mock()
         val zaakResource = ZaakResource(zaakService)
         mockMvc = MockMvcBuilders.standaloneSetup(zaakResource).build()
     }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakResourceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakResourceTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi.web.rest
+
+import com.ritense.zakenapi.exception.MultipleZakenFoundException
+import com.ritense.zakenapi.exception.ZaakNotFoundException
+import com.ritense.zakenapi.service.ZaakService
+import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.whenever
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+internal class ZaakResourceTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var zaakService: ZaakService
+
+    @BeforeEach
+    fun setUp() {
+        zaakService = org.mockito.kotlin.mock()
+        val zaakResource = ZaakResource(zaakService)
+        mockMvc = MockMvcBuilders.standaloneSetup(zaakResource).build()
+    }
+
+    @Test
+    fun `should return actief true when zaak has no einddatum`() {
+        whenever(zaakService.getActiveStatus(eq("ZAAK-001"), isNull())).thenReturn(true)
+
+        mockMvc.perform(
+            get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.actief").value(true))
+    }
+
+    @Test
+    fun `should return actief false when zaak has einddatum`() {
+        whenever(zaakService.getActiveStatus(eq("ZAAK-001"), isNull())).thenReturn(false)
+
+        mockMvc.perform(
+            get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.actief").value(false))
+    }
+
+    @Test
+    fun `should return 404 when no authorized zaak found`() {
+        whenever(zaakService.getActiveStatus(eq("ZAAK-001"), isNull()))
+            .thenThrow(ZaakNotFoundException("No authorized zaak found for identificatie 'ZAAK-001'"))
+
+        mockMvc.perform(
+            get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.errorCode").value("ZAAK_NOT_FOUND"))
+    }
+
+    @Test
+    fun `should return 409 when more than one authorized zaak found`() {
+        whenever(zaakService.getActiveStatus(eq("ZAAK-001"), isNull()))
+            .thenThrow(MultipleZakenFoundException("More than one authorized zaak found for identificatie 'ZAAK-001'"))
+
+        mockMvc.perform(
+            get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.errorCode").value("MORE_THAN_ONE_ZAAK_FOUND"))
+    }
+
+    @Test
+    fun `should pass plugin id when provided`() {
+        val pluginId = UUID.randomUUID()
+        whenever(zaakService.getActiveStatus(eq("ZAAK-001"), eq(pluginId))).thenReturn(true)
+
+        mockMvc.perform(
+            get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
+                .param("zaken_api_plugin_id", pluginId.toString())
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.actief").value(true))
+    }
+
+}

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakResourceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakResourceTest.kt
@@ -29,7 +29,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
@@ -54,7 +53,6 @@ internal class ZaakResourceTest {
             get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
                 .accept(MediaType.APPLICATION_JSON)
         )
-            .andDo(print())
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.actief").value(true))
     }
@@ -67,7 +65,6 @@ internal class ZaakResourceTest {
             get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
                 .accept(MediaType.APPLICATION_JSON)
         )
-            .andDo(print())
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.actief").value(false))
     }
@@ -81,7 +78,6 @@ internal class ZaakResourceTest {
             get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
                 .accept(MediaType.APPLICATION_JSON)
         )
-            .andDo(print())
             .andExpect(status().isNotFound)
             .andExpect(jsonPath("$.errorCode").value("ZAAK_NOT_FOUND"))
     }
@@ -95,7 +91,6 @@ internal class ZaakResourceTest {
             get("/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief", "ZAAK-001")
                 .accept(MediaType.APPLICATION_JSON)
         )
-            .andDo(print())
             .andExpect(status().isConflict)
             .andExpect(jsonPath("$.errorCode").value("MORE_THAN_ONE_ZAAK_FOUND"))
     }
@@ -110,7 +105,6 @@ internal class ZaakResourceTest {
                 .param("zaken_api_plugin_id", pluginId.toString())
                 .accept(MediaType.APPLICATION_JSON)
         )
-            .andDo(print())
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.actief").value(true))
     }

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -103,6 +103,7 @@
     * [Tabs](features/case/case-detail/tabs/README.md)
       * [Widgets](features/case/case-detail/tabs/widgets.md)
   * [📃 ZGW](features/case/zgw/README.md)
+    * [Check zaak active status](features/zgw/check-zaak-active-status.md)
     * [Documents](features/case/zgw/zgw-documents/README.md)
       * [Access control](features/case/zgw/zgw-documents/access-control.md)
       * [Uploading to Documenten API with metadata](features/case/zgw/zgw-documents/upload-to-documenten-api-with-metadata.md)

--- a/documentation/features/access-control/configurable-elements.md
+++ b/documentation/features/access-control/configurable-elements.md
@@ -180,6 +180,16 @@ define what can be configured for that element.
 				<strong>ZGW</strong>
 			</td>
 			<td valign="top">
+				<a href="../zgw/check-zaak-active-status.md#access-control">Zaak</a>
+			</td>
+			<td valign="top">
+				<code>com.ritense.zakenapi.security.Zaak</code>
+			</td>
+			<td valign="top">Zaken API</td>
+		</tr>
+		<tr>
+			<td valign="top"></td>
+			<td valign="top">
 				<a href="../case/zgw/zgw-documents/access-control.md">Documents</a>
 			</td>
 			<td valign="top">

--- a/documentation/features/zgw/check-zaak-active-status.md
+++ b/documentation/features/zgw/check-zaak-active-status.md
@@ -1,0 +1,62 @@
+# Check zaak active status
+
+{% hint style="success" %}
+Available since Valtimo `13.21.0`
+{% endhint %}
+
+Valtimo provides an API endpoint to check whether a zaak is still active. A zaak is considered active when its `einddatum` (end date) has not been set.
+
+## API
+
+### Endpoint
+
+```
+GET /api/v1/zaken-api/zaak/{zaakIdentificatie}/actief
+```
+
+### Parameters
+
+| Parameter              | Type   | Required | Description                                                                                          |
+|------------------------|--------|----------|------------------------------------------------------------------------------------------------------|
+| `zaakIdentificatie`    | String | Yes      | The identificatie of the zaak to check.                                                              |
+| `zaken_api_plugin_id`  | UUID   | No       | The ID of a specific Zaken API plugin configuration to use. If omitted, all configured Zaken API plugins are searched. |
+
+### Responses
+
+| Status | Description                                                                 |
+|--------|-----------------------------------------------------------------------------|
+| 200    | Returns `{ "actief": true }` or `{ "actief": false }`.                     |
+| 404    | No authorized zaak was found for the given identificatie.                   |
+| 409    | More than one authorized zaak was found for the given identificatie.        |
+
+## Access control
+
+This endpoint is secured with PBAC. A new resource type `com.ritense.zakenapi.security.Zaak` is available with the following action:
+
+| Action               | Description                                      |
+|----------------------|--------------------------------------------------|
+| `view_active_status` | Allows checking the active status of a zaak.     |
+
+The resource supports a `zaaktype` field condition, so access can be restricted to specific zaaktypen.
+
+### Example permission configuration
+
+```json
+[
+    {
+        "resourceType": "com.ritense.zakenapi.security.Zaak",
+        "action": "view_active_status",
+        "roleKey": "ROLE_USER",
+        "conditions": [
+            {
+                "type": "field",
+                "field": "zaaktype",
+                "operator": "==",
+                "value": "http://localhost:8001/catalogi/api/v1/zaaktypen/my-zaaktype-uuid"
+            }
+        ]
+    }
+]
+```
+
+This configuration grants users with the `ROLE_USER` role permission to check the active status of zaken that match the specified zaaktype.

--- a/documentation/release-notes/13.x.x/13.21.0/README.md
+++ b/documentation/release-notes/13.x.x/13.21.0/README.md
@@ -6,9 +6,9 @@
 
 ## New Features
 
-* **New feature title**
+* **Check if a zaak is still active**
 
-  New feature explanation.
+  A new API endpoint has been added to check whether a zaak is still active (i.e. its `einddatum` is not set). The endpoint looks up a zaak by its identificatie and returns whether it is active. Access is controlled through PBAC: a new `com.ritense.zakenapi.security.Zaak` resource type with the `view_active_status` action allows administrators to restrict which zaaktypen a user may query. See [Check zaak active status](../../../features/zgw/check-zaak-active-status.md) for details.
 
 ## Enhancements
 


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/449

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Create a new bezwaar case in Valtimo
- [ ] Validate that the zaak is created in the Zaken API and copy the zaak-identificatie and zaak-type URL
- [ ] Put the zaak-type URL in the zaken.permission.json so that you (as admin) have access to it.
- [ ] Reboot the application so that the updated zaken.permission.json is enforced.
- [ ] Make a request to `/api/v1/zaken-api/zaak/{zaakIdentificatie}/actief` with a valid token. (Replace `{zaakIdentificatie}` with the zaak-identificatie from the zaak in the Zaken API).
- [ ] Ensure that the endpoint returns that the zaak is active.
- [ ] Set the einddatum of the zaak in the Zaken API to a date before today.
- [ ] Repeat the call to the new endpoin tto ensure that the endpoint returns that the endpoint is no longer active.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [x] Yes
- [ ] Not applicable

Valtimo access control checks have been implemented
- [x] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
