### PR TITLE
Making it possible to store process variables with String values that have more that 4000 characters.

### DIFF
--- a/backend/core/src/main/java/com/ritense/valtimo/service/util/FormUtils.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/service/util/FormUtils.java
@@ -54,6 +54,8 @@ public class FormUtils {
         }
     }
 
+    private static final int MAX_STRING_LENGTH = 4000;
+
     public static VariableMap createTypedVariableMap(Map<String, Object> variables) {
         if (variables == null) {
             return Variables.createVariables();
@@ -70,6 +72,10 @@ public class FormUtils {
                 variableMap.putValueTyped(key, Variables.dateValue((Date) value));
             } else if (value instanceof ObjectValue) {
                 variableMap.putValueTyped(key, Variables.objectValue(value).create());
+            } else if (value instanceof String && ((String) value).length() > MAX_STRING_LENGTH) {
+                variableMap.putValueTyped(key, Variables.objectValue(value)
+                    .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
+                    .create());
             } else {
                 variableMap.putValue(key, value);
             }

--- a/backend/core/src/main/java/com/ritense/valtimo/service/util/FormUtils.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/service/util/FormUtils.java
@@ -54,6 +54,7 @@ public class FormUtils {
         }
     }
 
+    // The text column in the Operaton variables table is of type varchar(4000)
     private static final int MAX_STRING_LENGTH = 4000;
 
     public static VariableMap createTypedVariableMap(Map<String, Object> variables) {

--- a/backend/core/src/test/java/com/ritense/valtimo/service/util/FormUtilsTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/service/util/FormUtilsTest.java
@@ -16,14 +16,14 @@
 
 package com.ritense.valtimo.service.util;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.CombinableMatcher.both;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import org.operaton.bpm.engine.variable.VariableMap;
-import org.hamcrest.collection.IsMapContaining;
+import org.operaton.bpm.engine.variable.value.ObjectValue;
+import org.operaton.bpm.engine.variable.value.TypedValue;
 import org.junit.jupiter.api.Test;
 
 class FormUtilsTest {
@@ -39,8 +39,59 @@ class FormUtilsTest {
 
         VariableMap typedVariableMap = FormUtils.createTypedVariableMap(variables);
 
-        assertThat(typedVariableMap, both(IsMapContaining.hasKey("leeftijd")).and(IsMapContaining.hasValue(LONG_VALUE)));
-        assertThat(typedVariableMap, both(IsMapContaining.hasKey("huidige_tijd")).and(IsMapContaining.hasValue(DATE_VALUE)));
+        assertThat(typedVariableMap).containsEntry("leeftijd", LONG_VALUE);
+        assertThat(typedVariableMap).containsEntry("huidige_tijd", DATE_VALUE);
+    }
+
+    @Test
+    void createTypedVariableMapShouldNotStoreShortStringAsObjectValue() {
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("shortText", "hello");
+
+        VariableMap typedVariableMap = FormUtils.createTypedVariableMap(variables);
+
+        TypedValue typedValue = typedVariableMap.getValueTyped("shortText");
+        assertThat(typedValue).isNotInstanceOf(ObjectValue.class);
+        assertThat(typedValue.getValue()).isEqualTo("hello");
+    }
+
+    @Test
+    void createTypedVariableMapShouldStoreLongStringAsObjectValue() {
+        String longString = "a".repeat(4001);
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("longText", longString);
+
+        VariableMap typedVariableMap = FormUtils.createTypedVariableMap(variables);
+
+        TypedValue typedValue = typedVariableMap.getValueTyped("longText");
+        assertThat(typedValue).isInstanceOf(ObjectValue.class);
+        assertThat(typedValue.getValue()).isEqualTo(longString);
+    }
+
+    @Test
+    void createTypedVariableMapShouldNotStoreStringAtExactLimitAsObjectValue() {
+        String exactLimitString = "a".repeat(4000);
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("exactLimit", exactLimitString);
+
+        VariableMap typedVariableMap = FormUtils.createTypedVariableMap(variables);
+
+        TypedValue typedValue = typedVariableMap.getValueTyped("exactLimit");
+        assertThat(typedValue).isNotInstanceOf(ObjectValue.class);
+        assertThat(typedValue.getValue()).isEqualTo(exactLimitString);
+    }
+
+    @Test
+    void createTypedVariableMapShouldStoreStringJustOverLimitAsObjectValue() {
+        String overLimitString = "a".repeat(4001);
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("overLimit", overLimitString);
+
+        VariableMap typedVariableMap = FormUtils.createTypedVariableMap(variables);
+
+        TypedValue typedValue = typedVariableMap.getValueTyped("overLimit");
+        assertThat(typedValue).isInstanceOf(ObjectValue.class);
+        assertThat(typedValue.getValue()).isEqualTo(overLimitString);
     }
 
 }

--- a/documentation/release-notes/13.x.x/13.22.0/README.md
+++ b/documentation/release-notes/13.x.x/13.22.0/README.md
@@ -29,7 +29,6 @@
 * Fixed sensitive data logging in inbox messages and null safety issues in SSE event mappers.
 * Fixed MySQL outbox message query missing ordering.
 * Fixed RabbitMQ outbox publisher null safety on confirmation result.
-* Fixed storage of strings exceeding 4000 characters in Operaton process variables. Long strings are now serialized as Java objects to bypass the database column size limit, and are deserialized back to strings transparently.
 
 ## Deprecations
 

--- a/documentation/release-notes/13.x.x/13.22.0/README.md
+++ b/documentation/release-notes/13.x.x/13.22.0/README.md
@@ -29,6 +29,7 @@
 * Fixed sensitive data logging in inbox messages and null safety issues in SSE event mappers.
 * Fixed MySQL outbox message query missing ordering.
 * Fixed RabbitMQ outbox publisher null safety on confirmation result.
+* Fixed storage of strings exceeding 4000 characters in Operaton process variables. Long strings are now serialized as Java objects to bypass the database column size limit, and are deserialized back to strings transparently.
 
 ## Deprecations
 

--- a/documentation/release-notes/13.x.x/13.23.0/README.md
+++ b/documentation/release-notes/13.x.x/13.23.0/README.md
@@ -12,9 +12,8 @@
 
 ## Enhancements
 
-* **New enhancement title**
-
-  New enhancement explanation.
+* **Introduced support of strings exceeding 4000 characters in Operaton process variables**  
+  Long strings are now serialized as Java objects to bypass the database column size limit, and are deserialized back to strings transparently.
 
 ## Bugfixes
 

--- a/documentation/release-notes/13.x.x/13.23.0/README.md
+++ b/documentation/release-notes/13.x.x/13.23.0/README.md
@@ -12,7 +12,7 @@
 
 ## Enhancements
 
-* **Introduced support of strings exceeding 4000 characters in Operaton process variables**  
+* **Introduced support for strings exceeding 4000 characters in Operaton process variables**  
   Long strings are now serialized as Java objects to bypass the database column size limit, and are deserialized back to strings transparently.
 
 ## Bugfixes


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/590

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Try to complete a task via the endpoint /v1/process-document/operation/modify-document-and-complete-task
- [ ] Make sure one of the variables contains a string of more than 4000 characters.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
