### PR TITLE
Add handling for `InformatieObjectReceivedEvent` and `ZaakInformatieO…

### DIFF
--- a/backend/case/src/main/kotlin/com/ritense/document/event/InformatieObjectReceivedEvent.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/event/InformatieObjectReceivedEvent.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.document.event
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonView
+import com.ritense.valtimo.contract.audit.AuditEvent
+import com.ritense.valtimo.contract.audit.AuditMetaData
+import com.ritense.valtimo.contract.audit.view.AuditView
+import com.ritense.valtimo.contract.utils.AssertionConcern
+import com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentNotNull
+import java.time.LocalDateTime
+import java.util.Objects
+import java.util.UUID
+
+class InformatieObjectReceivedEvent @JsonCreator constructor(
+    origin: String,
+    occurredOn: LocalDateTime,
+    user: String,
+    private var documentId: UUID,
+    private var identificatie: String
+) : AuditMetaData(UUID.randomUUID(), origin, occurredOn, user), AuditEvent {
+
+    init {
+        assertArgumentNotNull(documentId, "documentId is required")
+        assertArgumentNotNull(identificatie, "informationObjectId.identificatie  is required")
+    }
+
+    fun setDocumentId(documentId: UUID) {
+        this.documentId = documentId
+    }
+
+    fun setIdentificatie(identificatie: String) {
+        this.identificatie = identificatie
+    }
+
+    @JsonView(AuditView.Internal::class)
+    @JsonIgnore(false)
+    override fun getDocumentId(): UUID = documentId
+
+    @JsonProperty
+    @JsonView(AuditView.Public::class)
+    fun getIdentificatie() = identificatie
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InformatieObjectReceivedEvent) return false
+        if (!super.equals(other)) return false
+
+        return identificatie == other.identificatie && documentId == other.documentId
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(super.hashCode(), identificatie, documentId)
+    }
+}

--- a/backend/case/src/main/kotlin/com/ritense/document/event/InformatieObjectReceivedEvent.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/event/InformatieObjectReceivedEvent.kt
@@ -39,7 +39,7 @@ class InformatieObjectReceivedEvent @JsonCreator constructor(
 
     init {
         assertArgumentNotNull(documentId, "documentId is required")
-        assertArgumentNotNull(identificatie, "informationObjectId.identificatie  is required")
+        assertArgumentNotNull(identificatie, "identificatie  is required")
     }
 
     fun setDocumentId(documentId: UUID) {

--- a/backend/process-document/src/main/java/com/ritense/processdocument/service/impl/OperatonProcessJsonSchemaDocumentAuditService.java
+++ b/backend/process-document/src/main/java/com/ritense/processdocument/service/impl/OperatonProcessJsonSchemaDocumentAuditService.java
@@ -31,6 +31,7 @@ import com.ritense.document.event.DocumentAssigneeChangedEvent;
 import com.ritense.document.event.DocumentRetentionPeriodSetEvent;
 import com.ritense.document.event.DocumentRetentionPeriodUnsetEvent;
 import com.ritense.document.event.DocumentUnassignedEvent;
+import com.ritense.document.event.InformatieObjectReceivedEvent;
 import com.ritense.document.service.impl.JsonSchemaDocumentService;
 import com.ritense.processdocument.event.BesluitAddedEvent;
 import com.ritense.processdocument.service.ProcessDocumentAuditService;
@@ -71,6 +72,7 @@ public class OperatonProcessJsonSchemaDocumentAuditService implements ProcessDoc
         final Pageable pageable
     ) {
         final List<Class<? extends AuditEvent>> eventTypes = List.of(
+            InformatieObjectReceivedEvent.class,
             JsonSchemaDocumentCreatedEvent.class,
             JsonSchemaDocumentModifiedEvent.class,
             DocumentRetentionPeriodSetEvent.class,

--- a/backend/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/event/NotificatiesApiNotificationReceivedEvent.kt
+++ b/backend/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/event/NotificatiesApiNotificationReceivedEvent.kt
@@ -22,6 +22,7 @@ data class NotificatiesApiNotificationReceivedEvent(
     val kanaal: String,
     val hoofdObject: String?,
     val resourceUrl: String,
+    val resource: String?,
     val actie: String,
     val aanmaakdatum: LocalDateTime?,
     val kenmerken: Map<String, String>

--- a/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiInboundEventRepositoryIT.kt
+++ b/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiInboundEventRepositoryIT.kt
@@ -147,7 +147,8 @@ class NotificatiesApiInboundEventRepositoryIT : BaseIntegrationTest() {
             resourceUrl = "http://example.com/resource/${UUID.randomUUID()}",
             actie = "create",
             aanmaakdatum = LocalDateTime.now(),
-            kenmerken = mapOf("bronId" to UUID.randomUUID().toString())
+            kenmerken = mapOf("bronId" to UUID.randomUUID().toString()),
+            resource = null
         )
         return objectMapper.writeValueAsString(notification)
     }

--- a/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiInboundEventIntakeServiceTest.kt
+++ b/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiInboundEventIntakeServiceTest.kt
@@ -122,7 +122,8 @@ class NotificatiesApiInboundEventIntakeServiceTest {
             hoofdObject = "http://example.com/object/1",
             actie = "update",
             aanmaakdatum = LocalDateTime.now(),
-            kenmerken = mapOf("a" to "1", "b" to "2")
+            kenmerken = mapOf("a" to "1", "b" to "2"),
+            resource = null
         )
     }
 }

--- a/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiInboundEventProcessingServiceIT.kt
+++ b/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiInboundEventProcessingServiceIT.kt
@@ -100,7 +100,8 @@ class NotificatiesApiInboundEventProcessingServiceIT : BaseIntegrationTest() {
             hoofdObject = null,
             actie = "update",
             aanmaakdatum = LocalDateTime.now(),
-            kenmerken = mapOf("bronId" to UUID.randomUUID().toString())
+            kenmerken = mapOf("bronId" to UUID.randomUUID().toString()),
+            resource = null
         )
         return objectMapper.writeValueAsString(notification)
     }

--- a/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiInboundEventProcessingServiceTest.kt
+++ b/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiInboundEventProcessingServiceTest.kt
@@ -153,7 +153,8 @@ class NotificatiesApiInboundEventProcessingServiceTest {
             hoofdObject = "http://example.com/object/1",
             actie = "update",
             aanmaakdatum = LocalDateTime.now(),
-            kenmerken = mapOf("a" to "1")
+            kenmerken = mapOf("a" to "1"),
+            resource = null
         )
     }
 }

--- a/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiServiceTest.kt
+++ b/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/service/NotificatiesApiServiceTest.kt
@@ -140,7 +140,8 @@ class NotificatiesApiServiceTest {
             resourceUrl = "http://example.com",
             actie = "create",
             aanmaakdatum = LocalDateTime.now(),
-            kenmerken = mapOf("bronId" to UUID.randomUUID().toString())
+            kenmerken = mapOf("bronId" to UUID.randomUUID().toString()),
+            resource = null
         )
     }
 }

--- a/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/web/rest/NotificatiesApiResourceTest.kt
+++ b/backend/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/web/rest/NotificatiesApiResourceTest.kt
@@ -87,7 +87,8 @@ class NotificatiesApiResourceTest {
             actie = "",
             hoofdObject = "",
             aanmaakdatum = null,
-            kenmerken = mapOf()
+            kenmerken = mapOf(),
+            resource = null
         )
     }
 

--- a/backend/zgw/portaaltaak/src/test/kotlin/com/ritense/portaaltaak/PortaalTaakEventListenerIntTest.kt
+++ b/backend/zgw/portaaltaak/src/test/kotlin/com/ritense/portaaltaak/PortaalTaakEventListenerIntTest.kt
@@ -229,7 +229,8 @@ internal class PortaalTaakEventListenerIntTest : BaseIntegrationTest() {
             actie = "update",
             aanmaakdatum = null,
             resourceUrl = "${server.url("/")}objects",
-            kenmerken = mapOf(Pair("objectType", objectManagement.objecttypeId))
+            kenmerken = mapOf(Pair("objectType", objectManagement.objecttypeId)),
+            resource = null
         )
     }
 

--- a/backend/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginEventListenerIntTest.kt
+++ b/backend/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginEventListenerIntTest.kt
@@ -579,7 +579,8 @@ internal class VerzoekPluginEventListenerIntTest : BaseIntegrationTest() {
             actie = "create",
             resourceUrl = "aResource",
             aanmaakdatum = null,
-            kenmerken = mapOf(Pair("objectType", "something/$objectType"))
+            kenmerken = mapOf(Pair("objectType", "something/$objectType")),
+            resource = null
         )
     }
 }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ExtractUuid.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ExtractUuid.kt
@@ -33,4 +33,13 @@ object ExtractUuid {
         }
     }
 
+    fun extractUuidFromUri(uri: String): UUID? {
+        return try {
+            val lastSegment = uri.substringAfterLast("/").takeIf { it.isNotBlank() }
+
+            lastSegment?.let { UUID.fromString(it) }
+        } catch (e: Exception) {
+            null
+        }
+    }
 }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ExtractUuid.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ExtractUuid.kt
@@ -35,9 +35,7 @@ object ExtractUuid {
 
     fun extractUuidFromUri(uri: String): UUID? {
         return try {
-            val lastSegment = uri.substringAfterLast("/").takeIf { it.isNotBlank() }
-
-            lastSegment?.let { UUID.fromString(it) }
+            extractUuidFromUri(URI(uri))
         } catch (e: Exception) {
             null
         }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -1320,6 +1320,14 @@ class ZakenApiPlugin(
         return results.singleOrNull()
     }
 
+    fun getZaakInformatieObjectByUrl(zaakInformatieobjectUrl: URI, caseDocumentId: UUID) =
+        client.getZaakInformatieObject(
+            authentication = authenticationPluginConfiguration,
+            baseUrl = url,
+            zaakInformatieobjectUrl = zaakInformatieobjectUrl,
+            caseDocumentId
+        )
+
     fun deleteZaakInformatieobject(zaakInformatieobjectUrl: URI, caseDocumentId: UUID?) {
         logger.debug { "Deleting zaak informatie object for URL '$zaakInformatieobjectUrl'" }
         client.deleteZaakInformatieObject(
@@ -1539,7 +1547,6 @@ class ZakenApiPlugin(
     }
 
     fun patchZaakNotitie(
-
         zaakNotitieUrl: URI,
         onderwerp: String? = null,
         tekst: String? = null,

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
@@ -23,21 +23,21 @@ import com.ritense.outbox.OutboxService
 import com.ritense.resource.authorization.ResourcePermission
 import com.ritense.resource.authorization.ResourcePermissionActionProvider
 import com.ritense.zakenapi.ZakenApiAuthentication
+import com.ritense.zakenapi.domain.CreateZaakNotitieRequest
 import com.ritense.zakenapi.domain.CreateZaakRequest
 import com.ritense.zakenapi.domain.CreateZaakResultaatRequest
 import com.ritense.zakenapi.domain.CreateZaakResultaatResponse
 import com.ritense.zakenapi.domain.CreateZaakStatusRequest
 import com.ritense.zakenapi.domain.CreateZaakStatusResponse
 import com.ritense.zakenapi.domain.CreateZaakeigenschapRequest
+import com.ritense.zakenapi.domain.GetZaakResultatenRequest
+import com.ritense.zakenapi.domain.PatchZaakNotitieRequest
 import com.ritense.zakenapi.domain.PatchZaakRequest
+import com.ritense.zakenapi.domain.PutZaakNotitieRequest
 import com.ritense.zakenapi.domain.SearchParameter
 import com.ritense.zakenapi.domain.UpdateZaakeigenschapRequest
 import com.ritense.zakenapi.domain.ZaakInformatieObject
 import com.ritense.zakenapi.domain.ZaakNotitie
-import com.ritense.zakenapi.domain.CreateZaakNotitieRequest
-import com.ritense.zakenapi.domain.GetZaakResultatenRequest
-import com.ritense.zakenapi.domain.PatchZaakNotitieRequest
-import com.ritense.zakenapi.domain.PutZaakNotitieRequest
 import com.ritense.zakenapi.domain.ZaakObject
 import com.ritense.zakenapi.domain.ZaakResponse
 import com.ritense.zakenapi.domain.ZaakResultaat
@@ -57,12 +57,19 @@ import com.ritense.zakenapi.event.ZaakCreated
 import com.ritense.zakenapi.event.ZaakInformatieObjectListed
 import com.ritense.zakenapi.event.ZaakInformatieObjectenListed
 import com.ritense.zakenapi.event.ZaakListed
+import com.ritense.zakenapi.event.ZaakNotitieCreated
+import com.ritense.zakenapi.event.ZaakNotitieDeleted
+import com.ritense.zakenapi.event.ZaakNotitiePatched
+import com.ritense.zakenapi.event.ZaakNotitieUpdated
+import com.ritense.zakenapi.event.ZaakNotitieViewed
+import com.ritense.zakenapi.event.ZaakNotitiesListed
 import com.ritense.zakenapi.event.ZaakObjectCreated
 import com.ritense.zakenapi.event.ZaakObjectViewed
 import com.ritense.zakenapi.event.ZaakObjectenListed
 import com.ritense.zakenapi.event.ZaakOpschortingUpdated
 import com.ritense.zakenapi.event.ZaakPatched
 import com.ritense.zakenapi.event.ZaakResultaatCreated
+import com.ritense.zakenapi.event.ZaakResultaatDeleted
 import com.ritense.zakenapi.event.ZaakResultaatViewed
 import com.ritense.zakenapi.event.ZaakRolCreated
 import com.ritense.zakenapi.event.ZaakRolDeleted
@@ -76,13 +83,6 @@ import com.ritense.zakenapi.event.ZaakeigenschapCreated
 import com.ritense.zakenapi.event.ZaakeigenschapDeleted
 import com.ritense.zakenapi.event.ZaakeigenschapListed
 import com.ritense.zakenapi.event.ZaakeigenschapUpdated
-import com.ritense.zakenapi.event.ZaakNotitieCreated
-import com.ritense.zakenapi.event.ZaakNotitieDeleted
-import com.ritense.zakenapi.event.ZaakNotitiePatched
-import com.ritense.zakenapi.event.ZaakNotitieUpdated
-import com.ritense.zakenapi.event.ZaakNotitieViewed
-import com.ritense.zakenapi.event.ZaakNotitiesListed
-import com.ritense.zakenapi.event.ZaakResultaatDeleted
 import com.ritense.zakenapi.exception.ZaakRolNotUpdatedException
 import com.ritense.zgw.ClientTools
 import com.ritense.zgw.Page
@@ -94,7 +94,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
-import kotlin.toString
 
 class ZakenApiClient(
     private val restClientBuilder: RestClient.Builder,
@@ -227,19 +226,16 @@ class ZakenApiClient(
         baseUrl: URI,
         zaakInformatieobjectUrl: URI,
         caseDocumentId: UUID,
-    ): ZaakInformatieObject? {
+    ): ZaakInformatieObject {
         validateUrlHost(baseUrl, zaakInformatieobjectUrl)
 
-        if (!authorizationService.hasPermission(
-                EntityAuthorizationRequest(
-                    ResourcePermission::class.java,
-                    ResourcePermissionActionProvider.VIEW,
-                    ResourcePermission(caseDocumentId)
-                )
+        authorizationService.requirePermission(
+            EntityAuthorizationRequest(
+                ResourcePermission::class.java,
+                ResourcePermissionActionProvider.VIEW,
+                ResourcePermission(caseDocumentId)
             )
-        ) {
-            return null
-        }
+        )
 
         val result = buildRestClient(authentication)
             .get()

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
@@ -54,6 +54,7 @@ import com.ritense.zakenapi.domain.zaakobjectrequest.ZaakObjectRequest
 import com.ritense.zakenapi.domain.zaakobjectrequest.ZaakObjectType
 import com.ritense.zakenapi.event.DocumentLinkedToZaak
 import com.ritense.zakenapi.event.ZaakCreated
+import com.ritense.zakenapi.event.ZaakInformatieObjectListed
 import com.ritense.zakenapi.event.ZaakInformatieObjectenListed
 import com.ritense.zakenapi.event.ZaakListed
 import com.ritense.zakenapi.event.ZaakObjectCreated
@@ -218,6 +219,38 @@ class ZakenApiClient(
             .body<List<ZaakInformatieObject>>()!!
 
         outboxService.send { ZaakInformatieObjectenListed(objectMapper.valueToTree(result)) }
+        return result
+    }
+
+    fun getZaakInformatieObject(
+        authentication: ZakenApiAuthentication,
+        baseUrl: URI,
+        zaakInformatieobjectUrl: URI,
+        caseDocumentId: UUID,
+    ): ZaakInformatieObject? {
+        validateUrlHost(baseUrl, zaakInformatieobjectUrl)
+
+        if (!authorizationService.hasPermission(
+                EntityAuthorizationRequest(
+                    ResourcePermission::class.java,
+                    ResourcePermissionActionProvider.VIEW,
+                    ResourcePermission(caseDocumentId)
+                )
+            )
+        ) {
+            return null
+        }
+
+        val result = buildRestClient(authentication)
+            .get()
+            .uri {
+                ClientTools.baseUrlToBuilder(it, zaakInformatieobjectUrl)
+                    .build()
+            }
+            .retrieve()
+            .body<ZaakInformatieObject>()!!
+
+        outboxService.send { ZaakInformatieObjectListed(objectMapper.valueToTree(result)) }
         return result
     }
 

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/event/ZaakInformatieObjectListed.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/event/ZaakInformatieObjectListed.kt
@@ -16,12 +16,12 @@
 
 package com.ritense.zakenapi.event
 
-import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.ritense.outbox.domain.BaseEvent
 
-class ZaakInformatieObjectenListed (zaakInformatieObjecten: ArrayNode) : BaseEvent(
-    type = "com.ritense.gzac.zrc.zaakinformatieobject.listed",
-    resultType = "List<com.ritense.zakenapi.domain.ZaakInformatieObject>",
+class ZaakInformatieObjectListed (zaakInformatieObject: ObjectNode) : BaseEvent(
+    type = "com.ritense.gzac.zrc.zaakinformatieobject.viewed",
+    resultType = "com.ritense.zakenapi.domain.ZaakInformatieObject",
     resultId = null,
-    result = zaakInformatieObjecten
+    result = zaakInformatieObject
 )

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ExtractUuidTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ExtractUuidTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.zakenapi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.util.UUID
+
+internal class ExtractUuidTest {
+
+    private val uuid = UUID.fromString("e1e96e94-e7ff-47d1-9ea1-7c7c81713480")
+
+    @Test
+    fun `should extract UUID from URI`() {
+        val uri = URI("https://example.com/zaken/$uuid")
+
+        val result = ExtractUuid.extractUuidFromUri(uri)
+
+        assertThat(result).isEqualTo(uuid)
+    }
+
+    @Test
+    fun `should return null when URI last segment is not a UUID`() {
+        val uri = URI("https://example.com/zaken/not-a-uuid")
+
+        val result = ExtractUuid.extractUuidFromUri(uri)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `should return null when URI ends with a trailing slash`() {
+        val uri = URI("https://example.com/zaken/$uuid/")
+
+        val result = ExtractUuid.extractUuidFromUri(uri)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `should extract UUID from string`() {
+        val result = ExtractUuid.extractUuidFromUri("https://example.com/zaken/$uuid")
+
+        assertThat(result).isEqualTo(uuid)
+    }
+
+    @Test
+    fun `should return null when string is not a valid URI`() {
+        val result = ExtractUuid.extractUuidFromUri("not a valid uri")
+
+        assertThat(result).isNull()
+    }
+}

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -46,6 +46,7 @@ import com.ritense.zakenapi.domain.NotitieType
 import com.ritense.zakenapi.domain.NotitieStatus
 import com.ritense.zakenapi.domain.PutZaakNotitieRequest
 import com.ritense.zakenapi.domain.ZaakHersteltermijn
+import com.ritense.zakenapi.domain.ZaakInformatieObject
 import com.ritense.zakenapi.domain.ZaakInstanceLink
 import com.ritense.zakenapi.domain.ZaakObject
 import com.ritense.zakenapi.domain.ZaakResponse
@@ -1718,6 +1719,73 @@ internal class ZakenApiPluginTest {
             zaakUrl = eq(zaakUrl),
             page = eq(1)
         )
+    }
+
+    @Test
+    fun `should return zaak informatie object by url`() {
+        // given
+        val caseDocumentId = UUID.randomUUID()
+        val zaakInformatieobjectUrl = URI("${zakenApiUrl()}/zaakinformatieobjecten/abc123")
+        val zaakInformatieObject: ZaakInformatieObject = mock()
+
+        val authenticationMock: ZakenApiAuthentication = mock()
+        val zakenApiClient: ZakenApiClient = mock {
+            on {
+                this.getZaakInformatieObject(
+                    authentication = eq(authenticationMock),
+                    baseUrl = eq(zakenApiUri()),
+                    zaakInformatieobjectUrl = eq(zaakInformatieobjectUrl),
+                    caseDocumentId = eq(caseDocumentId)
+                )
+            } doReturn zaakInformatieObject
+        }
+
+        val plugin = zakenApiPlugin(
+            zakenApiClient = zakenApiClient,
+            authenticationMock = authenticationMock
+        )
+
+        // when
+        val result = plugin.getZaakInformatieObjectByUrl(zaakInformatieobjectUrl, caseDocumentId)
+
+        // then
+        assertThat(result).isEqualTo(zaakInformatieObject)
+        verify(zakenApiClient, times(1)).getZaakInformatieObject(
+            authentication = eq(authenticationMock),
+            baseUrl = eq(zakenApiUri()),
+            zaakInformatieobjectUrl = eq(zaakInformatieobjectUrl),
+            caseDocumentId = eq(caseDocumentId)
+        )
+    }
+
+    @Test
+    fun `should return null when not authorized to get zaak informatie object by url`() {
+        // given
+        val caseDocumentId = UUID.randomUUID()
+        val zaakInformatieobjectUrl = URI("${zakenApiUrl()}/zaakinformatieobjecten/abc123")
+
+        val authenticationMock: ZakenApiAuthentication = mock()
+        val zakenApiClient: ZakenApiClient = mock {
+            on {
+                this.getZaakInformatieObject(
+                    authentication = eq(authenticationMock),
+                    baseUrl = eq(zakenApiUri()),
+                    zaakInformatieobjectUrl = eq(zaakInformatieobjectUrl),
+                    caseDocumentId = eq(caseDocumentId)
+                )
+            } doReturn null
+        }
+
+        val plugin = zakenApiPlugin(
+            zakenApiClient = zakenApiClient,
+            authenticationMock = authenticationMock
+        )
+
+        // when
+        val result = plugin.getZaakInformatieObjectByUrl(zaakInformatieobjectUrl, caseDocumentId)
+
+        // then
+        assertThat(result).isNull()
     }
 
     private fun zakenApiPlugin(

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -73,6 +73,8 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.springframework.security.access.AccessDeniedException
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -1759,7 +1761,7 @@ internal class ZakenApiPluginTest {
     }
 
     @Test
-    fun `should return null when not authorized to get zaak informatie object by url`() {
+    fun `should throw exception when not authorized to get zaak informatie object by url`() {
         // given
         val caseDocumentId = UUID.randomUUID()
         val zaakInformatieobjectUrl = URI("${zakenApiUrl()}/zaakinformatieobjecten/abc123")
@@ -1773,7 +1775,7 @@ internal class ZakenApiPluginTest {
                     zaakInformatieobjectUrl = eq(zaakInformatieobjectUrl),
                     caseDocumentId = eq(caseDocumentId)
                 )
-            } doReturn null
+            } doThrow AccessDeniedException("Access denied")
         }
 
         val plugin = zakenApiPlugin(
@@ -1781,11 +1783,10 @@ internal class ZakenApiPluginTest {
             authenticationMock = authenticationMock
         )
 
-        // when
-        val result = plugin.getZaakInformatieObjectByUrl(zaakInformatieobjectUrl, caseDocumentId)
-
-        // then
-        assertThat(result).isNull()
+        // when / then
+        assertThrows<AccessDeniedException> {
+            plugin.getZaakInformatieObjectByUrl(zaakInformatieobjectUrl, caseDocumentId)
+        }
     }
 
     private fun zakenApiPlugin(

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
@@ -143,20 +143,20 @@ internal class ZakenApiClientIT @Autowired constructor(
             caseDocumentId = CASE_DOCUMENT_ID
         )
 
-        assertEquals(URI("https://example.com"), result!!.url)
+        assertEquals(URI("https://example.com"), result.url)
     }
 
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
-    fun `should return null for get single zaakinformatieobject by url when missing permission`() {
-        val result = zakenApiClient.getZaakInformatieObject(
-            authentication = zakenApiPlugin.authenticationPluginConfiguration,
-            baseUrl = zakenApiPlugin.url,
-            zaakInformatieobjectUrl = ZAAK_INFORMATIEOBJECT_URL,
-            caseDocumentId = CASE_DOCUMENT_ID
-        )
-
-        assertEquals(null, result)
+    fun `should throw access denied for get single zaakinformatieobject by url when missing permission`() {
+        assertThrows<AccessDeniedException> {
+            zakenApiClient.getZaakInformatieObject(
+                authentication = zakenApiPlugin.authenticationPluginConfiguration,
+                baseUrl = zakenApiPlugin.url,
+                zaakInformatieobjectUrl = ZAAK_INFORMATIEOBJECT_URL,
+                caseDocumentId = CASE_DOCUMENT_ID
+            )
+        }
     }
 
     @Test

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
@@ -122,6 +122,45 @@ internal class ZakenApiClientIT @Autowired constructor(
 
     @Test
     @WithMockUser(authorities = ["ROLE_TEST"])
+    fun `should allow get single zaakinformatieobject by url`() {
+        val permissions = listOf(
+            Permission(
+                id = CASE_DOCUMENT_ID,
+                resourceType = ResourcePermission::class.java,
+                actions = mutableListOf(ResourcePermissionActionProvider.VIEW),
+                conditionContainer = ConditionContainer(),
+                role = roleTest,
+                contextResourceType = null,
+                contextConditionContainer = null
+            )
+        )
+        permissionRepository.saveAllAndFlush(permissions)
+
+        val result = zakenApiClient.getZaakInformatieObject(
+            authentication = zakenApiPlugin.authenticationPluginConfiguration,
+            baseUrl = zakenApiPlugin.url,
+            zaakInformatieobjectUrl = ZAAK_INFORMATIEOBJECT_URL,
+            caseDocumentId = CASE_DOCUMENT_ID
+        )
+
+        assertEquals(URI("https://example.com"), result!!.url)
+    }
+
+    @Test
+    @WithMockUser(authorities = ["ROLE_TEST"])
+    fun `should return null for get single zaakinformatieobject by url when missing permission`() {
+        val result = zakenApiClient.getZaakInformatieObject(
+            authentication = zakenApiPlugin.authenticationPluginConfiguration,
+            baseUrl = zakenApiPlugin.url,
+            zaakInformatieobjectUrl = ZAAK_INFORMATIEOBJECT_URL,
+            caseDocumentId = CASE_DOCUMENT_ID
+        )
+
+        assertEquals(null, result)
+    }
+
+    @Test
+    @WithMockUser(authorities = ["ROLE_TEST"])
     fun `should allow zaak-document list`() {
         val permissions = listOf(
             Permission(
@@ -165,6 +204,7 @@ internal class ZakenApiClientIT @Autowired constructor(
                 return when (request.method + " " + request.path?.substringBefore('?')) {
                     "POST $ZAKEN_API_PATH/zaakinformatieobjecten" -> handleLinkDocumentRequest()
                     "GET $ZAKEN_API_PATH/zaakinformatieobjecten" -> handleListDocumentRequest()
+                    "GET $ZAKEN_API_PATH/zaakinformatieobjecten/$ZAAK_ID" -> handleGetSingleDocumentRequest()
                     else -> MockResponse().setResponseCode(404)
                 }
             }
@@ -173,6 +213,22 @@ internal class ZakenApiClientIT @Autowired constructor(
     }
 
     private fun handleLinkDocumentRequest(zone: String = "Z"): MockResponse {
+        val body = """
+            {
+                "url": "https://example.com",
+                "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+                "informatieobject": "https://example.com",
+                "zaak": "https://example.com",
+                "aardRelatieWeergave": "Hoort bij, omgekeerd: kent",
+                "titel": "string",
+                "beschrijving": "string",
+                "registratiedatum": "2019-08-24T14:15:22Z"
+            }
+        """.trimIndent()
+        return mockResponse(body)
+    }
+
+    private fun handleGetSingleDocumentRequest(): MockResponse {
         val body = """
             {
                 "url": "https://example.com",
@@ -213,6 +269,7 @@ internal class ZakenApiClientIT @Autowired constructor(
         val CASE_DOCUMENT_ID: UUID = UUID.fromString(ZAAK_ID)
 
         private val ZAAK_URL = URI("${ZAKEN_API_URL}/zaken/$ZAAK_ID")
+        val ZAAK_INFORMATIEOBJECT_URL = URI("${ZAKEN_API_URL}/zaakinformatieobjecten/$ZAAK_ID")
     }
 
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.*
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.reactive.function.client.ClientRequest
@@ -1847,24 +1848,25 @@ internal class ZakenApiClientTest {
     }
 
     @Test
-    fun `should return null and not call api when not authorized to get zaakinformatieobject`() {
+    fun `should throw exception and not call api when not authorized to get zaakinformatieobject`() {
         val zaakInformatieobjectUrl = zakenApiBaseUri("/zaakinformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f")
         val caseDocumentId = UUID.randomUUID()
         val requestsBefore = mockApi.requestCount
 
         authorizationService = mock {
-            on { this.hasPermission<Any>(any()) } doReturn false
+            on { this.requirePermission<Any>(any()) } doThrow AccessDeniedException("Unauthorized")
         }
         val client = zakenApiClient()
 
-        val result = client.getZaakInformatieObject(
-            authentication = TestAuthentication(),
-            baseUrl = zakenApiBaseUri(),
-            zaakInformatieobjectUrl = zaakInformatieobjectUrl,
-            caseDocumentId = caseDocumentId
-        )
+        assertThrows<AccessDeniedException> {
+            client.getZaakInformatieObject(
+                authentication = TestAuthentication(),
+                baseUrl = zakenApiBaseUri(),
+                zaakInformatieobjectUrl = zaakInformatieobjectUrl,
+                caseDocumentId = caseDocumentId
+            )
+        }
 
-        assertThat(result).isNull()
         assertEquals(requestsBefore, mockApi.requestCount)
         verify(outboxService, times(0)).send(any())
     }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
@@ -1801,6 +1801,72 @@ internal class ZakenApiClientTest {
         verify(outboxService, times(0)).send(any())
     }
 
+    @Test
+    fun `should send get zaakinformatieobject request, parse response and send outbox message`() {
+        val uuid = "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+        val zaakInformatieobjectUrl = zakenApiBaseUri("/zaakinformatieobjecten/$uuid")
+        val caseDocumentId = UUID.randomUUID()
+        val client = zakenApiClient()
+
+        val responseBody = """
+            {
+                "url": "$zaakInformatieobjectUrl",
+                "uuid": "$uuid",
+                "informatieobject": "$HTTPS_EXAMPLE_COM",
+                "zaak": "${zaakUri()}",
+                "aardRelatieWeergave": "Hoort bij, omgekeerd: kent",
+                "titel": "test",
+                "beschrijving": "test omschrijving",
+                "registratiedatum": "2019-08-24T14:15:22Z"
+            }
+        """.trimIndent()
+
+        mockApi.enqueue(mockResponse(responseBody))
+
+        val result = client.getZaakInformatieObject(
+            authentication = TestAuthentication(),
+            baseUrl = zakenApiBaseUri(),
+            zaakInformatieobjectUrl = zaakInformatieobjectUrl,
+            caseDocumentId = caseDocumentId
+        )
+
+        val recordedRequest = mockApi.takeRequest()
+
+        assertEquals("Bearer test", recordedRequest.getHeader("Authorization"))
+        assertEquals(URI(zaakInformatieobjectUrl.toString()), result!!.url)
+        assertEquals(UUID.fromString(uuid), result.uuid)
+        assertEquals(URI(HTTPS_EXAMPLE_COM), result.informatieobject)
+        assertEquals("Hoort bij, omgekeerd: kent", result.aardRelatieWeergave)
+        assertEquals("test", result.titel)
+        assertEquals("test omschrijving", result.beschrijving)
+
+        argumentCaptor<Supplier<BaseEvent>> {
+            verify(outboxService).send(capture())
+            assertThat(firstValue.get()).isInstanceOf(ZaakInformatieObjectListed::class.java)
+        }
+    }
+
+    @Test
+    fun `should return null and not call api when not authorized to get zaakinformatieobject`() {
+        val zaakInformatieobjectUrl = zakenApiBaseUri("/zaakinformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f")
+        val caseDocumentId = UUID.randomUUID()
+
+        authorizationService = mock {
+            on { this.hasPermission<Any>(any()) } doReturn false
+        }
+        val client = zakenApiClient()
+
+        val result = client.getZaakInformatieObject(
+            authentication = TestAuthentication(),
+            baseUrl = zakenApiBaseUri(),
+            zaakInformatieobjectUrl = zaakInformatieobjectUrl,
+            caseDocumentId = caseDocumentId
+        )
+
+        assertThat(result).isNull()
+        verify(outboxService, times(0)).send(any())
+    }
+
     private fun zakenApiClient() = ZakenApiClient(
         restClientBuilder = restClientBuilder,
         outboxService = outboxService,

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientTest.kt
@@ -1850,6 +1850,7 @@ internal class ZakenApiClientTest {
     fun `should return null and not call api when not authorized to get zaakinformatieobject`() {
         val zaakInformatieobjectUrl = zakenApiBaseUri("/zaakinformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f")
         val caseDocumentId = UUID.randomUUID()
+        val requestsBefore = mockApi.requestCount
 
         authorizationService = mock {
             on { this.hasPermission<Any>(any()) } doReturn false
@@ -1864,6 +1865,7 @@ internal class ZakenApiClientTest {
         )
 
         assertThat(result).isNull()
+        assertEquals(requestsBefore, mockApi.requestCount)
         verify(outboxService, times(0)).send(any())
     }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                          
the github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/491

These extensions are necessary for the documenten verzoeken plugin. Can you put this in a branch so I can test my plugin in hte Plugin repo?
                                                                                                                                                                                 
   - Add `InformatieObjectReceivedEvent` audit event to track when an informatie object is received for a case document
   - Register `InformatieObjectReceivedEvent` in `OperatonProcessJsonSchemaDocumentAuditService` so it appears in the document audit trail
   - Add `resource` field to `NotificatiesApiNotificationReceivedEvent` to capture the resource type from notifications
   - Add `extractUuidFromUri` utility to `ExtractUuid` for parsing UUIDs from URI paths
   - Add `getZaakInformatieObjectByUrl` to `ZakenApiPlugin` and corresponding `getZaakInformatieObject` in `ZakenApiClient` with authorization check and outbox event emission
   - Add new `ZaakInformatieObjectListed` outbox event for single zaak informatie object retrieval
   - Add missing license headers to `ZaakInformatieObjectenListed`

   ## Unittests and integration tests for
- [x] com.ritense.zakenapi.client.ZakenApiClient#getZaakInformatieObjecten
- [x]  com.ritense.zakenapi.ZakenApiPlugin#getZaakInformatieObjectByUrl
- [x]  com.ritense.zakenapi.ExtractUuid#extractUuidFromUri

   ## Test plan for the document verzoeken plugin
   - [ ] Verify `InformatieObjectReceivedEvent` appears in case audit trail after an informatie object is received
   - [ ] Verify `ZaakInformatieObjectListed` outbox event is emitted when fetching a zaak informatie object by URL
   - [ ] Verify authorization check in `getZaakInformatieObject` blocks unauthorized access
   - [ ] Verify `resource` field is correctly deserialized from notificaties-api notification payloads
   - [ ] Run unit tests: `./gradlew :backend:case:test :backend:zgw:zaken-api:test :backend:zgw:notificaties-api:test`
