### PR TITLE
Fixed deserialization of beginRegistratie in Documenten API responses

### DIFF
--- a/backend/contract/src/main/kotlin/com/ritense/valtimo/contract/json/Iso8601Deserializer.kt
+++ b/backend/contract/src/main/kotlin/com/ritense/valtimo/contract/json/Iso8601Deserializer.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.contract.json
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import java.io.IOException
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeParseException
+
+class Iso8601Deserializer : StdDeserializer<OffsetDateTime?>(OffsetDateTime::class.java) {
+
+    @Throws(IOException::class)
+    override fun deserialize(p: JsonParser, ctx: DeserializationContext?): OffsetDateTime? {
+        val value = p.text?.trim()
+
+        if (value.isNullOrBlank()) {
+            return null
+        }
+
+        try {
+            // "2026-03-23T14:37:41+01:00" or "2026-03-23T14:37:41Z"
+            return OffsetDateTime.parse(value)
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        try {
+            // "2026-03-23T14:37:41+01:00[Europe/Amsterdam]"
+            return ZonedDateTime.parse(value).toOffsetDateTime()
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        try {
+            // "2026-03-23T14:37:41Z"
+            return Instant.parse(value).atOffset(ZoneOffset.UTC)
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        try {
+            // "2026-03-23T14:37:41"
+            return LocalDateTime.parse(value).atOffset(ZoneOffset.UTC)
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        error("Failed to parse ISO 8601 datetime: '$value'")
+    }
+}

--- a/backend/contract/src/test/kotlin/com/ritense/valtimo/contract/json/Iso8601DeserializerTest.kt
+++ b/backend/contract/src/test/kotlin/com/ritense/valtimo/contract/json/Iso8601DeserializerTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.contract.json
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class Iso8601DeserializerTest {
+
+    private val objectMapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+
+    @Test
+    fun `should deserialize offset datetime`() {
+        val json = """{"value": "2026-03-23T14:37:41+01:00"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.value)
+    }
+
+    @Test
+    fun `should deserialize UTC datetime with Z suffix`() {
+        val json = """{"value": "2026-03-23T14:37:41Z"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.UTC), result.value)
+    }
+
+    @Test
+    fun `should deserialize zoned datetime`() {
+        val json = """{"value": "2026-03-23T14:37:41+01:00[Europe/Amsterdam]"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.value)
+    }
+
+    @Test
+    fun `should deserialize local datetime as UTC`() {
+        val json = """{"value": "2026-03-23T14:37:41"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.UTC), result.value)
+    }
+
+    @Test
+    fun `should return null for null value`() {
+        val json = """{"value": null}"""
+
+        val result = objectMapper.readValue<NullableTestDto>(json)
+
+        assertEquals(null, result.value)
+    }
+
+    @Test
+    fun `should return null for blank value`() {
+        val json = """{"value": "  "}"""
+
+        val result = objectMapper.readValue<NullableTestDto>(json)
+
+        assertEquals(null, result.value)
+    }
+
+    @Test
+    fun `should throw error for invalid datetime`() {
+        val json = """{"value": "not-a-date"}"""
+
+        assertThrows<Exception> {
+            objectMapper.readValue<TestDto>(json)
+        }
+    }
+
+    private data class TestDto(
+        @JsonDeserialize(using = Iso8601Deserializer::class)
+        val value: OffsetDateTime
+    )
+
+    private data class NullableTestDto(
+        @JsonDeserialize(using = Iso8601Deserializer::class)
+        val value: OffsetDateTime?
+    )
+}

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -416,7 +416,7 @@ class DocumentenApiPlugin(
             documentCreateResult.auteur,
             documentCreateResult.bestandsnaam,
             documentCreateResult.bestandsomvang,
-            documentCreateResult.beginRegistratie
+            documentCreateResult.beginRegistratie.toLocalDateTime()
         )
         applicationEventPublisher.publishEvent(event)
         execution.setVariable(storedDocumentKey, documentCreateResult.url)

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentResult.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentResult.kt
@@ -16,14 +16,17 @@
 
 package com.ritense.documentenapi.client
 
-import java.time.LocalDateTime
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.ritense.valtimo.contract.json.Iso8601Deserializer
+import java.time.OffsetDateTime
 
 class CreateDocumentResult(
     val url: String,
     val auteur: String,
     val bestandsnaam: String,
     val bestandsomvang: Long,
-    val beginRegistratie: LocalDateTime,
+    @JsonDeserialize(using = Iso8601Deserializer::class)
+    val beginRegistratie: OffsetDateTime,
     val bestandsdelen: List<Bestandsdeel>,
     val lock: String?
 ) {

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/DocumentInformatieObject.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/DocumentInformatieObject.kt
@@ -17,13 +17,15 @@
 package com.ritense.documentenapi.client
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.ritense.valtimo.contract.json.Iso8601Deserializer
 import com.ritense.zgw.Rsin
 import com.ritense.zgw.domain.Vertrouwelijkheid
 import java.net.URI
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
-class DocumentInformatieObject (
+class DocumentInformatieObject(
     val url: URI,
     val identificatie: String? = null,
     val bronorganisatie: Rsin,
@@ -36,8 +38,8 @@ class DocumentInformatieObject (
     val formaat: String? = null,
     val taal: String,
     val versie: Int? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
-    val beginRegistratie: LocalDateTime,
+    @JsonDeserialize(using = Iso8601Deserializer::class)
+    val beginRegistratie: OffsetDateTime,
     val bestandsnaam: String? = null,
     val bestandsomvang: Long? = null,
     val link: URI? = null,

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -159,7 +159,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.of(2020, 1, 1, 1, 1, 1),
+            OffsetDateTime.parse("2020-01-01T01:01:01Z"),
             listOf(),
             null
         )
@@ -257,7 +257,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.of(2020, 1, 1, 1, 1, 1),
+            OffsetDateTime.parse("2020-01-01T01:01:01Z"),
             listOf(),
             null
         )
@@ -338,7 +338,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.of(2020, 1, 1, 1, 1, 1),
+            OffsetDateTime.parse("2020-01-01T01:01:01Z"),
             listOf(),
             null
         )
@@ -417,7 +417,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )
@@ -513,7 +513,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -60,6 +60,7 @@ import java.io.ByteArrayInputStream
 import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -661,7 +662,7 @@ internal class DocumentenApiPluginTest {
                 titel = "titel",
                 auteur = "auteur",
                 taal = "taal",
-                beginRegistratie = LocalDateTime.now(),
+                beginRegistratie = OffsetDateTime.now(),
                 status = DEFINITIEF
             )
         )

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,77 @@
 
 package com.ritense.documentenapi.client
 
-import java.time.OffsetDateTime
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 internal class CreateDocumentResultTest {
+
+    private val objectMapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+        .registerModule(JavaTimeModule())
+
+    @Test
+    fun `should deserialize beginRegistratie with offset`() {
+        val json = """
+            {
+                "url": "https://www.example.com/847789d3-a8b3-469a-ae01-a49a6bd21783",
+                "auteur": "test",
+                "bestandsnaam": "test.txt",
+                "bestandsomvang": 123,
+                "beginRegistratie": "2026-03-23T14:37:41+01:00",
+                "bestandsdelen": [],
+                "lock": null
+            }
+        """.trimIndent()
+
+        val result = objectMapper.readValue<CreateDocumentResult>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.beginRegistratie)
+    }
+
+    @Test
+    fun `should deserialize beginRegistratie without offset`() {
+        val json = """
+            {
+                "url": "https://www.example.com/847789d3-a8b3-469a-ae01-a49a6bd21783",
+                "auteur": "test",
+                "bestandsnaam": "test.txt",
+                "bestandsomvang": 123,
+                "beginRegistratie": "2026-03-23T14:37:41",
+                "bestandsdelen": [],
+                "lock": null
+            }
+        """.trimIndent()
+
+        val result = objectMapper.readValue<CreateDocumentResult>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.UTC), result.beginRegistratie)
+    }
+
+    @Test
+    fun `should deserialize beginRegistratie with zoned datetime`() {
+        val json = """
+            {
+                "url": "https://www.example.com/847789d3-a8b3-469a-ae01-a49a6bd21783",
+                "auteur": "test",
+                "bestandsnaam": "test.txt",
+                "bestandsomvang": 123,
+                "beginRegistratie": "2026-03-23T14:37:41+01:00[Europe/Amsterdam]",
+                "bestandsdelen": [],
+                "lock": null
+            }
+        """.trimIndent()
+
+        val result = objectMapper.readValue<CreateDocumentResult>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.beginRegistratie)
+    }
 
     @Test
     fun `should get uuid from url`() {

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
@@ -16,9 +16,9 @@
 
 package com.ritense.documentenapi.client
 
+import java.time.OffsetDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import java.time.LocalDateTime
 
 internal class CreateDocumentResultTest {
 
@@ -29,7 +29,7 @@ internal class CreateDocumentResultTest {
             "",
             "",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )
@@ -51,7 +51,7 @@ internal class CreateDocumentResultTest {
             "",
             "",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(bestandsdeel),
             "847789d3-a8b3-469a-ae01-a49a6bd21783"
         )
@@ -66,7 +66,7 @@ internal class CreateDocumentResultTest {
             "",
             "",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
@@ -66,7 +66,6 @@ import reactor.core.publisher.Mono
 import java.io.InputStream
 import java.net.URI
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.function.Supplier
@@ -210,7 +209,7 @@ DocumentenApiClientTest {
             "auteur",
             "bestandsnaam.jpg",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             bestandsdelen,
             "de9c883a-cdfc-493b-9c38-5824e334a1b1"
         )

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
@@ -67,6 +67,7 @@ import java.io.InputStream
 import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.function.Supplier
 import kotlin.test.assertEquals
@@ -405,7 +406,7 @@ DocumentenApiClientTest {
         assertEquals("formaat", result.formaat)
         assertEquals("nl", result.taal)
         assertEquals(4, result.versie)
-        assertEquals(LocalDateTime.of(2019, 8, 24, 14, 15, 22), result.beginRegistratie)
+        assertEquals(OffsetDateTime.parse("2019-08-24T14:15:22Z"), result.beginRegistratie)
         assertEquals("bestandsnaam", result.bestandsnaam)
         assertEquals(123, result.bestandsomvang)
         assertEquals(URI("http://example.com/link"), result.link)
@@ -767,7 +768,7 @@ DocumentenApiClientTest {
         assertEquals("formaat", result.formaat)
         assertEquals("nl", result.taal)
         assertEquals(4, result.versie)
-        assertEquals(LocalDateTime.of(2019, 8, 24, 14, 15, 22), result.beginRegistratie)
+        assertEquals(OffsetDateTime.parse("2019-08-24T14:15:22Z"), result.beginRegistratie)
         assertEquals("bestandsnaam", result.bestandsnaam)
         assertEquals(123, result.bestandsomvang)
         assertEquals(URI("http://example.com/link"), result.link)

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/service/DocumentenApiServiceTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/service/DocumentenApiServiceTest.kt
@@ -48,7 +48,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import java.net.URI
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class DocumentenApiServiceTest {
@@ -156,7 +156,7 @@ class DocumentenApiServiceTest {
         url = URI("http://localhost/informatieobjecttype/0e757153-fce3-44bc-a47f-494840784a16"),
         bronorganisatie = Rsin("404797441"),
         auteur = "y",
-        beginRegistratie = LocalDateTime.now(),
+        beginRegistratie = OffsetDateTime.now(),
         creatiedatum = LocalDate.now(),
         taal = "nl",
         titel = "titel",

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
@@ -54,6 +54,7 @@ import org.springframework.data.domain.Pageable
 import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ZaakDocumentServiceTest {
@@ -313,7 +314,7 @@ class ZaakDocumentServiceTest {
         url = uri,
         bronorganisatie = Rsin("404797441"),
         auteur = "y",
-        beginRegistratie = LocalDateTime.now(),
+        beginRegistratie = OffsetDateTime.now(),
         creatiedatum = LocalDate.now(),
         taal = "nl",
         titel = "titel",

--- a/documentation/release-notes/13.x.x/13.21.0/README.md
+++ b/documentation/release-notes/13.x.x/13.21.0/README.md
@@ -21,6 +21,8 @@
 * Fixed a bug where building blocks could not update the internal case status, case tags, or assignee of the calling
   case. The building block now correctly references the case definition of the parent case.
 
+* **Fixed deserialization of `beginRegistratie` in Documenten API responses**
+
 * **Fixed auto-deployment of global forms and object management configurations**
 
   Forms used by object management (edit/view forms) could not be auto-deployed in Valtimo 13 because the form importer


### PR DESCRIPTION
 https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/591
 
Some ZGW providers return the `beginRegistratie` timestamp in non-standard ISO 8601 variants (e.g. without timezone  offset, or with a zoned datetime format). A custom `Iso8601Deserializer` is now applied to the `beginRegistratie` field of `DocumentInformatieObject`, allowing it to parse these variants correctly.

```
Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `java.time.LocalDateTime` from String "2026-03-23T14:37:41+00:00": Failed to deserialize java.time.LocalDateTime: (java.time.format.DateTimeParseException) Text '2026-03-23T14:37:41+00:00' could not be parsed, unparsed text found at index 19
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 16246] (through reference chain: com.ritense.documentenapi.client.DocumentInformatieObject["beginRegistratie"])
	at com.fasterxml.jackson.databind.exc.InvalidFormatException.from(InvalidFormatException.java:67)
	at com.fasterxml.jackson.databind.DeserializationContext.weirdStringException(DeserializationContext.java:1986)
	at com.fasterxml.jackson.databind.DeserializationContext.handleWeirdStringValue(DeserializationContext.java:1272)
	at com.fasterxml.jackson.datatype.jsr310.deser.JSR310DeserializerBase._handleDateTimeException(JSR310DeserializerBase.java:176)
	at com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer._fromString(LocalDateTimeDeserializer.java:257)
	at com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer.deserialize(LocalDateTimeDeserializer.java:154)
	at com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer.deserialize(LocalDateTimeDeserializer.java:44)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:543)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:587)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:440)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1499)
	at com.fasterxml.jackson.module.blackbird.deser.SuperSonicBeanDeserializer.deserializeFromObject(SuperSonicBeanDeserializer.java:247)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.module.blackbird.deser.SuperSonicBeanDeserializer.deserialize(SuperSonicBeanDeserializer.java:116)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:2130)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1500)
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:397)
	... 213 common frames omitted
Caused by: java.time.format.DateTimeParseException: Text '2026-03-23T14:37:41+00:00' could not be parsed, unparsed text found at index 19
	at java.base/java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:2111)
	at java.base/java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:2010)
	at java.base/java.time.LocalDateTime.parse(LocalDateTime.java:494)
	at com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer._fromString(LocalDateTimeDeserializer.java:255)
	... 226 common frames omitted
```
