### PR TITLE
GH-653: Fix sensitive data logging, etc

### DIFF
--- a/backend/case/src/main/kotlin/com/ritense/case/mapper/ConfigurationIssueSseEventMapper.kt
+++ b/backend/case/src/main/kotlin/com/ritense/case/mapper/ConfigurationIssueSseEventMapper.kt
@@ -31,9 +31,11 @@ class ConfigurationIssueSseEventMapper : SseEventMapper {
                 val caseDefinitionKey = result?.get("caseDefinitionKey")?.asText()
                     ?: event.resultId
                     ?: return null
+                val caseDefinitionVersionTag = result?.get("caseDefinitionVersionTag")?.asText()
+                    ?: return null
                 ConfigurationIssueUpdatedSseEvent(
                     caseDefinitionKey = caseDefinitionKey,
-                    caseDefinitionVersionTag = result?.get("caseDefinitionVersionTag")?.asText() ?: ""
+                    caseDefinitionVersionTag = caseDefinitionVersionTag
                 )
             }
             else -> null

--- a/backend/case/src/main/kotlin/com/ritense/document/mapper/DocumentSseEventMapper.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/mapper/DocumentSseEventMapper.kt
@@ -27,6 +27,7 @@ import com.ritense.document.event.DocumentUpdatedSseEvent
 import com.ritense.inbox.ValtimoEvent
 import com.ritense.valtimo.web.sse.domain.SseEventMapper
 import com.ritense.valtimo.web.sse.event.BaseSseEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 class DocumentSseEventMapper : SseEventMapper {
 
@@ -35,13 +36,20 @@ class DocumentSseEventMapper : SseEventMapper {
             DocumentCreated.TYPE -> CaseCreatedEvent()
             DocumentAssigned.TYPE -> CaseAssignedEvent()
             DocumentUnassigned.TYPE -> CaseUnassignedEvent()
-            DocumentUpdated.TYPE -> event.let {
-                DocumentUpdatedSseEvent(
-                    it.resultId!!
-                )
+            DocumentUpdated.TYPE -> {
+                val resultId = event.resultId
+                if (resultId == null) {
+                    logger.warn { "Received DocumentUpdated event without resultId, skipping" }
+                    return null
+                }
+                DocumentUpdatedSseEvent(resultId)
             }
 
             else -> null
         }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
     }
 }

--- a/backend/case/src/test/kotlin/com/ritense/case/mapper/ConfigurationIssueSseEventMapperTest.kt
+++ b/backend/case/src/test/kotlin/com/ritense/case/mapper/ConfigurationIssueSseEventMapperTest.kt
@@ -54,7 +54,7 @@ class ConfigurationIssueSseEventMapperTest {
     }
 
     @Test
-    fun `map should fallback to resultId when result is not ObjectNode`() {
+    fun `map should return null when result is not ObjectNode and caseDefinitionVersionTag is missing`() {
         val event = ValtimoEvent(
             id = "test-id",
             type = ConfigurationIssueUpdated.TYPE,
@@ -68,10 +68,7 @@ class ConfigurationIssueSseEventMapperTest {
 
         val result = mapper.map(event)
 
-        assertThat(result).isInstanceOf(ConfigurationIssueUpdatedSseEvent::class.java)
-        val sseEvent = result as ConfigurationIssueUpdatedSseEvent
-        assertThat(sseEvent.caseDefinitionKey).isEqualTo("fallback-key")
-        assertThat(sseEvent.caseDefinitionVersionTag).isEqualTo("")
+        assertThat(result).isNull()
     }
 
     @Test

--- a/backend/case/src/test/kotlin/com/ritense/document/mapper/DocumentSseEventMapperTest.kt
+++ b/backend/case/src/test/kotlin/com/ritense/document/mapper/DocumentSseEventMapperTest.kt
@@ -83,6 +83,16 @@ class DocumentSseEventMapperTest {
     }
 
     @Test
+    fun `should return null when document updated event has no resultId`() {
+        val valtimoEvent = mock<ValtimoEvent>()
+        whenever(valtimoEvent.type).thenReturn(DocumentUpdated.TYPE)
+        whenever(valtimoEvent.resultId).thenReturn(null)
+
+        val sseEvent = documentSseEventMapper.map(valtimoEvent)
+        assertNull(sseEvent)
+    }
+
+    @Test
     fun `should map to null with unknown type event`() {
         val valtimoEvent = mock<ValtimoEvent>()
         whenever(valtimoEvent.type).thenReturn("unknown")

--- a/backend/inbox/src/main/kotlin/com/ritense/inbox/InboxHandlingService.kt
+++ b/backend/inbox/src/main/kotlin/com/ritense/inbox/InboxHandlingService.kt
@@ -22,7 +22,7 @@ class InboxHandlingService(
     private val eventHandlers: List<InboxEventHandler>,
 ) {
     fun handle(message: String) {
-        logger.info("Received message: {}", message)
+        logger.debug { "Received inbox message" }
         eventHandlers.forEach { it.handle(message) }
     }
 

--- a/backend/inbox/src/main/kotlin/com/ritense/inbox/ValtimoCloudEventMapper.kt
+++ b/backend/inbox/src/main/kotlin/com/ritense/inbox/ValtimoCloudEventMapper.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.cloudevents.CloudEvent
 import io.cloudevents.core.provider.EventFormatProvider
 import io.cloudevents.jackson.JsonFormat
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 class ValtimoCloudEventMapper(
     private val objectMapper: ObjectMapper
@@ -34,6 +35,7 @@ class ValtimoCloudEventMapper(
         return try {
             cloudEventFormat.deserialize(payload.encodeToByteArray())
         } catch (ex: Exception) {
+            logger.warn(ex) { "Failed to deserialize CloudEvent from payload" }
             null
         }
     }
@@ -52,7 +54,12 @@ class ValtimoCloudEventMapper(
                 result = cloudEventData?.result
             )
         } catch (ex: Exception) {
+            logger.warn(ex) { "Failed to map CloudEvent to ValtimoEvent" }
             null
         }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
     }
 }

--- a/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
+++ b/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
@@ -40,7 +40,7 @@ class RabbitMessagePublisher(
         rabbitTemplate.exchange ?: ""
     }
     private val routingKey: String = routingKey ?: run {
-        logger.debug { "Using Rabbit template default routingKey: ${rabbitTemplate.exchange}" }
+        logger.debug { "Using Rabbit template default routingKey: ${rabbitTemplate.routingKey}" }
         rabbitTemplate.routingKey ?: ""
     }
 
@@ -58,14 +58,15 @@ class RabbitMessagePublisher(
 
         try {
             val result = correlationData.future[deliveryTimeout.toMillis(), TimeUnit.MILLISECONDS]
-            if (!result!!.isAck) {
-                throw MessagePublishingFailed("Outbox message was not acknowledged: reason=${result.reason}, routingKey=${routingKey}, msgId=${message.id}, correlationId= ${correlationData.id}\"")
-            } else if (correlationData.returned != null) {
-                val returned = correlationData.returned!!
-                throw MessagePublishingFailed("Could not deliver outbox message: routingKey=${returned.routingKey}, code=${returned.replyCode}, msg=${returned.replyText}, routingKey=${routingKey}, msgId=${message.id}, correlationId= ${correlationData.id}\"")
+                ?: throw MessagePublishingFailed("Outbox message confirmation result was null: routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
+            if (!result.isAck) {
+                throw MessagePublishingFailed("Outbox message was not acknowledged: reason=${result.reason}, routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
+            }
+            correlationData.returned?.let { returned ->
+                throw MessagePublishingFailed("Could not deliver outbox message: routingKey=${returned.routingKey}, code=${returned.replyCode}, msg=${returned.replyText}, routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
             }
         } catch (timeoutException: TimeoutException) {
-            throw MessagePublishingFailed("Outbox message delivery was not confirmed in time: routingKey=${routingKey}, msgId=${message.id}, correlationId= ${correlationData.id}")
+            throw MessagePublishingFailed("Outbox message delivery was not confirmed in time: routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
         }
     }
 

--- a/documentation/release-notes/13.x.x/13.22.0/README.md
+++ b/documentation/release-notes/13.x.x/13.22.0/README.md
@@ -18,4 +18,4 @@
 
 ## Bugfixes
 
-* New bugfix.
+* Fixed sensitive data logging in inbox messages, silent exception swallowing in cloud event mapping, and null safety issues in SSE event mappers.


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/653 
 - Downgrade inbox message logging from INFO to DEBUG and remove payload from log output
  - Add WARN-level error logging to `ValtimoCloudEventMapper` catch blocks (without sensitive data)                                                                                                                                  
  - Replace `resultId!!` with null-safe check in `DocumentSseEventMapper` to prevent NPE                                                                                                                                             
  - Return null instead of empty string for missing `caseDefinitionVersionTag` in `ConfigurationIssueSseEventMapper`         