### PR TITLE
Improve outbox publishing performance with batched message delivery and circuit breaker resilience

### DIFF
--- a/backend/core/src/test/kotlin/com/ritense/valtimo/jackson/ZonedLocalDateTimeDeserializerTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/jackson/ZonedLocalDateTimeDeserializerTest.kt
@@ -55,7 +55,7 @@ class ZonedLocalDateTimeDeserializerTest {
     @Test
     fun `should deserialize to null`() {
         val dateTimeString = """"""""
-        val result: LocalDateTime = mapper.readValue(dateTimeString)
+        val result: LocalDateTime? = mapper.readValue(dateTimeString)
         assertThat(result).isNull()
     }
 

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -94,6 +94,7 @@ kotestVersion=5.9.1
 shedlockVersion=5.14.0
 jsonassertVersion=1.5.3
 cloudEventsCoreVersion=3.0.0
+resilience4jVersion=2.4.0
 slf4jVersion=2.0.13
 
 # version overrides

--- a/backend/gradle/test.gradle
+++ b/backend/gradle/test.gradle
@@ -49,7 +49,7 @@ tasks.register("integrationTestingPostgresql", Test) {
 tasks.register("integrationTestingMysql", Test) {
     group = 'verification'
     description = 'Runs MySQL-based integration tests.'
-    systemProperty("spring.profiles.include", "inttest,mysql")
+    systemProperty("spring.profiles.include", "mysql")
     testLogging {
         events("passed", "skipped", "failed", "standardError")
     }
@@ -66,7 +66,7 @@ tasks.register("integrationTestingMysql", Test) {
 
 tasks.register("securityTesting", Test) {
     group = 'verification'
-    systemProperty("spring.profiles.include", "inttest,postgresql")
+    systemProperty("spring.profiles.include", "postgresql")
     testLogging {
         events("passed", "skipped", "failed", "standardError")
     }

--- a/backend/gradle/test.gradle
+++ b/backend/gradle/test.gradle
@@ -32,6 +32,9 @@ tasks.register("integrationTesting") {
 tasks.register("integrationTestingPostgresql", Test) {
     group = 'verification'
     systemProperty("spring.profiles.include", "postgresql")
+    testLogging {
+        events("passed", "skipped", "failed", "standardError")
+    }
     useJUnitPlatform {
         includeTags "integration"
         excludeTags "security"
@@ -45,7 +48,11 @@ tasks.register("integrationTestingPostgresql", Test) {
 
 tasks.register("integrationTestingMysql", Test) {
     group = 'verification'
-    systemProperty("spring.profiles.include", "mysql")
+    description = 'Runs MySQL-based integration tests.'
+    systemProperty("spring.profiles.include", "inttest,mysql")
+    testLogging {
+        events("passed", "skipped", "failed", "standardError")
+    }
     useJUnitPlatform {
         includeTags "integration"
         excludeTags "security"
@@ -59,7 +66,10 @@ tasks.register("integrationTestingMysql", Test) {
 
 tasks.register("securityTesting", Test) {
     group = 'verification'
-    systemProperty("spring.profiles.include", "postgresql")
+    systemProperty("spring.profiles.include", "inttest,postgresql")
+    testLogging {
+        events("passed", "skipped", "failed", "standardError")
+    }
     useJUnitPlatform {
         includeTags "security"
         excludeTags "integration"

--- a/backend/openzaak/src/main/kotlin/com/ritense/openzaak/domain/configuration/Rsin.kt
+++ b/backend/openzaak/src/main/kotlin/com/ritense/openzaak/domain/configuration/Rsin.kt
@@ -9,7 +9,7 @@ data class Rsin(private val value: String) : Validatable {
     companion object {
         @JvmStatic
         @JsonCreator
-        fun create(value: String) = value
+        fun create(value: String) = Rsin(value)
     }
 
     @JsonValue

--- a/backend/outbox/build.gradle
+++ b/backend/outbox/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation "io.cloudevents:cloudevents-core:$cloudEventsCoreVersion"
     implementation "io.cloudevents:cloudevents-json-jackson:$cloudEventsCoreVersion"
 
-    implementation "io.github.resilience4j:resilience4j-circuitbreaker:${resilience4jVersion}"
+    implementation "io.github.resilience4j:resilience4j-circuitbreaker:$resilience4jVersion"
 
     compileOnly "org.springframework.boot:spring-boot-starter-actuator"
 

--- a/backend/outbox/build.gradle
+++ b/backend/outbox/build.gradle
@@ -49,6 +49,11 @@ dependencies {
     implementation "io.cloudevents:cloudevents-core:$cloudEventsCoreVersion"
     implementation "io.cloudevents:cloudevents-json-jackson:$cloudEventsCoreVersion"
 
+    implementation "io.github.resilience4j:resilience4j-circuitbreaker:${resilience4jVersion}"
+
+    compileOnly "org.springframework.boot:spring-boot-starter-actuator"
+
+    testImplementation "org.springframework.boot:spring-boot-starter-actuator"
     testImplementation project(':test-utils-common')
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
+++ b/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
@@ -29,6 +29,7 @@ import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
 
 class RabbitMessagePublisher(
@@ -87,6 +88,11 @@ class RabbitMessagePublisher(
             CompletableFuture.allOf(*allFutures.toTypedArray())[deliveryTimeout.toMillis(), TimeUnit.MILLISECONDS]
         } catch (_: TimeoutException) {
             // Some futures may not have completed — handled per-message below
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            // Proceed to collect partial results — incomplete futures handled per-message below
+        } catch (_: ExecutionException) {
+            // Individual future failures handled per-message below
         }
 
         // Phase 3: collect results per message

--- a/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
+++ b/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
@@ -17,6 +17,7 @@
 package com.ritense.outbox.rabbitmq
 
 import com.ritense.outbox.OutboxMessage
+import com.ritense.outbox.publisher.MessagePublishResult
 import com.ritense.outbox.publisher.MessagePublisher
 import com.ritense.outbox.publisher.MessagePublishingFailed
 import mu.KLogger
@@ -26,6 +27,7 @@ import org.springframework.amqp.rabbit.connection.CorrelationData
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -52,21 +54,73 @@ class RabbitMessagePublisher(
     }
 
     override fun publish(message: OutboxMessage) {
-        val correlationData = CorrelationData(UUID.randomUUID().toString())
-        logger.trace { "Sending message to RabbitMQ: routingKey=${routingKey}, msgId=${message.id}, correlationId= ${correlationData.id}" }
+        val result = publishBatch(listOf(message)).first()
+        if (!result.success) {
+            throw result.error ?: MessagePublishingFailed("Failed to publish outbox message ${message.id}")
+        }
+    }
 
-        rabbitTemplate.convertAndSend(exchange, routingKey, message.message, correlationData)
+    /**
+     * Pipelines message sends to RabbitMQ for improved throughput.
+     *
+     * Instead of send-wait-send-wait per message, this sends all messages first,
+     * then waits for all publisher confirms in parallel. The deliveryTimeout applies
+     * to the entire batch, not per message.
+     *
+     * Each message still gets its own CorrelationData and is individually verified,
+     * so delivery guarantees are identical to calling [publish] per message.
+     */
+    override fun publishBatch(messages: List<OutboxMessage>): List<MessagePublishResult> {
+        if (messages.isEmpty()) return emptyList()
 
+        // Phase 1: send all messages without waiting for confirms
+        val pending = messages.map { message ->
+            val correlationData = CorrelationData(UUID.randomUUID().toString())
+            logger.trace { "Sending message to RabbitMQ: routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}" }
+            rabbitTemplate.convertAndSend(exchange, routingKey, message.message, correlationData)
+            message to correlationData
+        }
+
+        // Phase 2: wait for all confirms in parallel with a single timeout for the entire batch
+        val allFutures = pending.map { (_, correlationData) -> correlationData.future.toCompletableFuture() }
         try {
-            val result = correlationData.future.get(deliveryTimeout.toMillis(), TimeUnit.MILLISECONDS)
-            if (!result!!.isAck) {
-                throw MessagePublishingFailed("Outbox message was not acknowledged: reason=${result.reason}, routingKey=${routingKey}, msgId=${message.id}, correlationId= ${correlationData.id}\"")
-            } else if (correlationData.returned != null) {
-                val returned = correlationData.returned!!
-                throw MessagePublishingFailed("Could not deliver outbox message: routingKey=${returned.routingKey}, code=${returned.replyCode}, msg=${returned.replyText}, routingKey=${routingKey}, msgId=${message.id}, correlationId= ${correlationData.id}\"")
+            CompletableFuture.allOf(*allFutures.toTypedArray())[deliveryTimeout.toMillis(), TimeUnit.MILLISECONDS]
+        } catch (_: TimeoutException) {
+            // Some futures may not have completed — handled per-message below
+        }
+
+        // Phase 3: collect results per message
+        return pending.map { (message, correlationData) ->
+            val future = correlationData.future.toCompletableFuture()
+            if (!future.isDone) {
+                return@map MessagePublishResult(
+                    messageId = message.id,
+                    success = false,
+                    error = MessagePublishingFailed("Outbox message delivery was not confirmed in time: routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
+                )
             }
-        } catch (timeoutException: TimeoutException) {
-            throw MessagePublishingFailed("Outbox message delivery was not confirmed in time: routingKey=${routingKey}, msgId=${message.id}, correlationId= ${correlationData.id}")
+            val result = future.get()
+                ?: return@map MessagePublishResult(
+                    messageId = message.id,
+                    success = false,
+                    error = MessagePublishingFailed("Outbox message confirmation result was null: routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
+                )
+            if (!result.isAck) {
+                return@map MessagePublishResult(
+                    messageId = message.id,
+                    success = false,
+                    error = MessagePublishingFailed("Outbox message was not acknowledged: reason=${result.reason}, routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
+                )
+            }
+            val returned = correlationData.returned
+            if (returned != null) {
+                return@map MessagePublishResult(
+                    messageId = message.id,
+                    success = false,
+                    error = MessagePublishingFailed("Could not deliver outbox message: returnedRoutingKey=${returned.routingKey}, code=${returned.replyCode}, msg=${returned.replyText}, configuredRoutingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
+                )
+            }
+            MessagePublishResult(messageId = message.id, success = true)
         }
     }
 

--- a/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/config/RabbitOutboxAutoconfiguration.kt
+++ b/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/config/RabbitOutboxAutoconfiguration.kt
@@ -33,7 +33,7 @@ class RabbitOutboxAutoconfiguration {
 
     @Bean
     @ConditionalOnMissingBean(MessagePublisher::class)
-    fun outboxPublisher(rabbitTemplate: RabbitTemplate, configurationProperties: RabbitOutboxConfigurationProperties): MessagePublisher {
+    fun rabbitMessagePublisher(rabbitTemplate: RabbitTemplate, configurationProperties: RabbitOutboxConfigurationProperties): MessagePublisher {
         return RabbitMessagePublisher(
             rabbitTemplate,
             configurationProperties.routingKey,

--- a/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherIntTest.kt
+++ b/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherIntTest.kt
@@ -49,6 +49,31 @@ class RabbitMessagePublisherIntTest : BaseIntegrationTest() {
             val msg = rabbitTemplate.receive(configurationProperties.routingKey!!)
             assertThat(msg!!.body.toString(Charsets.UTF_8)).isEqualTo(uuid)
         }
+
+        @Test
+        fun `should send batch of messages to rabbitmq queue`() {
+            rabbitAdmin.purgeQueue(configurationProperties.routingKey!!)
+
+            val uuid1 = UUID.randomUUID().toString()
+            val uuid2 = UUID.randomUUID().toString()
+            val results = springCloudMessagePublisher.publishBatch(
+                listOf(
+                    OutboxMessage(message = uuid1),
+                    OutboxMessage(message = uuid2)
+                )
+            )
+
+            assertThat(results).hasSize(2)
+            assertThat(results).allMatch { it.success }
+
+            val msg1 = rabbitTemplate.receive(configurationProperties.routingKey!!)
+            val msg2 = rabbitTemplate.receive(configurationProperties.routingKey!!)
+            val receivedMessages = setOf(
+                msg1!!.body.toString(Charsets.UTF_8),
+                msg2!!.body.toString(Charsets.UTF_8)
+            )
+            assertThat(receivedMessages).containsExactlyInAnyOrder(uuid1, uuid2)
+        }
     }
 
     @Nested
@@ -91,6 +116,20 @@ class RabbitMessagePublisherIntTest : BaseIntegrationTest() {
             }
 
             assertThat(ex.message).contains("NO_ROUTE")
+        }
+
+        @Test
+        fun `publishBatch should return failure for unroutable messages`() {
+            val results = messagePublisher.publishBatch(
+                listOf(
+                    OutboxMessage(message = UUID.randomUUID().toString()),
+                    OutboxMessage(message = UUID.randomUUID().toString())
+                )
+            )
+
+            assertThat(results).hasSize(2)
+            assertThat(results).allMatch { !it.success }
+            assertThat(results).allMatch { it.error!!.message!!.contains("NO_ROUTE") }
         }
     }
 }

--- a/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherIntTest.kt
+++ b/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherIntTest.kt
@@ -120,7 +120,7 @@ class RabbitMessagePublisherIntTest : BaseIntegrationTest() {
 
         @Test
         fun `publishBatch should return failure for unroutable messages`() {
-            val results = messagePublisher.publishBatch(
+            val results = springCloudMessagePublisher.publishBatch(
                 listOf(
                     OutboxMessage(message = UUID.randomUUID().toString()),
                     OutboxMessage(message = UUID.randomUUID().toString())

--- a/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherTest.kt
+++ b/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherTest.kt
@@ -101,6 +101,126 @@ class RabbitMessagePublisherTest {
         Assertions.assertThat(ex.message).contains("not confirmed in time")
     }
 
+    @Test
+    fun `publishBatch should send all messages before waiting for confirms`() {
+        val rabbitTemplate = getMockedRabbitTemplate()
+        val sendOrder = mutableListOf<String>()
+
+        whenever(rabbitTemplate.convertAndSend(any<String>(), eq("test"), any<String>(), any<CorrelationData>())).thenAnswer { answer ->
+            sendOrder.add("send")
+            val correlationData = answer.getArgument(3, CorrelationData::class.java)
+            correlationData.future.complete(CorrelationData.Confirm(true, null))
+        }
+
+        val publisher = RabbitMessagePublisher(rabbitTemplate, "test")
+        val messages = listOf(
+            OutboxMessage(message = "msg1"),
+            OutboxMessage(message = "msg2"),
+            OutboxMessage(message = "msg3")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        Assertions.assertThat(results).hasSize(3)
+        Assertions.assertThat(results).allMatch { it.success }
+        Assertions.assertThat(sendOrder).hasSize(3)
+    }
+
+    @Test
+    fun `publishBatch should return per-message results on partial failure`() {
+        val rabbitTemplate = getMockedRabbitTemplate()
+        var callCount = 0
+
+        whenever(rabbitTemplate.convertAndSend(any<String>(), eq("test"), any<String>(), any<CorrelationData>())).thenAnswer { answer ->
+            callCount++
+            val correlationData = answer.getArgument(3, CorrelationData::class.java)
+            if (callCount == 2) {
+                correlationData.future.complete(CorrelationData.Confirm(false, "nacked"))
+            } else {
+                correlationData.future.complete(CorrelationData.Confirm(true, null))
+            }
+        }
+
+        val publisher = RabbitMessagePublisher(rabbitTemplate, "test")
+        val messages = listOf(
+            OutboxMessage(message = "ok1"),
+            OutboxMessage(message = "fail"),
+            OutboxMessage(message = "ok2")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        Assertions.assertThat(results[0].success).isTrue()
+        Assertions.assertThat(results[1].success).isFalse()
+        Assertions.assertThat(results[1].error!!.message).contains("not acknowledged")
+        Assertions.assertThat(results[2].success).isTrue()
+    }
+
+    @Test
+    fun `publishBatch should handle returned messages per message`() {
+        val rabbitTemplate = getMockedRabbitTemplate()
+        var callCount = 0
+
+        whenever(rabbitTemplate.convertAndSend(any<String>(), eq("test"), any<String>(), any<CorrelationData>())).thenAnswer { answer ->
+            callCount++
+            val message = MessageBuilder.withBody(answer.getArgument(2, String::class.java).toByteArray()).build()
+            val correlationData = answer.getArgument(3, CorrelationData::class.java)
+            if (callCount == 1) {
+                correlationData.returned = ReturnedMessage(message, 312, "NO_ROUTE", "", "")
+            }
+            correlationData.future.complete(CorrelationData.Confirm(true, null))
+        }
+
+        val publisher = RabbitMessagePublisher(rabbitTemplate, "test")
+        val messages = listOf(
+            OutboxMessage(message = "unroutable"),
+            OutboxMessage(message = "ok")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        Assertions.assertThat(results[0].success).isFalse()
+        Assertions.assertThat(results[0].error!!.message).contains("NO_ROUTE")
+        Assertions.assertThat(results[1].success).isTrue()
+    }
+
+    @Test
+    fun `publishBatch should handle timeout per message`() {
+        val rabbitTemplate = getMockedRabbitTemplate()
+        var callCount = 0
+
+        whenever(rabbitTemplate.convertAndSend(any<String>(), eq("test"), any<String>(), any<CorrelationData>())).thenAnswer { answer ->
+            callCount++
+            val correlationData = answer.getArgument(3, CorrelationData::class.java)
+            // Only complete the second message — first will time out
+            if (callCount == 2) {
+                correlationData.future.complete(CorrelationData.Confirm(true, null))
+            }
+        }
+
+        val publisher = RabbitMessagePublisher(rabbitTemplate, "test")
+        val messages = listOf(
+            OutboxMessage(message = "timeout"),
+            OutboxMessage(message = "ok")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        Assertions.assertThat(results[0].success).isFalse()
+        Assertions.assertThat(results[0].error!!.message).contains("not confirmed in time")
+        Assertions.assertThat(results[1].success).isTrue()
+    }
+
+    @Test
+    fun `publishBatch should return empty list for empty input`() {
+        val rabbitTemplate = getMockedRabbitTemplate()
+        val publisher = RabbitMessagePublisher(rabbitTemplate, "test")
+
+        val results = publisher.publishBatch(emptyList())
+
+        Assertions.assertThat(results).isEmpty()
+    }
+
     private fun getMockedRabbitTemplate(
         publisherConfirms: Boolean = true,
         publisherReturns: Boolean = true,

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxContext.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxContext.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox
+
+import java.util.concurrent.Callable
+
+class OutboxContext {
+
+    companion object {
+        private val suppressOutboxThreadLocal = ThreadLocal.withInitial { false }
+
+        @JvmStatic
+        val outboxSuppressed: Boolean
+            get() = suppressOutboxThreadLocal.get()
+
+        /**
+         * Runs the given [callable] with outbox publishing suppressed.
+         * If the outbox is already suppressed by a parent call, this is a no-op:
+         * the callable runs directly without resetting the suppressed state on completion.
+         */
+        @JvmStatic
+        fun <T> runWithSuppressedOutbox(suppress: Boolean = true, callable: Callable<T>): T {
+            return if (!suppress || outboxSuppressed) {
+                callable.call()
+            } else {
+                try {
+                    suppressOutboxThreadLocal.set(true)
+                    callable.call()
+                } finally {
+                    suppressOutboxThreadLocal.set(false)
+                }
+            }
+        }
+    }
+}

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
@@ -42,7 +42,7 @@ class OutboxLiquibaseRunner(
         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcConnection)
         try {
             val liquibase = Liquibase(LIQUIBASE_CHANGE_LOG_LOCATION, ClassLoaderResourceAccessor(), database)
-            logger.info("Running liquibase master changelog: {}", liquibase.changeLogFile)
+            logger.info { "Running liquibase master changelog: ${liquibase.changeLogFile}" }
             liquibase.update(context)
         } catch (liquibaseException: LiquibaseException) {
             throw DatabaseException(liquibaseException)
@@ -51,7 +51,7 @@ class OutboxLiquibaseRunner(
                 connection.rollback()
                 connection.close()
             } catch (sqlException: SQLException) {
-                logger.error("Error closing connection ", sqlException)
+                logger.error(sqlException) { "Error closing connection" }
             }
         }
     }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/UserProvider.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/UserProvider.kt
@@ -16,31 +16,21 @@
 
 package com.ritense.outbox
 
-import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
-import java.util.stream.Collectors
 
+/**
+ * Provides the current user's identity and roles for enriching outbox CloudEvents.
+ *
+ * This class exists because the outbox module is intentionally isolated from other
+ * Valtimo modules. It can be overridden by providing a custom [UserProvider] bean.
+ */
 open class UserProvider {
-    open fun getCurrentUserLogin(): String? {
-        val securityContext = SecurityContextHolder.getContext()
-        val authentication = securityContext.authentication
-        var userName: String? = null
-        if (authentication != null) {
-            userName = authentication.name
-        }
-        return userName
-    }
+    open fun getCurrentUserLogin(): String? =
+        SecurityContextHolder.getContext().authentication?.name
 
-    open fun getCurrentUserRoles(): List<String> {
-        val roles: List<String> = ArrayList()
-        val securityContext = SecurityContextHolder.getContext()
-        val authentication = securityContext.authentication
-        return if (authentication != null) {
-            authentication
-                .authorities
-                .stream()
-                .map { obj: GrantedAuthority -> obj.authority }
-                .collect(Collectors.toList())
-        } else roles
-    }
+    open fun getCurrentUserRoles(): List<String> =
+        SecurityContextHolder.getContext().authentication
+            ?.authorities
+            ?.map { it.authority }
+            ?: emptyList()
 }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/ValtimoOutboxService.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/ValtimoOutboxService.kt
@@ -51,6 +51,11 @@ open class ValtimoOutboxService(
 
     @Transactional(propagation = Propagation.MANDATORY)
     override fun send(eventSupplier: Supplier<BaseEvent>) {
+        if (OutboxContext.outboxSuppressed) {
+            logger.debug { "Outbox is suppressed, skipping message" }
+            return
+        }
+
         val baseEvent = eventSupplier.get()
 
         val userId = baseEvent.userId ?: userProvider.getCurrentUserLogin() ?: "System"
@@ -96,14 +101,40 @@ open class ValtimoOutboxService(
         persistMessage(message)
     }
 
+    /**
+     * Collects deferred messages for a read-only transaction and persists them all in a single
+     * REQUIRES_NEW transaction during beforeCommit. This avoids opening a separate transaction
+     * per message, which would otherwise cause N transactions for N messages.
+     *
+     * Messages are stored as a transaction-bound resource using [TransactionSynchronizationManager],
+     * and a single [TransactionSynchronization] is registered on the first call. Subsequent calls
+     * within the same transaction simply add to the existing list.
+     */
     private fun deferMessage(message: String) {
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun beforeCommit(readOnly: Boolean) {
-                requiresNewTransactionTemplate.executeWithoutResult {
-                    persistMessage(message)
+        val key = DeferredMessagesKey::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        var deferredMessages = TransactionSynchronizationManager.getResource(key) as MutableList<String>?
+
+        if (deferredMessages == null) {
+            deferredMessages = mutableListOf()
+            TransactionSynchronizationManager.bindResource(key, deferredMessages)
+            TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+                override fun beforeCommit(readOnly: Boolean) {
+                    @Suppress("UNCHECKED_CAST")
+                    val messages = TransactionSynchronizationManager.getResource(key) as List<String>
+                    requiresNewTransactionTemplate.executeWithoutResult {
+                        persistMessages(messages)
+                    }
                 }
-            }
-        })
+
+                override fun afterCompletion(status: Int) {
+                    TransactionSynchronizationManager.unbindResourceIfPossible(key)
+                }
+            })
+        }
+
+        deferredMessages.add(message)
     }
 
     private fun persistMessage(message: String) {
@@ -112,9 +143,35 @@ open class ValtimoOutboxService(
         outboxMessageRepository.save(outboxMessage)
     }
 
+    private fun persistMessages(messages: List<String>) {
+        val outboxMessages = messages.map { OutboxMessage(message = it) }
+        logger.debug { "Saving ${outboxMessages.size} OutboxMessage(s)" }
+        outboxMessageRepository.saveAll(outboxMessages)
+    }
+
+    /** Resource key used to bind the list of deferred messages to the current transaction. */
+    private object DeferredMessagesKey
+
+    @Deprecated(
+        message = "Will be removed in 14.0. Use getOldestMessages(batchSize) instead",
+        replaceWith = ReplaceWith("getOldestMessages(1).firstOrNull()")
+    )
+    @Transactional(propagation = Propagation.MANDATORY)
     open fun getOldestMessage() = outboxMessageRepository.findOutboxMessage()
 
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun getOldestMessages(batchSize: Int): List<OutboxMessage> =
+        outboxMessageRepository.findOutboxMessages(batchSize)
+
+    @Deprecated(
+        message = "Will be removed in 14.0. Use deleteMessages(ids) instead",
+        replaceWith = ReplaceWith("deleteMessages(listOf(id))")
+    )
+    @Transactional(propagation = Propagation.MANDATORY)
     open fun deleteMessage(id: UUID) = outboxMessageRepository.deleteById(id)
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun deleteMessages(ids: List<UUID>) = outboxMessageRepository.deleteAllById(ids)
 
     companion object {
         private val logger = KotlinLogging.logger {}

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,12 @@ import com.ritense.outbox.repository.impl.PostgresOutboxMessageRepository
 import com.ritense.outbox.publisher.MessagePublisher
 import com.ritense.outbox.publisher.PollingPublisherJob
 import com.ritense.outbox.publisher.PollingPublisherService
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.domain.EntityScan
@@ -40,9 +43,11 @@ import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean
 import org.springframework.transaction.PlatformTransactionManager
+import java.time.Duration
 import java.util.UUID
 import javax.sql.DataSource
 
@@ -51,7 +56,7 @@ import javax.sql.DataSource
 @EnableJpaRepositories(basePackages = ["com.ritense.outbox.repository.impl"])
 @EntityScan(basePackages = ["com.ritense.outbox"])
 @AutoConfigureAfter(DataSourceAutoConfiguration::class, HibernateJpaAutoConfiguration::class)
-@EnableConfigurationProperties(LiquibaseProperties::class)
+@EnableConfigurationProperties(LiquibaseProperties::class, OutboxPollingProperties::class)
 class OutboxAutoConfiguration {
 
     @Bean
@@ -63,10 +68,9 @@ class OutboxAutoConfiguration {
         return OutboxLiquibaseRunner(liquibaseProperties, datasource)
     }
 
-    @ConditionalOnMissingBean(UserProvider::class)
     @Bean
-    fun userProvider(
-    ): UserProvider {
+    @ConditionalOnMissingBean(UserProvider::class)
+    fun outboxUserProvider(): UserProvider {
         return UserProvider()
     }
 
@@ -89,17 +93,52 @@ class OutboxAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = ["outboxCircuitBreaker"])
+    fun outboxCircuitBreaker(
+        pollingProperties: OutboxPollingProperties
+    ): CircuitBreaker? {
+        if (!pollingProperties.circuitBreaker.enabled) {
+            return null
+        }
+        val props = pollingProperties.circuitBreaker
+        val config = CircuitBreakerConfig.custom()
+            .failureRateThreshold(props.failureRateThreshold)
+            .minimumNumberOfCalls(props.minimumNumberOfCalls)
+            .slidingWindowSize(props.slidingWindowSize)
+            .waitDurationInOpenState(Duration.ofSeconds(props.waitDurationInOpenStateSeconds))
+            .permittedNumberOfCallsInHalfOpenState(props.permittedNumberOfCallsInHalfOpenState)
+            .build()
+        return CircuitBreaker.of("outboxPollingPublisher", config)
+    }
+
+    @Bean
     @ConditionalOnMissingBean(PollingPublisherService::class)
     fun pollingPublisherService(
         outboxService: ValtimoOutboxService,
         messagePublisher: MessagePublisher,
-        platformTransactionManager: PlatformTransactionManager
+        platformTransactionManager: PlatformTransactionManager,
+        pollingProperties: OutboxPollingProperties,
+        outboxCircuitBreaker: CircuitBreaker?
     ): PollingPublisherService {
         return PollingPublisherService(
             outboxService,
             messagePublisher,
-            platformTransactionManager
+            platformTransactionManager,
+            pollingProperties.batchSize,
+            outboxCircuitBreaker
         )
+    }
+
+    @Configuration
+    @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.AbstractHealthIndicator"])
+    class OutboxHealthIndicatorConfiguration {
+        @Bean
+        @ConditionalOnMissingBean(name = ["outboxPublisherHealthIndicator"])
+        fun outboxPublisherHealthIndicator(
+            outboxCircuitBreaker: CircuitBreaker?
+        ): com.ritense.outbox.health.OutboxPublisherHealthIndicator {
+            return com.ritense.outbox.health.OutboxPublisherHealthIndicator(outboxCircuitBreaker)
+        }
     }
 
     @Bean

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxPollingProperties.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxPollingProperties.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "valtimo.outbox.publisher.polling")
+data class OutboxPollingProperties(
+    /** Number of messages to fetch and publish per poll cycle. */
+    val batchSize: Int = 10,
+    val circuitBreaker: CircuitBreakerProperties = CircuitBreakerProperties()
+) {
+    data class CircuitBreakerProperties(
+        val enabled: Boolean = true,
+        /** Percentage of failures in the sliding window that triggers the circuit to open. */
+        val failureRateThreshold: Float = 50.0f,
+        /** Minimum number of calls before the failure rate is evaluated. */
+        val minimumNumberOfCalls: Int = 5,
+        /** Number of calls tracked in the sliding window for failure rate calculation. */
+        val slidingWindowSize: Int = 10,
+        /** How long the circuit stays open before transitioning to half-open. */
+        val waitDurationInOpenStateSeconds: Long = 60,
+        /** Number of test calls allowed in half-open state before deciding to close or re-open. */
+        val permittedNumberOfCallsInHalfOpenState: Int = 3
+    )
+}

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicator.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicator.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import org.springframework.boot.actuate.health.AbstractHealthIndicator
+import org.springframework.boot.actuate.health.Health
+
+/**
+ * Exposes the outbox publisher circuit breaker state via the /actuator/health endpoint.
+ *
+ * Reports DOWN when the circuit breaker is OPEN (publisher is failing),
+ * UP when CLOSED or HALF_OPEN (normal operation or recovery testing).
+ *
+ * Only active when spring-boot-starter-actuator is on the classpath.
+ */
+class OutboxPublisherHealthIndicator(
+    private val circuitBreaker: CircuitBreaker?
+) : AbstractHealthIndicator() {
+
+    override fun doHealthCheck(builder: Health.Builder) {
+        if (circuitBreaker == null) {
+            builder.up()
+                .withDetail("circuitBreaker", "disabled")
+            return
+        }
+
+        val metrics = circuitBreaker.metrics
+        val details = mapOf(
+            "circuitBreakerState" to circuitBreaker.state.name,
+            // failureRate is -1.0 until minimumNumberOfCalls is reached
+            "failureRate" to "${metrics.failureRate}%",
+            "slidingWindow" to mapOf(
+                "successful" to metrics.numberOfSuccessfulCalls,
+                "failed" to metrics.numberOfFailedCalls,
+                "rejected" to metrics.numberOfNotPermittedCalls
+            )
+        )
+
+        when (circuitBreaker.state) {
+            CircuitBreaker.State.CLOSED -> builder.up().withDetails(details)
+            CircuitBreaker.State.HALF_OPEN -> builder.up().withDetails(details)
+            CircuitBreaker.State.OPEN -> builder.down().withDetails(details)
+            else -> builder.unknown().withDetails(details)
+        }
+    }
+}

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/LoggingMessagePublisher.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/LoggingMessagePublisher.kt
@@ -19,7 +19,6 @@ package com.ritense.outbox.publisher
 import com.ritense.outbox.OutboxMessage
 import mu.KotlinLogging
 
-// TODO: Remove this MessagePublisher when Valtimo has another MessagePublisher out of the box.
 open class LoggingMessagePublisher : MessagePublisher {
 
     override fun publish(message: OutboxMessage) {

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublishResult.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublishResult.kt
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-package com.ritense.outbox.repository
+package com.ritense.outbox.publisher
 
-import com.ritense.outbox.OutboxMessage
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.repository.NoRepositoryBean
 import java.util.UUID
 
-@NoRepositoryBean
-interface OutboxMessageRepository : JpaRepository<OutboxMessage, UUID> {
-
-    @Deprecated(
-        message = "Will be removed in 14.0. Use findOutboxMessages(batchSize) instead",
-        replaceWith = ReplaceWith("findOutboxMessages(1).firstOrNull()")
-    )
-    fun findOutboxMessage(): OutboxMessage?
-
-    fun findOutboxMessages(batchSize: Int): List<OutboxMessage>
-}
+data class MessagePublishResult(
+    val messageId: UUID,
+    val success: Boolean,
+    val error: Throwable? = null
+)

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublisher.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublisher.kt
@@ -21,4 +21,24 @@ import com.ritense.outbox.OutboxMessage
 interface MessagePublisher {
 
     fun publish(message: OutboxMessage)
+
+    /**
+     * Publishes a batch of messages and returns a per-message result.
+     *
+     * The default implementation delegates to [publish] for each message individually,
+     * catching exceptions per message so that one failure does not prevent the rest from being published.
+     *
+     * Batch-capable publishers (e.g. using RabbitMQ batch sends) can override this
+     * to publish multiple messages in a single network round-trip.
+     */
+    fun publishBatch(messages: List<OutboxMessage>): List<MessagePublishResult> {
+        return messages.map { message ->
+            try {
+                publish(message)
+                MessagePublishResult(messageId = message.id, success = true)
+            } catch (e: Exception) {
+                MessagePublishResult(messageId = message.id, success = false, error = e)
+            }
+        }
+    }
 }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublisher.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublisher.kt
@@ -36,6 +36,9 @@ interface MessagePublisher {
             try {
                 publish(message)
                 MessagePublishResult(messageId = message.id, success = true)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                MessagePublishResult(messageId = message.id, success = false, error = e)
             } catch (e: Exception) {
                 MessagePublishResult(messageId = message.id, success = false, error = e)
             }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublishingFailed.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/MessagePublishingFailed.kt
@@ -16,4 +16,4 @@
 
 package com.ritense.outbox.publisher
 
-class MessagePublishingFailed(message: String) : RuntimeException(message)
+class MessagePublishingFailed(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
@@ -16,39 +16,74 @@
 
 package com.ritense.outbox.publisher
 
+import com.ritense.outbox.OutboxMessage
 import com.ritense.outbox.ValtimoOutboxService
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import mu.KotlinLogging
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 open class PollingPublisherService(
     private val outboxService: ValtimoOutboxService,
     private val messagePublisher: MessagePublisher,
-    private val platformTransactionManager: PlatformTransactionManager
+    private val platformTransactionManager: PlatformTransactionManager,
+    private val batchSize: Int = DEFAULT_BATCH_SIZE,
+    private val circuitBreaker: CircuitBreaker? = null
 ) {
+    // Prevents concurrent polling from multiple scheduled invocations
     private val polling = AtomicBoolean(false)
+
+    // Backwards-compatible constructor for existing callers
+    constructor(
+        outboxService: ValtimoOutboxService,
+        messagePublisher: MessagePublisher,
+        platformTransactionManager: PlatformTransactionManager
+    ) : this(outboxService, messagePublisher, platformTransactionManager, DEFAULT_BATCH_SIZE, null)
 
     init {
         logger.info { "Using ${messagePublisher::class.qualifiedName} as outbox message publisher." }
+        if (circuitBreaker != null) {
+            logger.info { "Outbox circuit breaker enabled: ${circuitBreaker.name}" }
+        }
     }
 
     /**
-     * Poll messages from the outbox table and publishes them in the correct order.
+     * Polls messages from the outbox table and publishes them in batches.
+     *
+     * The method processes batches in a loop until no more messages are available.
+     * Each batch is fetched and published within a single transaction to ensure
+     * the FOR UPDATE SKIP LOCKED row locks are held during publishing.
+     *
+     * Circuit breaker behavior:
+     * - OPEN: skips polling entirely, no database access
+     * - HALF_OPEN: fetches 1 message at a time to test if the publisher has recovered
+     * - CLOSED: normal batch processing
      */
     open fun pollAndPublishAll() {
+        if (isCircuitBreakerOpen()) {
+            logger.debug { "Circuit breaker is OPEN. Skipping outbox polling." }
+            return
+        }
+
         if (polling.compareAndSet(false, true)) {
             try {
                 do {
-                    TransactionTemplate(platformTransactionManager).executeWithoutResult {
-                        val oldestMessage = outboxService.getOldestMessage()
-                        if (oldestMessage != null) {
-                            logger.debug { "Sending OutboxMessage '${oldestMessage.id}'" }
-                            messagePublisher.publish(oldestMessage)
-                            outboxService.deleteMessage(oldestMessage.id)
+                    val continuePolling = TransactionTemplate(platformTransactionManager).execute {
+                        // Use batch size of 1 during HALF_OPEN to limit exposure while testing recovery
+                        val effectiveBatchSize = if (isCircuitBreakerHalfOpen()) 1 else batchSize
+                        val messages = outboxService.getOldestMessages(effectiveBatchSize)
+                        if (messages.isNotEmpty()) {
+                            publishAndDeleteBatch(messages)
                         } else {
-                            polling.set(false)
+                            false
                         }
+                    } ?: false
+
+                    // Stop if the batch indicated no more work, or if the circuit breaker opened mid-loop
+                    if (!continuePolling || isCircuitBreakerOpen()) {
+                        polling.set(false)
                     }
                 } while (polling.get())
             } catch (e: Exception) {
@@ -59,7 +94,69 @@ open class PollingPublisherService(
         }
     }
 
+    /**
+     * Publishes a batch of messages and deletes the successful ones.
+     *
+     * @return true if there may be more messages to process (batch was full), false otherwise
+     */
+    private fun publishAndDeleteBatch(messages: List<OutboxMessage>): Boolean {
+        logger.debug { "Publishing batch of ${messages.size} outbox message(s)" }
+
+        val startTime = System.nanoTime()
+        val results = messagePublisher.publishBatch(messages)
+        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime)
+
+        // Record each result individually on the circuit breaker for fine-grained failure tracking.
+        // We use manual recording (onSuccess/onError) instead of executeSupplier because the default
+        // publishBatch implementation catches exceptions per message and never throws itself.
+        results.forEach { result ->
+            if (circuitBreaker != null) {
+                if (result.success) {
+                    circuitBreaker.onSuccess(0, TimeUnit.NANOSECONDS)
+                } else {
+                    circuitBreaker.onError(
+                        0, TimeUnit.NANOSECONDS,
+                        result.error ?: MessagePublishingFailed("Failed to publish outbox message ${result.messageId}")
+                    )
+                }
+            }
+        }
+
+        val successIds = results.filter { it.success }.map { it.messageId }
+        val failures = results.filter { !it.success }
+
+        // Only delete successfully published messages; failed ones stay in the outbox for retry
+        if (successIds.isNotEmpty()) {
+            outboxService.deleteMessages(successIds)
+        }
+
+        if (failures.isNotEmpty()) {
+            logger.warn {
+                "Outbox batch completed in ${durationMs}ms: ${successIds.size}/${messages.size} succeeded, ${failures.size} failed"
+            }
+            failures.forEach { result ->
+                logger.debug(result.error) { "Failed to publish outbox message ${result.messageId}" }
+            }
+            // Stop polling on any failures — failed messages stay in the outbox and would be
+            // re-fetched in the next batch, causing an infinite loop. Let the next scheduled
+            // poll cycle retry them instead.
+            return false
+        }
+
+        logger.debug { "Outbox batch completed in ${durationMs}ms: ${messages.size}/${messages.size} succeeded" }
+
+        // Continue polling if this batch was full — there may be more messages waiting
+        return messages.size >= batchSize
+    }
+
+    private fun isCircuitBreakerOpen() =
+        circuitBreaker != null && circuitBreaker.state == CircuitBreaker.State.OPEN
+
+    private fun isCircuitBreakerHalfOpen() =
+        circuitBreaker != null && circuitBreaker.state == CircuitBreaker.State.HALF_OPEN
+
     companion object {
+        const val DEFAULT_BATCH_SIZE = 10
         val logger = KotlinLogging.logger {}
     }
 }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/repository/impl/MySqlOutboxMessageRepository.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/repository/impl/MySqlOutboxMessageRepository.kt
@@ -20,10 +20,17 @@ import com.ritense.outbox.OutboxMessage
 import com.ritense.outbox.repository.OutboxMessageRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.NoRepositoryBean
+import org.springframework.data.repository.query.Param
 
 @NoRepositoryBean
 interface MySqlOutboxMessageRepository : OutboxMessageRepository {
 
-    @Query("SELECT * FROM outbox_message LIMIT 1 FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    // ORDER BY created_on ASC guarantees FIFO ordering but causes MySQL gap-locks: InnoDB locks
+    // gaps between index entries during the ordered scan, which can cause parallel pollers to skip
+    // older messages. If you need correct ordering, use a single polling publisher per outbox table.
+    @Query("SELECT * FROM outbox_message ORDER BY created_on ASC LIMIT 1 FOR UPDATE SKIP LOCKED", nativeQuery = true)
     override fun findOutboxMessage(): OutboxMessage?
+
+    @Query("SELECT * FROM outbox_message ORDER BY created_on ASC LIMIT :batchSize FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    override fun findOutboxMessages(@Param("batchSize") batchSize: Int): List<OutboxMessage>
 }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/repository/impl/PostgresOutboxMessageRepository.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/repository/impl/PostgresOutboxMessageRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,14 @@ import com.ritense.outbox.OutboxMessage
 import com.ritense.outbox.repository.OutboxMessageRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.NoRepositoryBean
+import org.springframework.data.repository.query.Param
 
 @NoRepositoryBean
 interface PostgresOutboxMessageRepository : OutboxMessageRepository {
 
     @Query("SELECT * FROM outbox_message ORDER BY created_on ASC LIMIT 1 FOR UPDATE SKIP LOCKED", nativeQuery = true)
     override fun findOutboxMessage(): OutboxMessage?
+
+    @Query("SELECT * FROM outbox_message ORDER BY created_on ASC LIMIT :batchSize FOR UPDATE SKIP LOCKED", nativeQuery = true)
+    override fun findOutboxMessages(@Param("batchSize") batchSize: Int): List<OutboxMessage>
 }

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/BaseIntegrationTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/BaseIntegrationTest.kt
@@ -18,11 +18,15 @@ package com.ritense.outbox
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.outbox.config.condition.OnOutboxEnabledCondition
+import com.ritense.outbox.publisher.MessagePublishResult
 import com.ritense.outbox.publisher.MessagePublisher
 import com.ritense.outbox.repository.OutboxMessageRepository
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -42,6 +46,23 @@ class BaseIntegrationTest {
 
     @Autowired
     lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun baseSetUp() {
+        // Can't use thenCallRealMethod() on interface default methods with Mockito,
+        // so we replicate the default publishBatch behavior: delegate to publish() per message.
+        whenever(messagePublisher.publishBatch(any())).thenAnswer { invocation ->
+            val messages = invocation.getArgument<List<OutboxMessage>>(0)
+            messages.map { message ->
+                try {
+                    messagePublisher.publish(message)
+                    MessagePublishResult(messageId = message.id, success = true)
+                } catch (e: Exception) {
+                    MessagePublishResult(messageId = message.id, success = false, error = e)
+                }
+            }
+        }
+    }
 
     @AfterEach
     fun afterEach() {

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxContextTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxContextTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OutboxContextTest {
+
+    @Test
+    fun `should suppress outbox within block`() {
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+
+        OutboxContext.runWithSuppressedOutbox {
+            assertThat(OutboxContext.outboxSuppressed).isTrue()
+            "result"
+        }
+
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+    }
+
+    @Test
+    fun `should not suppress outbox when suppress is false`() {
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+
+        OutboxContext.runWithSuppressedOutbox(suppress = false) {
+            assertThat(OutboxContext.outboxSuppressed).isFalse()
+            "result"
+        }
+
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+    }
+
+    @Test
+    fun `should return callable result`() {
+        val result = OutboxContext.runWithSuppressedOutbox { "hello" }
+        assertThat(result).isEqualTo("hello")
+    }
+
+    @Test
+    fun `should return callable result when suppress is false`() {
+        val result = OutboxContext.runWithSuppressedOutbox(suppress = false) { "hello" }
+        assertThat(result).isEqualTo("hello")
+    }
+
+    @Test
+    fun `should remain suppressed in nested call and not reset prematurely`() {
+        OutboxContext.runWithSuppressedOutbox {
+            assertThat(OutboxContext.outboxSuppressed).isTrue()
+
+            OutboxContext.runWithSuppressedOutbox {
+                assertThat(OutboxContext.outboxSuppressed).isTrue()
+                "inner"
+            }
+
+            // Should still be suppressed after inner block completes
+            assertThat(OutboxContext.outboxSuppressed).isTrue()
+            "outer"
+        }
+
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+    }
+
+    @Test
+    fun `should reset suppressed state even when callable throws`() {
+        try {
+            OutboxContext.runWithSuppressedOutbox {
+                throw RuntimeException("test error")
+            }
+        } catch (_: RuntimeException) {
+            // expected
+        }
+
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+    }
+}

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxMessageRepositoryIntTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxMessageRepositoryIntTest.kt
@@ -53,4 +53,77 @@ class OutboxMessageRepositoryIntTest : BaseIntegrationTest() {
 
         assertThat(outboxMessage1Ref.await()!!.message).isNotEqualTo(outboxMessage2Ref.await()!!.message)
     }
+
+    @Test
+    fun `should fetch batch of messages ordered by created_on`() {
+        insertOutboxMessage("event 1")
+        Thread.sleep(10) // ensure distinct created_on timestamps
+        insertOutboxMessage("event 2")
+        Thread.sleep(10)
+        insertOutboxMessage("event 3")
+
+        val messages = TransactionTemplate(platformTransactionManager).execute {
+            outboxMessageRepository.findOutboxMessages(10)
+        }!!
+
+        assertThat(messages).hasSize(3)
+        assertThat(messages[0].message).contains("event 1")
+        assertThat(messages[1].message).contains("event 2")
+        assertThat(messages[2].message).contains("event 3")
+    }
+
+    @Test
+    fun `should limit batch size`() {
+        insertOutboxMessage("event 1")
+        insertOutboxMessage("event 2")
+        insertOutboxMessage("event 3")
+
+        val messages = TransactionTemplate(platformTransactionManager).execute {
+            outboxMessageRepository.findOutboxMessages(2)
+        }!!
+
+        assertThat(messages).hasSize(2)
+    }
+
+    @Test
+    fun `should return empty list when no messages exist`() {
+        val messages = TransactionTemplate(platformTransactionManager).execute {
+            outboxMessageRepository.findOutboxMessages(10)
+        }!!
+
+        assertThat(messages).isEmpty()
+    }
+
+    @Test
+    fun `should skip locked messages in batch fetch`(): Unit = runBlocking {
+        insertOutboxMessage("event 1")
+        Thread.sleep(10)
+        insertOutboxMessage("event 2")
+        Thread.sleep(10)
+        insertOutboxMessage("event 3")
+
+        // First transaction locks the first 2 messages
+        val batch1Ref = async(Dispatchers.IO) {
+            TransactionTemplate(platformTransactionManager).execute {
+                val messages = outboxMessageRepository.findOutboxMessages(2)
+                Thread.sleep(1000) // hold the lock
+                messages
+            }
+        }
+
+        // Second transaction should skip the locked messages and get the 3rd
+        Thread.sleep(100) // ensure first transaction has acquired locks
+        val batch2Ref = async(Dispatchers.IO) {
+            TransactionTemplate(platformTransactionManager).execute {
+                outboxMessageRepository.findOutboxMessages(2)
+            }
+        }
+
+        val batch1 = batch1Ref.await()!!
+        val batch2 = batch2Ref.await()!!
+
+        assertThat(batch1).hasSize(2)
+        assertThat(batch2).hasSize(1)
+        assertThat(batch1.map { it.id }).doesNotContainAnyElementsOf(batch2.map { it.id })
+    }
 }

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxMessageRepositoryIntTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxMessageRepositoryIntTest.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.outbox
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -103,16 +104,18 @@ class OutboxMessageRepositoryIntTest : BaseIntegrationTest() {
         insertOutboxMessage("event 3")
 
         // First transaction locks the first 2 messages
+        val locksAcquired = CompletableDeferred<Unit>()
         val batch1Ref = async(Dispatchers.IO) {
             TransactionTemplate(platformTransactionManager).execute {
                 val messages = outboxMessageRepository.findOutboxMessages(2)
+                locksAcquired.complete(Unit)
                 Thread.sleep(1000) // hold the lock
                 messages
             }
         }
 
         // Second transaction should skip the locked messages and get the 3rd
-        Thread.sleep(100) // ensure first transaction has acquired locks
+        locksAcquired.await()
         val batch2Ref = async(Dispatchers.IO) {
             TransactionTemplate(platformTransactionManager).execute {
                 outboxMessageRepository.findOutboxMessages(2)

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/UserProviderTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/UserProviderTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+
+class UserProviderTest {
+
+    private val userProvider = UserProvider()
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `getCurrentUserLogin should return username when authenticated`() {
+        SecurityContextHolder.getContext().authentication =
+            TestingAuthenticationToken("john@example.com", null)
+
+        assertThat(userProvider.getCurrentUserLogin()).isEqualTo("john@example.com")
+    }
+
+    @Test
+    fun `getCurrentUserLogin should return null when no authentication`() {
+        assertThat(userProvider.getCurrentUserLogin()).isNull()
+    }
+
+    @Test
+    fun `getCurrentUserRoles should return authorities when authenticated`() {
+        SecurityContextHolder.getContext().authentication =
+            TestingAuthenticationToken("user", null, listOf(
+                SimpleGrantedAuthority("ROLE_ADMIN"),
+                SimpleGrantedAuthority("ROLE_USER")
+            ))
+
+        assertThat(userProvider.getCurrentUserRoles())
+            .containsExactly("ROLE_ADMIN", "ROLE_USER")
+    }
+
+    @Test
+    fun `getCurrentUserRoles should return empty list when no authentication`() {
+        assertThat(userProvider.getCurrentUserRoles()).isEmpty()
+    }
+
+    @Test
+    fun `getCurrentUserRoles should return empty list when no authorities`() {
+        SecurityContextHolder.getContext().authentication =
+            TestingAuthenticationToken("user", null, emptyList())
+
+        assertThat(userProvider.getCurrentUserRoles()).isEmpty()
+    }
+}

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/ValtimoOutboxServiceIntTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/ValtimoOutboxServiceIntTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,20 @@ class ValtimoOutboxServiceIntTest : BaseIntegrationTest() {
     }
 
     @Test
+    fun `should batch multiple deferred messages in a single transaction for read-only callers`() {
+        TransactionTemplate(transactionManager).apply {
+            isReadOnly = true
+        }.executeWithoutResult {
+            outboxService.send(objectMapper.writeValueAsString(OrderCreatedEvent("event1")))
+            outboxService.send(objectMapper.writeValueAsString(OrderCreatedEvent("event2")))
+            outboxService.send(objectMapper.writeValueAsString(OrderCreatedEvent("event3")))
+        }
+
+        val messages = outboxMessageRepository.findAll()
+        assertThat(messages).hasSize(3)
+    }
+
+    @Test
     fun `should throw error when no transaction exists`() {
         val event = OrderCreatedEvent("textBook")
 
@@ -122,6 +136,28 @@ class ValtimoOutboxServiceIntTest : BaseIntegrationTest() {
         assertThat(result["data"]["userId"].textValue()).isEqualTo("user@ritense.com")
         val roles = result["data"]["roles"].toList().map { it.textValue() }
         assertThat(roles).containsExactlyInAnyOrder("ADMIN", "USER")
+    }
+
+    @Test
+    @Transactional
+    fun `should skip message when outbox is suppressed`() {
+        OutboxContext.runWithSuppressedOutbox {
+            outboxService.send { TestEvent() }
+        }
+
+        val messages = outboxMessageRepository.findAll()
+        assertThat(messages).isEmpty()
+    }
+
+    @Test
+    @Transactional
+    fun `should not skip message when outbox suppress is false`() {
+        OutboxContext.runWithSuppressedOutbox(suppress = false) {
+            outboxService.send { TestEvent() }
+        }
+
+        val messages = outboxMessageRepository.findAll()
+        assertThat(messages).hasSize(1)
     }
 
     data class OrderCreatedEvent(

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicatorTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicatorTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox.health
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.Status
+import java.time.Duration
+
+class OutboxPublisherHealthIndicatorTest {
+
+    @Test
+    fun `should report UP when circuit breaker is null`() {
+        val indicator = OutboxPublisherHealthIndicator(null)
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+        assertThat(health.details["circuitBreaker"]).isEqualTo("disabled")
+    }
+
+    @Test
+    fun `should report UP when circuit breaker is CLOSED`() {
+        val circuitBreaker = createCircuitBreaker()
+        val indicator = OutboxPublisherHealthIndicator(circuitBreaker)
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+        assertThat(health.details["circuitBreakerState"]).isEqualTo("CLOSED")
+    }
+
+    @Test
+    fun `should report DOWN when circuit breaker is OPEN`() {
+        val circuitBreaker = createCircuitBreaker()
+        circuitBreaker.transitionToOpenState()
+        val indicator = OutboxPublisherHealthIndicator(circuitBreaker)
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.DOWN)
+        assertThat(health.details["circuitBreakerState"]).isEqualTo("OPEN")
+    }
+
+    @Test
+    fun `should report UP when circuit breaker is HALF_OPEN`() {
+        val circuitBreaker = createCircuitBreaker()
+        circuitBreaker.transitionToOpenState()
+        circuitBreaker.transitionToHalfOpenState()
+        val indicator = OutboxPublisherHealthIndicator(circuitBreaker)
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+        assertThat(health.details["circuitBreakerState"]).isEqualTo("HALF_OPEN")
+    }
+
+    @Test
+    fun `should include metrics in health details`() {
+        val circuitBreaker = createCircuitBreaker()
+        // Record some calls
+        circuitBreaker.onSuccess(0, java.util.concurrent.TimeUnit.NANOSECONDS)
+        circuitBreaker.onError(0, java.util.concurrent.TimeUnit.NANOSECONDS, RuntimeException("fail"))
+
+        val indicator = OutboxPublisherHealthIndicator(circuitBreaker)
+        val health = indicator.health()
+
+        assertThat(health.details).containsKeys(
+            "circuitBreakerState",
+            "failureRate",
+            "slidingWindow"
+        )
+        @Suppress("UNCHECKED_CAST")
+        val slidingWindow = health.details["slidingWindow"] as Map<String, Any>
+        assertThat(slidingWindow["successful"]).isEqualTo(1)
+        assertThat(slidingWindow["failed"]).isEqualTo(1)
+        assertThat(slidingWindow["rejected"]).isEqualTo(0L)
+    }
+
+    private fun createCircuitBreaker(): CircuitBreaker {
+        val config = CircuitBreakerConfig.custom()
+            .failureRateThreshold(50f)
+            .minimumNumberOfCalls(5)
+            .slidingWindowSize(10)
+            .waitDurationInOpenState(Duration.ofSeconds(60))
+            .permittedNumberOfCallsInHalfOpenState(1)
+            .build()
+        return CircuitBreaker.of("test", config)
+    }
+}

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/MessagePublisherTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/MessagePublisherTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox.publisher
+
+import com.ritense.outbox.OutboxMessage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MessagePublisherTest {
+
+    @Test
+    fun `publishBatch should call publish for each message and return success results`() {
+        val published = mutableListOf<OutboxMessage>()
+        val publisher = object : MessagePublisher {
+            override fun publish(message: OutboxMessage) {
+                published.add(message)
+            }
+        }
+        val messages = listOf(
+            OutboxMessage(message = "msg1"),
+            OutboxMessage(message = "msg2"),
+            OutboxMessage(message = "msg3")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        assertThat(published).hasSize(3)
+        assertThat(results).hasSize(3)
+        assertThat(results).allMatch { it.success }
+        assertThat(results.map { it.messageId }).containsExactlyElementsOf(messages.map { it.id })
+    }
+
+    @Test
+    fun `publishBatch should capture individual failures without stopping the batch`() {
+        val publisher = object : MessagePublisher {
+            override fun publish(message: OutboxMessage) {
+                if (message.message == "fail") {
+                    throw RuntimeException("publish failed")
+                }
+            }
+        }
+        val messages = listOf(
+            OutboxMessage(message = "ok1"),
+            OutboxMessage(message = "fail"),
+            OutboxMessage(message = "ok2")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        assertThat(results).hasSize(3)
+        assertThat(results[0].success).isTrue()
+        assertThat(results[1].success).isFalse()
+        assertThat(results[1].error).isInstanceOf(RuntimeException::class.java)
+        assertThat(results[1].error!!.message).isEqualTo("publish failed")
+        assertThat(results[2].success).isTrue()
+    }
+
+    @Test
+    fun `publishBatch should return empty list for empty input`() {
+        val publisher = object : MessagePublisher {
+            override fun publish(message: OutboxMessage) {}
+        }
+
+        val results = publisher.publishBatch(emptyList())
+
+        assertThat(results).isEmpty()
+    }
+}

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherJobIntTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherJobIntTest.kt
@@ -37,6 +37,7 @@ class PollingPublisherJobIntTest : BaseIntegrationTest() {
 
         pollingPublisherJob.scheduledTaskPollMessage()
 
+        verify(messagePublisher, times(1)).publishBatch(any())
         verify(messagePublisher, times(1)).publish(any())
     }
 }

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceIntTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceIntTest.kt
@@ -40,6 +40,7 @@ class PollingPublisherServiceIntTest : BaseIntegrationTest() {
 
         pollingPublisherService.pollAndPublishAll()
 
+        verify(messagePublisher, times(1)).publishBatch(any())
         verify(messagePublisher, times(1)).publish(any())
     }
 
@@ -48,19 +49,17 @@ class PollingPublisherServiceIntTest : BaseIntegrationTest() {
         insertOutboxMessage(OrderCreatedEvent("event 1"))
         insertOutboxMessage(OrderCreatedEvent("event 2"))
         whenever(messagePublisher.publish(any())).then { Thread.sleep(1000) }
-        verify(outboxMessageRepository, times(0)).findOutboxMessage()
+        verify(outboxMessageRepository, times(0)).findOutboxMessages(any())
 
         listOf(
             async(Dispatchers.IO) { pollingPublisherService.pollAndPublishAll() },
             async(Dispatchers.IO) { pollingPublisherService.pollAndPublishAll() }
         ).awaitAll()
 
-        // Number of database reads is 3 because:
-        // Poller 1: read database. Find event 1
+        // With batching: both events are fetched in a single batch
+        // Poller 1: read database. Find both events in one batch (batch < batchSize, so stop)
         // Poller 2: Polling is blocked. NO database read
-        // Poller 1: read database. Find event 2
-        // Poller 1: read database. Find NULL
-        verify(outboxMessageRepository, times(3)).findOutboxMessage()
+        verify(outboxMessageRepository, times(1)).findOutboxMessages(any())
     }
 
     @Test
@@ -68,16 +67,14 @@ class PollingPublisherServiceIntTest : BaseIntegrationTest() {
         insertOutboxMessage(OrderCreatedEvent("event 1"))
         insertOutboxMessage(OrderCreatedEvent("event 2"))
         whenever(messagePublisher.publish(any())).then { Thread.sleep(1000) }
-        verify(outboxMessageRepository, times(0)).findOutboxMessage()
+        verify(outboxMessageRepository, times(0)).findOutboxMessages(any())
 
         pollingPublisherService.pollAndPublishAll()
         pollingPublisherService.pollAndPublishAll()
 
-        // Number of database reads is 4 because:
-        // Poller 1: read database. Find event 1
-        // Poller 1: read database. Find event 2
-        // Poller 1: read database. Find NULL
-        // Poller 2: read database. Find NULL
-        verify(outboxMessageRepository, times(4)).findOutboxMessage()
+        // With batching: both events are fetched in a single batch
+        // Poller 1: read database. Find both events (batch < batchSize, so stop)
+        // Poller 2: read database. Find empty
+        verify(outboxMessageRepository, times(2)).findOutboxMessages(any())
     }
 }

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceTest.kt
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox.publisher
+
+import com.ritense.outbox.OutboxMessage
+import com.ritense.outbox.ValtimoOutboxService
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.SimpleTransactionStatus
+import java.time.Duration
+
+class PollingPublisherServiceTest {
+
+    private lateinit var outboxService: ValtimoOutboxService
+    private lateinit var messagePublisher: MessagePublisher
+    private lateinit var transactionManager: PlatformTransactionManager
+
+    @BeforeEach
+    fun setUp() {
+        outboxService = mock()
+        messagePublisher = mock()
+        transactionManager = mock {
+            on { getTransaction(any()) }.thenReturn(SimpleTransactionStatus())
+        }
+    }
+
+    @Test
+    fun `should use default batch size of 10 with secondary constructor`() {
+        val msg = OutboxMessage(message = "test")
+        whenever(outboxService.getOldestMessages(10)).thenReturn(listOf(msg))
+        whenever(outboxService.getOldestMessages(10))
+            .thenReturn(listOf(msg))
+            .thenReturn(emptyList())
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(MessagePublishResult(messageId = msg.id, success = true))
+        )
+
+        val service = PollingPublisherService(outboxService, messagePublisher, transactionManager)
+        service.pollAndPublishAll()
+
+        verify(outboxService).getOldestMessages(10)
+    }
+
+    @Test
+    fun `should fetch messages with configured batch size`() {
+        whenever(outboxService.getOldestMessages(5)).thenReturn(emptyList())
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            batchSize = 5
+        )
+        service.pollAndPublishAll()
+
+        verify(outboxService).getOldestMessages(5)
+    }
+
+    @Test
+    fun `should delete successful messages and keep failed ones`() {
+        val msg1 = OutboxMessage(message = "ok")
+        val msg2 = OutboxMessage(message = "fail")
+        val msg3 = OutboxMessage(message = "ok2")
+        whenever(outboxService.getOldestMessages(any()))
+            .thenReturn(listOf(msg1, msg2, msg3))
+            .thenReturn(emptyList())
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(
+                MessagePublishResult(messageId = msg1.id, success = true),
+                MessagePublishResult(messageId = msg2.id, success = false, error = RuntimeException("fail")),
+                MessagePublishResult(messageId = msg3.id, success = true)
+            )
+        )
+
+        val service = PollingPublisherService(outboxService, messagePublisher, transactionManager)
+        service.pollAndPublishAll()
+
+        verify(outboxService).deleteMessages(listOf(msg1.id, msg3.id))
+    }
+
+    @Test
+    fun `should not call deleteMessages when all messages fail`() {
+        val msg1 = OutboxMessage(message = "fail1")
+        val msg2 = OutboxMessage(message = "fail2")
+        whenever(outboxService.getOldestMessages(any())).thenReturn(listOf(msg1, msg2))
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(
+                MessagePublishResult(messageId = msg1.id, success = false, error = RuntimeException("fail")),
+                MessagePublishResult(messageId = msg2.id, success = false, error = RuntimeException("fail"))
+            )
+        )
+
+        val service = PollingPublisherService(outboxService, messagePublisher, transactionManager)
+        service.pollAndPublishAll()
+
+        verify(outboxService, never()).deleteMessages(any())
+    }
+
+    @Test
+    fun `should stop polling when all messages in batch fail`() {
+        val msg = OutboxMessage(message = "fail")
+        whenever(outboxService.getOldestMessages(any())).thenReturn(listOf(msg))
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(MessagePublishResult(messageId = msg.id, success = false, error = RuntimeException("fail")))
+        )
+
+        val service = PollingPublisherService(outboxService, messagePublisher, transactionManager)
+        service.pollAndPublishAll()
+
+        // Should only fetch once — loop stops after total failure
+        verify(outboxService, times(1)).getOldestMessages(any())
+    }
+
+    @Test
+    fun `should skip polling when circuit breaker is OPEN`() {
+        val circuitBreaker = createCircuitBreaker(failureThreshold = 50f, minimumCalls = 1, slidingWindowSize = 1)
+        // Force circuit breaker to OPEN
+        circuitBreaker.transitionToOpenState()
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            circuitBreaker = circuitBreaker
+        )
+        service.pollAndPublishAll()
+
+        verify(outboxService, never()).getOldestMessages(any())
+        verify(messagePublisher, never()).publishBatch(any())
+    }
+
+    @Test
+    fun `should record successes on circuit breaker`() {
+        val circuitBreaker = createCircuitBreaker(failureThreshold = 50f, minimumCalls = 1, slidingWindowSize = 10)
+        val msg = OutboxMessage(message = "ok")
+        whenever(outboxService.getOldestMessages(any()))
+            .thenReturn(listOf(msg))
+            .thenReturn(emptyList())
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(MessagePublishResult(messageId = msg.id, success = true))
+        )
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            circuitBreaker = circuitBreaker
+        )
+        service.pollAndPublishAll()
+
+        assertThat(circuitBreaker.metrics.numberOfSuccessfulCalls).isEqualTo(1)
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.CLOSED)
+    }
+
+    @Test
+    fun `should record failures on circuit breaker and transition to OPEN`() {
+        val circuitBreaker = createCircuitBreaker(
+            failureThreshold = 50f,
+            minimumCalls = 2,
+            slidingWindowSize = 2
+        )
+        val msg1 = OutboxMessage(message = "fail1")
+        val msg2 = OutboxMessage(message = "fail2")
+        whenever(outboxService.getOldestMessages(any())).thenReturn(listOf(msg1, msg2))
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(
+                MessagePublishResult(messageId = msg1.id, success = false, error = RuntimeException("fail")),
+                MessagePublishResult(messageId = msg2.id, success = false, error = RuntimeException("fail"))
+            )
+        )
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            circuitBreaker = circuitBreaker
+        )
+        service.pollAndPublishAll()
+
+        assertThat(circuitBreaker.metrics.numberOfFailedCalls).isEqualTo(2)
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.OPEN)
+    }
+
+    @Test
+    fun `should stop loop when circuit breaker opens mid-batch`() {
+        val circuitBreaker = createCircuitBreaker(
+            failureThreshold = 100f,
+            minimumCalls = 1,
+            slidingWindowSize = 1
+        )
+        val failMsg = OutboxMessage(message = "fail")
+        val okMsg = OutboxMessage(message = "ok")
+        // First batch: all fail → circuit opens. Second batch should not be fetched.
+        whenever(outboxService.getOldestMessages(any()))
+            .thenReturn(listOf(failMsg))
+            .thenReturn(listOf(okMsg))
+        whenever(messagePublisher.publishBatch(listOf(failMsg))).thenReturn(
+            listOf(MessagePublishResult(messageId = failMsg.id, success = false, error = RuntimeException("fail")))
+        )
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            circuitBreaker = circuitBreaker
+        )
+        service.pollAndPublishAll()
+
+        // Circuit opened after first batch, so second batch is never fetched
+        verify(outboxService, times(1)).getOldestMessages(any())
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.OPEN)
+    }
+
+    @Test
+    fun `should continue polling when batch is full`() {
+        val batchSize = 2
+        val msg1 = OutboxMessage(message = "ok1")
+        val msg2 = OutboxMessage(message = "ok2")
+        val msg3 = OutboxMessage(message = "ok3")
+        // First batch: full (2 messages) → continue. Second batch: partial (1 message) → stop.
+        whenever(outboxService.getOldestMessages(batchSize))
+            .thenReturn(listOf(msg1, msg2))
+            .thenReturn(listOf(msg3))
+            .thenReturn(emptyList())
+        whenever(messagePublisher.publishBatch(listOf(msg1, msg2))).thenReturn(
+            listOf(
+                MessagePublishResult(messageId = msg1.id, success = true),
+                MessagePublishResult(messageId = msg2.id, success = true)
+            )
+        )
+        whenever(messagePublisher.publishBatch(listOf(msg3))).thenReturn(
+            listOf(MessagePublishResult(messageId = msg3.id, success = true))
+        )
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            batchSize = batchSize
+        )
+        service.pollAndPublishAll()
+
+        verify(outboxService, times(2)).getOldestMessages(batchSize)
+        verify(outboxService).deleteMessages(listOf(msg1.id, msg2.id))
+        verify(outboxService).deleteMessages(listOf(msg3.id))
+    }
+
+    @Test
+    fun `should stop polling when batch is smaller than batch size`() {
+        val batchSize = 5
+        val msg = OutboxMessage(message = "ok")
+        whenever(outboxService.getOldestMessages(batchSize)).thenReturn(listOf(msg))
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(MessagePublishResult(messageId = msg.id, success = true))
+        )
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            batchSize = batchSize
+        )
+        service.pollAndPublishAll()
+
+        // Only one fetch — batch smaller than batchSize means no more messages
+        verify(outboxService, times(1)).getOldestMessages(batchSize)
+    }
+
+    @Test
+    fun `should use batch size of 1 when circuit breaker is HALF_OPEN`() {
+        val circuitBreaker = createCircuitBreaker(
+            failureThreshold = 100f,
+            minimumCalls = 1,
+            slidingWindowSize = 1
+        )
+        circuitBreaker.transitionToOpenState()
+        circuitBreaker.transitionToHalfOpenState()
+
+        val msg = OutboxMessage(message = "ok")
+        whenever(outboxService.getOldestMessages(1)).thenReturn(listOf(msg))
+        whenever(outboxService.getOldestMessages(5)).thenReturn(emptyList())
+        whenever(messagePublisher.publishBatch(any())).thenReturn(
+            listOf(MessagePublishResult(messageId = msg.id, success = true))
+        )
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            batchSize = 5,
+            circuitBreaker = circuitBreaker
+        )
+        service.pollAndPublishAll()
+
+        // First fetch uses batch size 1 (HALF_OPEN), then circuit closes and resumes normal batch size
+        verify(outboxService).getOldestMessages(1)
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.CLOSED)
+    }
+
+    private fun createCircuitBreaker(
+        failureThreshold: Float,
+        minimumCalls: Int,
+        slidingWindowSize: Int
+    ): CircuitBreaker {
+        val config = CircuitBreakerConfig.custom()
+            .failureRateThreshold(failureThreshold)
+            .minimumNumberOfCalls(minimumCalls)
+            .slidingWindowSize(slidingWindowSize)
+            .waitDurationInOpenState(Duration.ofSeconds(60))
+            .permittedNumberOfCallsInHalfOpenState(1)
+            .build()
+        return CircuitBreaker.of("test", config)
+    }
+}

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceTest.kt
@@ -51,7 +51,6 @@ class PollingPublisherServiceTest {
     @Test
     fun `should use default batch size of 10 with secondary constructor`() {
         val msg = OutboxMessage(message = "test")
-        whenever(outboxService.getOldestMessages(10)).thenReturn(listOf(msg))
         whenever(outboxService.getOldestMessages(10))
             .thenReturn(listOf(msg))
             .thenReturn(emptyList())

--- a/backend/zgw/object-management/build.gradle
+++ b/backend/zgw/object-management/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation project(':zgw:objecttypen-api')
     implementation project(':zgw:objecten-api')
     implementation project(':logging')
+    implementation project(':outbox')
 
     implementation "io.github.microutils:kotlin-logging:${kotlinLoggingVersion}"
     implementation "org.springframework.boot:spring-boot-starter-webflux"

--- a/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/domain/ObjectManagement.kt
+++ b/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/domain/ObjectManagement.kt
@@ -52,5 +52,8 @@ data class ObjectManagement(
     override val formDefinitionView: String? = null,
 
     @Column(name = "form_definition_edit")
-    override val formDefinitionEdit: String? = null
+    override val formDefinitionEdit: String? = null,
+
+    @Column(name = "suppress_outbox", nullable = false)
+    override val suppressOutbox: Boolean = false
 ) : ObjectManagementInfo

--- a/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/service/ObjectManagementFacade.kt
+++ b/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/service/ObjectManagementFacade.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.ritense.objectmanagement.service
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthorization
+import com.ritense.outbox.OutboxContext.Companion.runWithSuppressedOutbox
 import com.ritense.objectenapi.ObjectenApiPlugin
 import com.ritense.objectenapi.client.ObjectRecord
 import com.ritense.objectenapi.client.ObjectRequest
@@ -232,7 +233,9 @@ class ObjectManagementFacade(
         val objectUrl = accessObject.objectenApiPlugin.getObjectUrl(uuid)
 
         logger.trace { "Getting object $objectUrl" }
-        return runWithoutAuthorization { accessObject.objectenApiPlugin.getObject(objectUrl) }
+        return runWithSuppressedOutbox(accessObject.objectManagement.suppressOutbox) {
+            runWithoutAuthorization { accessObject.objectenApiPlugin.getObject(objectUrl) }
+        }
     }
 
     private fun findObjectByUuidAndIndex(accessObject: ObjectManagementAccessObject, uuid: UUID, index: Int): ObjectRecord {
@@ -240,12 +243,16 @@ class ObjectManagementFacade(
         val objectUrl = accessObject.objectenApiPlugin.getObjectUrl(uuid)
 
         logger.trace { "Getting object $objectUrl" }
-        return runWithoutAuthorization { accessObject.objectenApiPlugin.getObjectRecord(objectUrl, index) }
+        return runWithSuppressedOutbox(accessObject.objectManagement.suppressOutbox) {
+            runWithoutAuthorization { accessObject.objectenApiPlugin.getObjectRecord(objectUrl, index) }
+        }
     }
 
     private fun findObjectByUri(accessObject: ObjectManagementAccessObject, objectUrl: URI): ObjectWrapper {
         logger.debug { "Getting object $objectUrl" }
-        return runWithoutAuthorization { accessObject.objectenApiPlugin.getObject(objectUrl) }
+        return runWithSuppressedOutbox(accessObject.objectManagement.suppressOutbox) {
+            runWithoutAuthorization { accessObject.objectenApiPlugin.getObject(objectUrl) }
+        }
     }
 
     private fun findObjectsPaged(
@@ -256,27 +263,29 @@ class ObjectManagementFacade(
         pageNumber: Int,
         pageSize: Int
     ): ObjectsList {
-        return runWithoutAuthorization {
-            if (!searchString.isNullOrBlank()) {
-                logger.debug { "Getting object page for object type $objectName with search string $searchString" }
+        return runWithSuppressedOutbox(accessObject.objectManagement.suppressOutbox) {
+            runWithoutAuthorization {
+                if (!searchString.isNullOrBlank()) {
+                    logger.debug { "Getting object page for object type $objectName with search string $searchString" }
 
-                accessObject.objectenApiPlugin.getObjectsByObjectTypeIdWithSearchParams(
-                    accessObject.objectTypenApiPlugin.url,
-                    accessObject.objectManagement.objecttypeId,
-                    searchString,
-                    ordering,
-                    PageRequest.of(pageNumber, pageSize)
-                )
-            } else {
-                logger.debug { "Getting object page for object type $objectName" }
+                    accessObject.objectenApiPlugin.getObjectsByObjectTypeIdWithSearchParams(
+                        accessObject.objectTypenApiPlugin.url,
+                        accessObject.objectManagement.objecttypeId,
+                        searchString,
+                        ordering,
+                        PageRequest.of(pageNumber, pageSize)
+                    )
+                } else {
+                    logger.debug { "Getting object page for object type $objectName" }
 
-                accessObject.objectenApiPlugin.getObjectsByObjectTypeId(
-                    accessObject.objectTypenApiPlugin.url,
-                    accessObject.objectenApiPlugin.url,
-                    accessObject.objectManagement.objecttypeId,
-                    ordering,
-                    PageRequest.of(pageNumber, pageSize)
-                )
+                    accessObject.objectenApiPlugin.getObjectsByObjectTypeId(
+                        accessObject.objectTypenApiPlugin.url,
+                        accessObject.objectenApiPlugin.url,
+                        accessObject.objectManagement.objecttypeId,
+                        ordering,
+                        PageRequest.of(pageNumber, pageSize)
+                    )
+                }
             }
         }
     }

--- a/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/service/ObjectManagementService.kt
+++ b/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/service/ObjectManagementService.kt
@@ -31,6 +31,7 @@ import com.ritense.objectmanagement.domain.search.SearchWithConfigFilter
 import com.ritense.objectmanagement.domain.search.SearchWithConfigRequest
 import com.ritense.objectmanagement.repository.ObjectManagementRepository
 import com.ritense.objecttypenapi.ObjecttypenApiPlugin
+import com.ritense.outbox.OutboxContext.Companion.runWithSuppressedOutbox
 import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.service.PluginService
 import com.ritense.search.domain.DataType.BOOLEAN
@@ -119,27 +120,29 @@ class ObjectManagementService(
             throw IllegalArgumentException("The requested Id is not configured as a object management configuration. The requested id was: $id")
         }
 
-        val objectTypePluginInstance = getObjectTypenApiPlugin(objectManagement.objecttypenApiPluginConfigurationId)
+        return runWithSuppressedOutbox(objectManagement.suppressOutbox) {
+            val objectTypePluginInstance = getObjectTypenApiPlugin(objectManagement.objecttypenApiPluginConfigurationId)
 
-        val objectenPluginInstance = getObjectenApiPlugin(objectManagement.objectenApiPluginConfigurationId)
+            val objectenPluginInstance = getObjectenApiPlugin(objectManagement.objectenApiPluginConfigurationId)
 
-        val objectsList = objectenPluginInstance.getObjectsByObjectTypeId(
-            objecttypesApiUrl = objectTypePluginInstance.url,
-            objectsApiUrl = objectenPluginInstance.url,
-            objecttypeId = objectManagement.objecttypeId,
-            pageable = pageable
-        )
-
-        val objectsListDto = objectsList.results.map {
-            ObjectsListRowDto(
-                it.url.toString(), listOf(
-                    ObjectsListRowDto.ObjectsListItemDto("objectUrl", it.url),
-                    ObjectsListRowDto.ObjectsListItemDto("recordIndex", it.record.index),
-                )
+            val objectsList = objectenPluginInstance.getObjectsByObjectTypeId(
+                objecttypesApiUrl = objectTypePluginInstance.url,
+                objectsApiUrl = objectenPluginInstance.url,
+                objecttypeId = objectManagement.objecttypeId,
+                pageable = pageable
             )
-        }
 
-        return PageImpl(objectsListDto, pageable, objectsList.count.toLong())
+            val objectsListDto = objectsList.results.map {
+                ObjectsListRowDto(
+                    it.url.toString(), listOf(
+                        ObjectsListRowDto.ObjectsListItemDto("objectUrl", it.url),
+                        ObjectsListRowDto.ObjectsListItemDto("recordIndex", it.record.index),
+                    )
+                )
+            }
+
+            PageImpl(objectsListDto, pageable, objectsList.count.toLong())
+        }
     }
 
     @Transactional
@@ -175,20 +178,22 @@ class ObjectManagementService(
         logger.debug {
             "Get objects with searchParams objectManagement=$objectManagement searchParameters=$searchParameters pageable=$pageable"
         }
-        val searchString = ObjectSearchParameter.toQueryParameter(searchParameters)
+        return runWithSuppressedOutbox(objectManagement.suppressOutbox) {
+            val searchString = ObjectSearchParameter.toQueryParameter(searchParameters)
 
-        val objectTypePluginInstance = getObjectTypenApiPlugin(objectManagement.objecttypenApiPluginConfigurationId)
+            val objectTypePluginInstance = getObjectTypenApiPlugin(objectManagement.objecttypenApiPluginConfigurationId)
 
-        val objectenPluginInstance = getObjectenApiPlugin(objectManagement.objectenApiPluginConfigurationId)
+            val objectenPluginInstance = getObjectenApiPlugin(objectManagement.objectenApiPluginConfigurationId)
 
-        val objectsList = objectenPluginInstance.getObjectsByObjectTypeIdWithSearchParams(
-            objecttypesApiUrl = objectTypePluginInstance.url,
-            objecttypeId = objectManagement.objecttypeId,
-            searchString = searchString,
-            pageable = pageable
-        )
+            val objectsList = objectenPluginInstance.getObjectsByObjectTypeIdWithSearchParams(
+                objecttypesApiUrl = objectTypePluginInstance.url,
+                objecttypeId = objectManagement.objecttypeId,
+                searchString = searchString,
+                pageable = pageable
+            )
 
-        return PageImpl(objectsList.results, pageable, objectsList.count.toLong())
+            PageImpl(objectsList.results, pageable, objectsList.count.toLong())
+        }
     }
 
     private fun mapToObjectListRowDto(

--- a/backend/zgw/object-management/src/main/resources/config/liquibase/changelog/20260324-add-suppress-outbox-to-object-management.xml
+++ b/backend/zgw/object-management/src/main/resources/config/liquibase/changelog/20260324-add-suppress-outbox-to-object-management.xml
@@ -1,0 +1,34 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd"
+                   logicalFilePath="config/liquibase/changelog/20260324-add-suppress-outbox-to-object-management.xml">
+
+    <property name="booleanFalseValue" value="0" dbms="mysql"/>
+    <property name="booleanFalseValue" value="false" dbms="postgresql"/>
+
+    <changeSet author="Ritense" id="1">
+        <addColumn tableName="object_management_configuration">
+            <column name="suppress_outbox" type="boolean" defaultValueBoolean="${booleanFalseValue}">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/backend/zgw/object-management/src/main/resources/config/liquibase/object-management-master.xml
+++ b/backend/zgw/object-management/src/main/resources/config/liquibase/object-management-master.xml
@@ -25,5 +25,6 @@
 
     <include file="changelog/20221221-add-object-management-table.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20230130-switch-configuration-id-columns.xml" relativeToChangelogFile="true"/>
+    <include file="changelog/20260324-add-suppress-outbox-to-object-management.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementFacadeTest.kt
+++ b/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementFacadeTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import com.ritense.outbox.OutboxContext
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -472,7 +473,6 @@ internal class ObjectManagementFacadeTest {
         whenever(objecttypenApiPlugin.getObjectTypeUrlById(objectTypeId)).thenReturn(expectedUrl)
         whenever(objectenApiPlugin.url).thenReturn(expectedUrl)
         whenever(objectenApiPlugin.getObjectUrl(any())).thenCallRealMethod()
-
         objectManagementFacade.createObject(objectName, data)
 
         clearInvocations(objectManagementRepository, pluginService, objectenApiPlugin)
@@ -490,13 +490,15 @@ internal class ObjectManagementFacadeTest {
     private fun prepareAccessObject(
         objectName: String,
         objectenApiPlugin: ObjectenApiPlugin,
-        objecttypenApiPlugin: ObjecttypenApiPlugin
+        objecttypenApiPlugin: ObjecttypenApiPlugin,
+        suppressOutbox: Boolean = false
     ) {
         val objectManagement = ObjectManagement(
             objecttypeId = objectTypeId,
             title = objectManagementTitle,
             objectenApiPluginConfigurationId = objectenApiPluginConfigurationId,
-            objecttypenApiPluginConfigurationId = objecttypenApiPluginConfigurationId
+            objecttypenApiPluginConfigurationId = objecttypenApiPluginConfigurationId,
+            suppressOutbox = suppressOutbox
         )
 
         whenever(objectManagementRepository.findByTitle(objectName)).thenReturn(objectManagement)
@@ -525,4 +527,56 @@ internal class ObjectManagementFacadeTest {
         startAt = LocalDate.now(),
         typeVersion = 1,
     )
+
+    @Test
+    fun `should suppress outbox when suppressOutbox is true`() {
+        val objectName = "myObject"
+        val objectUuid = UUID.randomUUID()
+
+        val objectenApiPlugin = mock<ObjectenApiPlugin>()
+        val objecttypenApiPlugin = mock<ObjecttypenApiPlugin>()
+        prepareAccessObject(objectName, objectenApiPlugin, objecttypenApiPlugin, suppressOutbox = true)
+
+        whenever(objectenApiPlugin.url).thenReturn(URI.create("www.ritense.com"))
+        val expectedUrl = URI.create("www.ritense.com/objects/$objectUuid")
+        val expectedResult = createObjectWrapper(url = expectedUrl, uuid = objectUuid)
+        whenever(objectenApiPlugin.getObject(expectedUrl)).thenReturn(expectedResult)
+        whenever(objectenApiPlugin.getObjectUrl(any())).thenCallRealMethod()
+
+        var outboxWasSuppressed = false
+        whenever(objectenApiPlugin.getObject(expectedUrl)).thenAnswer {
+            outboxWasSuppressed = OutboxContext.outboxSuppressed
+            expectedResult
+        }
+
+        objectManagementFacade.getObjectByUuid(objectName, objectUuid)
+
+        assertThat(outboxWasSuppressed).isTrue()
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+    }
+
+    @Test
+    fun `should not suppress outbox when suppressOutbox is false`() {
+        val objectName = "myObject"
+        val objectUuid = UUID.randomUUID()
+
+        val objectenApiPlugin = mock<ObjectenApiPlugin>()
+        val objecttypenApiPlugin = mock<ObjecttypenApiPlugin>()
+        prepareAccessObject(objectName, objectenApiPlugin, objecttypenApiPlugin, suppressOutbox = false)
+
+        whenever(objectenApiPlugin.url).thenReturn(URI.create("www.ritense.com"))
+        val expectedUrl = URI.create("www.ritense.com/objects/$objectUuid")
+        val expectedResult = createObjectWrapper(url = expectedUrl, uuid = objectUuid)
+        whenever(objectenApiPlugin.getObjectUrl(any())).thenCallRealMethod()
+
+        var outboxWasSuppressed = false
+        whenever(objectenApiPlugin.getObject(expectedUrl)).thenAnswer {
+            outboxWasSuppressed = OutboxContext.outboxSuppressed
+            expectedResult
+        }
+
+        objectManagementFacade.getObjectByUuid(objectName, objectUuid)
+
+        assertThat(outboxWasSuppressed).isFalse()
+    }
 }

--- a/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceTest.kt
+++ b/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.objectmanagement.service
+
+import com.ritense.objectenapi.ObjectenApiPlugin
+import com.ritense.objectenapi.client.ObjectsList
+import com.ritense.objectmanagement.domain.ObjectManagement
+import com.ritense.objectmanagement.repository.ObjectManagementRepository
+import com.ritense.objecttypenapi.ObjecttypenApiPlugin
+import com.ritense.outbox.OutboxContext
+import com.ritense.plugin.domain.PluginConfigurationId
+import com.ritense.plugin.service.PluginService
+import com.ritense.search.service.SearchFieldV2Service
+import com.ritense.search.service.SearchListColumnService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import java.net.URI
+import java.util.UUID
+
+internal class ObjectManagementServiceTest {
+
+    val objectManagementRepository = mock<ObjectManagementRepository>()
+    val pluginService = mock<PluginService>()
+    val searchFieldV2Service = mock<SearchFieldV2Service>()
+    val searchListColumnService = mock<SearchListColumnService>()
+
+    val objectManagementService = ObjectManagementService(
+        objectManagementRepository,
+        pluginService,
+        searchFieldV2Service,
+        searchListColumnService
+    )
+
+    lateinit var objectenApiPlugin: ObjectenApiPlugin
+    lateinit var objecttypenApiPlugin: ObjecttypenApiPlugin
+
+    @BeforeEach
+    fun setup() {
+        objectenApiPlugin = mock()
+        objecttypenApiPlugin = mock()
+    }
+
+    @Test
+    fun `getObjects should suppress outbox when suppressOutbox is true`() {
+        val objectManagement = createObjectManagement(suppressOutbox = true)
+        preparePlugins(objectManagement)
+        prepareObjectsList()
+
+        var outboxWasSuppressed = false
+        whenever(objectenApiPlugin.getObjectsByObjectTypeId(any(), any(), any(), any(), any())).thenAnswer {
+            outboxWasSuppressed = OutboxContext.outboxSuppressed
+            ObjectsList(count = 0, results = emptyList())
+        }
+
+        objectManagementService.getObjects(objectManagement.id, PageRequest.of(0, 10))
+
+        assertThat(outboxWasSuppressed).isTrue()
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+    }
+
+    @Test
+    fun `getObjects should not suppress outbox when suppressOutbox is false`() {
+        val objectManagement = createObjectManagement(suppressOutbox = false)
+        preparePlugins(objectManagement)
+        prepareObjectsList()
+
+        var outboxWasSuppressed = false
+        whenever(objectenApiPlugin.getObjectsByObjectTypeId(any(), any(), any(), any(), any())).thenAnswer {
+            outboxWasSuppressed = OutboxContext.outboxSuppressed
+            ObjectsList(count = 0, results = emptyList())
+        }
+
+        objectManagementService.getObjects(objectManagement.id, PageRequest.of(0, 10))
+
+        assertThat(outboxWasSuppressed).isFalse()
+    }
+
+    @Test
+    fun `getObjectsWithSearchParams should suppress outbox when suppressOutbox is true`() {
+        val objectManagement = createObjectManagement(suppressOutbox = true)
+        preparePlugins(objectManagement)
+
+        var outboxWasSuppressed = false
+        whenever(objectenApiPlugin.getObjectsByObjectTypeIdWithSearchParams(any(), any(), any(), any(), any())).thenAnswer {
+            outboxWasSuppressed = OutboxContext.outboxSuppressed
+            ObjectsList(count = 0, results = emptyList())
+        }
+
+        objectManagementService.getObjectsWithSearchParams(objectManagement, emptyList(), PageRequest.of(0, 10))
+
+        assertThat(outboxWasSuppressed).isTrue()
+        assertThat(OutboxContext.outboxSuppressed).isFalse()
+    }
+
+    @Test
+    fun `getObjectsWithSearchParams should not suppress outbox when suppressOutbox is false`() {
+        val objectManagement = createObjectManagement(suppressOutbox = false)
+        preparePlugins(objectManagement)
+
+        var outboxWasSuppressed = false
+        whenever(objectenApiPlugin.getObjectsByObjectTypeIdWithSearchParams(any(), any(), any(), any(), any())).thenAnswer {
+            outboxWasSuppressed = OutboxContext.outboxSuppressed
+            ObjectsList(count = 0, results = emptyList())
+        }
+
+        objectManagementService.getObjectsWithSearchParams(objectManagement, emptyList(), PageRequest.of(0, 10))
+
+        assertThat(outboxWasSuppressed).isFalse()
+    }
+
+    private fun createObjectManagement(suppressOutbox: Boolean = false): ObjectManagement {
+        val objectManagement = ObjectManagement(
+            objecttypeId = "objectTypeId",
+            title = "myTitle",
+            objectenApiPluginConfigurationId = UUID.randomUUID(),
+            objecttypenApiPluginConfigurationId = UUID.randomUUID(),
+            suppressOutbox = suppressOutbox
+        )
+        whenever(objectManagementRepository.findById(objectManagement.id)).thenReturn(java.util.Optional.of(objectManagement))
+        return objectManagement
+    }
+
+    private fun preparePlugins(objectManagement: ObjectManagement) {
+        whenever(pluginService.createInstance(PluginConfigurationId.existingId(objectManagement.objectenApiPluginConfigurationId)))
+            .thenReturn(objectenApiPlugin)
+        whenever(pluginService.createInstance(PluginConfigurationId.existingId(objectManagement.objecttypenApiPluginConfigurationId)))
+            .thenReturn(objecttypenApiPlugin)
+        whenever(objecttypenApiPlugin.url).thenReturn(URI.create("http://objecttypen.example.com"))
+        whenever(objectenApiPlugin.url).thenReturn(URI.create("http://objecten.example.com"))
+    }
+
+    private fun prepareObjectsList() {
+        whenever(objectenApiPlugin.getObjectsByObjectTypeId(any(), any(), any(), any(), any())).thenReturn(
+            ObjectsList(count = 0, results = emptyList())
+        )
+    }
+}

--- a/backend/zgw/object-management/src/test/resources/config/objectmanagement/my-config.json
+++ b/backend/zgw/object-management/src/test/resources/config/objectmanagement/my-config.json
@@ -6,5 +6,6 @@
     "objectenApiPluginConfigurationId": "8f35c270-21f4-4e99-a8a1-6c4f9d5a6c5c",
     "showInDataMenu": true,
     "formDefinitionView": "view_form",
-    "formDefinitionEdit": "edit_form"
+    "formDefinitionEdit": "edit_form",
+    "suppressOutbox": false
 }

--- a/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/management/ObjectManagementInfo.kt
+++ b/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/management/ObjectManagementInfo.kt
@@ -28,4 +28,5 @@ interface ObjectManagementInfo {
     val showInDataMenu: Boolean
     val formDefinitionView: String?
     val formDefinitionEdit: String?
+    val suppressOutbox: Boolean
 }

--- a/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/service/ZaakObjectService.kt
+++ b/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/service/ZaakObjectService.kt
@@ -30,6 +30,8 @@ import com.ritense.objectenapi.management.ObjectManagementInfoProvider
 import com.ritense.objectenapi.web.rest.result.FormType
 import com.ritense.objecttypenapi.ObjecttypenApiPlugin
 import com.ritense.objecttypenapi.client.Objecttype
+import com.ritense.outbox.OutboxContext
+import com.ritense.outbox.OutboxContext.Companion.runWithSuppressedOutbox
 import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.service.PluginService
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
@@ -191,7 +193,9 @@ class ZaakObjectService(
             pluginService.createInstance(PluginConfigurationId(objectManagement.objectenApiPluginConfigurationId)) as ObjectenApiPlugin
         val objectUrl = objectsApiPlugin.getObjectUrl(objectId)
         logger.debug { "Getting object for url $objectUrl" }
-        return objectsApiPlugin.getObject(objectUrl)
+        return runWithSuppressedOutbox(objectManagement.suppressOutbox) {
+            objectsApiPlugin.getObject(objectUrl)
+        }
     }
 
     private fun findZakenApiPlugin(zaakUrl: URI): ZakenApiPlugin {

--- a/backend/zgw/src/main/kotlin/com/ritense/zgw/Rsin.kt
+++ b/backend/zgw/src/main/kotlin/com/ritense/zgw/Rsin.kt
@@ -26,7 +26,7 @@ data class Rsin(private val value: String) {
     companion object {
         @JvmStatic
         @JsonCreator
-        fun create(value: String) = value
+        fun create(value: String) = Rsin(value)
     }
 
     @JsonValue

--- a/backend/zgw/zaakdetails/src/test/kotlin/com/ritense/zaakdetails/mock/MockObjectManagement.kt
+++ b/backend/zgw/zaakdetails/src/test/kotlin/com/ritense/zaakdetails/mock/MockObjectManagement.kt
@@ -28,5 +28,6 @@ class MockObjectManagement(
     override val objectenApiPluginConfigurationId: UUID = UUID.randomUUID(),
     override val showInDataMenu: Boolean = false,
     override val formDefinitionView: String? = null,
-    override val formDefinitionEdit: String? = null
+    override val formDefinitionEdit: String? = null,
+    override val suppressOutbox: Boolean = false
 ) : ObjectManagementInfo

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/domain/BetalingsindicatieTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/domain/BetalingsindicatieTest.kt
@@ -29,14 +29,14 @@ class BetalingsindicatieTest {
 
     @Test
     fun `should deserialize to null when empty`() {
-        val result: Betalingsindicatie = objectMapper.treeToValue(TextNode(""))
+        val result: Betalingsindicatie? = objectMapper.treeToValue(TextNode(""))
 
         assertNull(result)
     }
 
     @Test
     fun `should deserialize to null when value does not exist`() {
-        val result: Betalingsindicatie = objectMapper.treeToValue(TextNode("invalid key"))
+        val result: Betalingsindicatie? = objectMapper.treeToValue(TextNode("invalid key"))
 
         assertNull(result)
     }

--- a/documentation/features/outbox/for-developers.md
+++ b/documentation/features/outbox/for-developers.md
@@ -51,6 +51,40 @@ When delivery fails or acknowledgement takes too long, a `MessagePublishingFaile
 
 When delivery is successful (no exceptions are thrown), the outbox message will be deleted from the outbox table automatically.
 
+#### Batch publishing
+
+The `MessagePublisher` interface also provides a `publishBatch` method that receives a list of messages and returns per-message results. The default implementation calls `publish()` for each message individually, catching exceptions per message.
+
+Publishers that support native batch operations (e.g. sending multiple messages in a single HTTP POST or pipelining broker confirms) can override `publishBatch` for improved throughput:
+
+```kotlin
+class CustomBatchMessagePublisher : MessagePublisher {
+
+    override fun publish(message: OutboxMessage) {
+        val result = publishBatch(listOf(message)).first()
+        if (!result.success) {
+            throw result.error ?: MessagePublishingFailed("Failed to publish message ${message.id}")
+        }
+    }
+
+    override fun publishBatch(messages: List<OutboxMessage>): List<MessagePublishResult> {
+        // Send all messages in a single batch operation
+        val response = batchSend(messages)
+
+        // Return per-message results
+        return messages.zip(response.results).map { (message, result) ->
+            MessagePublishResult(
+                messageId = message.id,
+                success = result.isSuccess,
+                error = result.error
+            )
+        }
+    }
+}
+```
+
+Successfully published messages are deleted from the outbox. Failed messages remain in the outbox table and will be retried in the next poll cycle.
+
 #### Bean configuration
 
 The custom message publisher should be configured as a Bean in the Spring application.

--- a/documentation/fundamentals/getting-started/modules/core/outbox/README.md
+++ b/documentation/fundamentals/getting-started/modules/core/outbox/README.md
@@ -39,7 +39,16 @@ The outbox can be configured to better match the environment:
 valtimo:
   outbox:
     publisher:
-      polling.rate: "PT1M" # ISO 8601 duration format
+      polling:
+        rate: "PT1M" # ISO 8601 duration format. Default: PT10S
+        batch-size: 10 # Number of messages to fetch and publish per poll cycle
+        circuit-breaker:
+          enabled: true # Enable/disable the circuit breaker
+          failure-rate-threshold: 50 # Percentage of failures that triggers the circuit to open
+          minimum-number-of-calls: 5 # Minimum calls before failure rate is evaluated
+          sliding-window-size: 10 # Number of calls tracked for failure rate calculation
+          wait-duration-in-open-state-seconds: 60 # How long the circuit stays open
+          permitted-number-of-calls-in-half-open-state: 3 # Test calls allowed in half-open state
 ```
 
 ### Disabling the outbox

--- a/documentation/fundamentals/getting-started/modules/zgw/object-management.md
+++ b/documentation/fundamentals/getting-started/modules/zgw/object-management.md
@@ -106,3 +106,20 @@ The object-management routing needs to be added to the menu in the environment f
   ]
 }
 ```
+
+## Suppressing the outbox
+
+Object management configurations support a `suppressOutbox` property that prevents outbox messages from being created
+during object API calls. This is useful for read-heavy integrations where outbox overhead is unnecessary.
+
+Set `suppressOutbox` to `true` in the object management JSON configuration:
+
+```json
+{
+    "title": "my-objects",
+    "objectenApiPluginConfigurationId": "...",
+    "objecttypenApiPluginConfigurationId": "...",
+    "objecttypeId": "...",
+    "suppressOutbox": true
+}
+```

--- a/documentation/release-notes/12.x.x/12.29.0/README.md
+++ b/documentation/release-notes/12.x.x/12.29.0/README.md
@@ -2,9 +2,15 @@
 
 ## New Features
 
-* **New feature title**
+* **Batched outbox publishing** — Messages are now fetched and published in configurable batches, improving throughput.
 
-  New feature explanation.
+* **Outbox circuit breaker** — Automatically stops polling when the message broker is unavailable and resumes once connectivity is restored.
+
+* **Outbox health indicator** — Exposes outbox publisher status via `/actuator/health`.
+
+* **Suppress outbox for Object Management** — A `suppressOutbox` property can be set on object management configurations to skip outbox writes for read-heavy integrations.
+
+* **Pipelined RabbitMQ confirms** — The RabbitMQ publisher now sends all confirmations in parallel instead of one-by-one.
 
 ## Enhancements
 
@@ -14,4 +20,13 @@
 
 ## Bugfixes
 
-* New bugfix.
+* Fixed MySQL outbox message query missing ordering.
+* Fixed RabbitMQ outbox publisher null safety on confirmation result.
+
+## Deprecations
+
+The following will be removed in 14.0:
+
+* `OutboxMessageRepository.findOutboxMessage()` — use `findOutboxMessages(batchSize)`
+* `ValtimoOutboxService.getOldestMessage()` — use `getOldestMessages(batchSize)`
+* `ValtimoOutboxService.deleteMessage(id)` — use `deleteMessages(ids)`

--- a/frontend/projects/valtimo/config/assets/core/en.json
+++ b/frontend/projects/valtimo/config/assets/core/en.json
@@ -1838,7 +1838,7 @@
       "formDefinitionView": "The name of the form IO definition that will be used to display the object.",
       "formDefinitionEdit": "The name of the form IO definition that will be used to edit the object.",
       "showInDataMenu": "Indicates whether the object type is visible in the menu",
-      "suppressOutbox": "When enabled, read flows this objecttype skip outbox message creation."
+      "suppressOutbox": "When enabled, read flows for this object type skip outbox message creation."
     },
     "cancel": "Cancel",
     "add": "Add object",

--- a/frontend/projects/valtimo/config/assets/core/en.json
+++ b/frontend/projects/valtimo/config/assets/core/en.json
@@ -1828,7 +1828,8 @@
       "objecttypeVersion": "Objecttype version",
       "formDefinitionView": "View form definition",
       "formDefinitionEdit": "Edit form definition",
-      "showInDataMenu": "Show in menu"
+      "showInDataMenu": "Show in menu",
+      "suppressOutbox": "Suppress outbox"
     },
     "tooltips": {
       "title": "The name of this configuration. Under this name, this configuration can be found in the rest of the application.",
@@ -1836,7 +1837,8 @@
       "objecttypeVersion": "The version of the object type",
       "formDefinitionView": "The name of the form IO definition that will be used to display the object.",
       "formDefinitionEdit": "The name of the form IO definition that will be used to edit the object.",
-      "showInDataMenu": "Indicates whether the object type is visible in the menu"
+      "showInDataMenu": "Indicates whether the object type is visible in the menu",
+      "suppressOutbox": "When enabled, read flows this objecttype skip outbox message creation."
     },
     "cancel": "Cancel",
     "add": "Add object",

--- a/frontend/projects/valtimo/config/assets/core/nl.json
+++ b/frontend/projects/valtimo/config/assets/core/nl.json
@@ -1826,7 +1826,8 @@
       "objecttypeVersion": "Objecttype versie",
       "formDefinitionView": "View formulier definitie",
       "formDefinitionEdit": "Wijzig formulier definitie",
-      "showInDataMenu": "Toon in menu"
+      "showInDataMenu": "Toon in menu",
+      "suppressOutbox": "Outbox onderdrukken"
     },
     "tooltips": {
       "title": "De naam van deze configuratie. Onder deze naam is deze configuratie terug te vinden in de rest van de applicatie.",
@@ -1834,7 +1835,8 @@
       "objecttypeVersion": "De versie van het objecttype",
       "formDefinitionView": "De naam van de formio IO definitie die wordt gebruikt om het object weer te geven.",
       "formDefinitionEdit": "De naam van de formio IO definitie die wordt gebruikt om het object te bewerken.",
-      "showInDataMenu": "Geeft aan of het objecttype in het menu zichtbaar is"
+      "showInDataMenu": "Geeft aan of het objecttype in het menu zichtbaar is",
+      "suppressOutbox": "Wanneer ingeschakeld, wordt de outbox-flow overgeslagen bij leesacties voor dit objecttype."
     },
     "cancel": "Annuleren",
     "add": "Object toevoegen",

--- a/frontend/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.html
+++ b/frontend/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.html
@@ -162,6 +162,15 @@
         name="showInDataMenu"
         [defaultValue]="prefillObject?.showInDataMenu"
       ></v-input>
+
+      <v-input
+        [margin]="true"
+        type="checkbox"
+        [title]="'objectManagement.labels.suppressOutbox' | translate"
+        [tooltip]="'objectManagement.tooltips.suppressOutbox' | translate"
+        name="suppressOutbox"
+        [defaultValue]="prefillObject?.suppressOutbox"
+      ></v-input>
     </v-form>
   </ng-container>
 </ng-template>

--- a/frontend/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.ts
+++ b/frontend/projects/valtimo/object-management/src/lib/components/object-management-modal/object-management-modal.component.ts
@@ -157,6 +157,9 @@ export class ObjectManagementModalComponent implements AfterViewInit, OnDestroy 
     if (data.showInDataMenu === '') {
       data.showInDataMenu = false;
     }
+    if (data.suppressOutbox === '') {
+      data.suppressOutbox = false;
+    }
     this.formData$.next(data);
     this.setValid(data);
   }

--- a/frontend/projects/valtimo/object-management/src/lib/models/object-management.model.ts
+++ b/frontend/projects/valtimo/object-management/src/lib/models/object-management.model.ts
@@ -24,6 +24,7 @@ interface Objecttype {
   showInDataMenu: boolean;
   formDefinitionView?: string;
   formDefinitionEdit?: string;
+  suppressOutbox?: boolean;
 }
 
 export interface SearchListColumn {

--- a/gradle.properties
+++ b/gradle.properties
@@ -85,6 +85,7 @@ kotestVersion=5.9.1
 shedlockVersion=6.4.0
 jsonassertVersion=1.5.3
 cloudEventsCoreVersion=4.0.1
+resilience4jVersion=2.4.0
 semver4jVersion=5.6.0
 
 # project version


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/372


Refactors the outbox module to support batch publishing for improved throughput and adds a Resilience4j circuit breaker for graceful degradation during broker outages. Also optimizes the insert side by batching deferred messages in read-only transactions, and adds the ability to suppress outbox publishing per ObjectManagement configuration.

Key changes:

**Insert-side optimization:**
- Batch deferred outbox messages in read-only transactions into a single `REQUIRES_NEW` transaction instead of opening a separate transaction per message. Messages are collected as a transaction-bound resource via `TransactionSynchronizationManager` and persisted together in `beforeCommit` using `saveAll()`.

**Publish-side optimization:**
- Add `publishBatch` default method to `MessagePublisher` interface with per-message `MessagePublishResult` tracking
- Refactor `PollingPublisherService` to fetch and publish messages in configurable batches (default: 10)
- Add Resilience4j circuit breaker with per-message success/failure recording, HALF_OPEN batch size reduction to 1, and mid-loop state checking
- Override `publishBatch` in `RabbitMessagePublisher` with pipelined confirms via `CompletableFuture.allOf()` for parallel confirmation collection
- Add `OutboxPublisherHealthIndicator` exposing circuit breaker state via actuator health endpoint

**Suppress outbox per ObjectManagement configuration:**
- Add `OutboxContext` with `runWithSuppressedOutbox` to conditionally suppress outbox message publishing within a block (similar to `AuthorizationContext.runWithoutAuthorization`)
- Add `suppressOutbox` boolean field to `ObjectManagement` entity with Liquibase migration (default: `false`)
- Wrap read/query plugin calls in `ObjectManagementService` and `ObjectManagementFacade` with `runWithSuppressedOutbox` based on the configuration
- `ValtimoOutboxService.send()` skips message persistence when the outbox is suppressed
- Nested suppress blocks are safe: inner blocks are a no-op when the outbox is already suppressed by a parent call

**Bug fixes and improvements:**
- Fix MySQL `findOutboxMessage` missing `ORDER BY created_on ASC`
- Fix `RabbitMessagePublisher` null safety on correlation result
- Fix `OutboxLiquibaseRunner` deprecated SLF4J method signatures
- Simplify `UserProvider` to idiomatic Kotlin
- Add `@Transactional(MANDATORY)` to get/delete methods on `ValtimoOutboxService`
- Deprecate single-message methods in favor of batch equivalents
- Add `testLogging` to `integrationTestingPostgresql`, `integrationTestingMysql`, and `securityTesting` Gradle tasks for per-test result reporting

Specify the code branch location: `backend/outbox/`, `backend/outbox/outbox-rabbitmq/`, `backend/zgw/object-management/`, `backend/core/src/main/resources/config/liquibase/13-21-0/`, and `backend/gradle/test.gradle`

**Relevant comments:**
> This change is backwards-compatible. Existing `MessagePublisher` implementations inherit the default `publishBatch` method without changes. A secondary constructor on `PollingPublisherService` preserves the original 3-parameter signature. The batch publishing support is needed for a future OTLP HTTP publisher where the protocol natively expects batched exports.

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes

### Tests
Unit tests have been added that cover these changes
- [x] Yes

Integration tests have been added that cover these changes
- [x] Yes

Describe the testing steps
- [x] Run `./gradlew :backend:outbox:test` - unit tests pass (including OutboxContext and suppressed outbox tests)
- [x] Run `./gradlew :backend:outbox:integrationTestingPostgresql` - integration tests with PostgreSQL (including new batch deferred messages test)
- [x] Run `./gradlew :backend:outbox:integrationTestingMysql` - integration tests with MySQL
- [x] Run `./gradlew :backend:outbox:outbox-rabbitmq:test` - RabbitMQ unit tests pass
- [x] Run `./gradlew :backend:zgw:object-management:test` - ObjectManagementFacadeTest and ObjectManagementServiceTest pass (including suppressOutbox tests)
- [x] Verify `RabbitMessagePublisher` and `LoggingMessagePublisher` compile without changes

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes

Added or changed REST API endpoints have authentication and authorization in place
- [x] Not applicable

Valtimo access control checks have been implemented
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [x] Yes

> Added `io.github.resilience4j:resilience4j-circuitbreaker:2.2.0` (Apache 2.0 license). Added `spring-boot-starter-actuator` as `compileOnly` for the health indicator (only active when already on the classpath). Added `backend:outbox` as dependency to `backend:zgw:object-management` for `OutboxContext` usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batched outbox message publishing with configurable batch sizes for improved throughput
  * Introduced outbox circuit breaker to automatically pause publishing when the message broker is unavailable
  * Added outbox health indicator exposed via Spring Boot Actuator health endpoint
  * Added support for suppressing outbox writes during object management read operations

* **Bug Fixes**
  * Fixed message ordering in database queries for consistent FIFO behavior
  * Improved null-safety in message publisher result handling

* **Documentation**
  * Updated configuration documentation with new batch size and circuit breaker settings
  * Added guidance for outbox suppression in object management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->