### PR TITLE
Backporting the fix for deserialization of beginRegistratie

### DIFF
--- a/backend/contract/src/main/kotlin/com/ritense/valtimo/contract/json/Iso8601Deserializer.kt
+++ b/backend/contract/src/main/kotlin/com/ritense/valtimo/contract/json/Iso8601Deserializer.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.contract.json
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import java.io.IOException
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeParseException
+
+class Iso8601Deserializer : StdDeserializer<OffsetDateTime?>(OffsetDateTime::class.java) {
+
+    @Throws(IOException::class)
+    override fun deserialize(p: JsonParser, ctx: DeserializationContext?): OffsetDateTime? {
+        val value = p.text?.trim()
+
+        if (value.isNullOrBlank()) {
+            return null
+        }
+
+        try {
+            // "2026-03-23T14:37:41+01:00" or "2026-03-23T14:37:41Z"
+            return OffsetDateTime.parse(value)
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        try {
+            // "2026-03-23T14:37:41+01:00[Europe/Amsterdam]"
+            return ZonedDateTime.parse(value).toOffsetDateTime()
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        try {
+            // "2026-03-23T14:37:41Z"
+            return Instant.parse(value).atOffset(ZoneOffset.UTC)
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        try {
+            // "2026-03-23T14:37:41"
+            return LocalDateTime.parse(value).atOffset(ZoneOffset.UTC)
+        } catch (ignored: DateTimeParseException) {
+        }
+
+        error("Failed to parse ISO 8601 datetime: '$value'")
+    }
+}

--- a/backend/contract/src/test/kotlin/com/ritense/valtimo/contract/json/Iso8601DeserializerTest.kt
+++ b/backend/contract/src/test/kotlin/com/ritense/valtimo/contract/json/Iso8601DeserializerTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.contract.json
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class Iso8601DeserializerTest {
+
+    private val objectMapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+
+    @Test
+    fun `should deserialize offset datetime`() {
+        val json = """{"value": "2026-03-23T14:37:41+01:00"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.value)
+    }
+
+    @Test
+    fun `should deserialize UTC datetime with Z suffix`() {
+        val json = """{"value": "2026-03-23T14:37:41Z"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.UTC), result.value)
+    }
+
+    @Test
+    fun `should deserialize zoned datetime`() {
+        val json = """{"value": "2026-03-23T14:37:41+01:00[Europe/Amsterdam]"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.value)
+    }
+
+    @Test
+    fun `should deserialize local datetime as UTC`() {
+        val json = """{"value": "2026-03-23T14:37:41"}"""
+
+        val result = objectMapper.readValue<TestDto>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.UTC), result.value)
+    }
+
+    @Test
+    fun `should return null for null value`() {
+        val json = """{"value": null}"""
+
+        val result = objectMapper.readValue<NullableTestDto>(json)
+
+        assertEquals(null, result.value)
+    }
+
+    @Test
+    fun `should return null for blank value`() {
+        val json = """{"value": "  "}"""
+
+        val result = objectMapper.readValue<NullableTestDto>(json)
+
+        assertEquals(null, result.value)
+    }
+
+    @Test
+    fun `should throw error for invalid datetime`() {
+        val json = """{"value": "not-a-date"}"""
+
+        assertThrows<Exception> {
+            objectMapper.readValue<TestDto>(json)
+        }
+    }
+
+    private data class TestDto(
+        @JsonDeserialize(using = Iso8601Deserializer::class)
+        val value: OffsetDateTime
+    )
+
+    private data class NullableTestDto(
+        @JsonDeserialize(using = Iso8601Deserializer::class)
+        val value: OffsetDateTime?
+    )
+}

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -375,7 +375,7 @@ class DocumentenApiPlugin(
             documentCreateResult.auteur,
             documentCreateResult.bestandsnaam,
             documentCreateResult.bestandsomvang,
-            documentCreateResult.beginRegistratie
+            documentCreateResult.beginRegistratie.toLocalDateTime()
         )
         applicationEventPublisher.publishEvent(event)
         execution.setVariable(storedDocumentKey, documentCreateResult.url)

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentResult.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentResult.kt
@@ -16,14 +16,17 @@
 
 package com.ritense.documentenapi.client
 
-import java.time.LocalDateTime
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.ritense.valtimo.contract.json.Iso8601Deserializer
+import java.time.OffsetDateTime
 
 class CreateDocumentResult(
     val url: String,
     val auteur: String,
     val bestandsnaam: String,
     val bestandsomvang: Long,
-    val beginRegistratie: LocalDateTime,
+    @JsonDeserialize(using = Iso8601Deserializer::class)
+    val beginRegistratie: OffsetDateTime,
     val bestandsdelen: List<Bestandsdeel>,
     val lock: String?
 ) {

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/DocumentInformatieObject.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/DocumentInformatieObject.kt
@@ -17,13 +17,15 @@
 package com.ritense.documentenapi.client
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.ritense.valtimo.contract.json.Iso8601Deserializer
 import com.ritense.zgw.Rsin
 import com.ritense.zgw.domain.Vertrouwelijkheid
 import java.net.URI
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
-class DocumentInformatieObject (
+class DocumentInformatieObject(
     val url: URI,
     val identificatie: String? = null,
     val bronorganisatie: Rsin,
@@ -36,8 +38,8 @@ class DocumentInformatieObject (
     val formaat: String? = null,
     val taal: String,
     val versie: Int? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
-    val beginRegistratie: LocalDateTime,
+    @JsonDeserialize(using = Iso8601Deserializer::class)
+    val beginRegistratie: OffsetDateTime,
     val bestandsnaam: String? = null,
     val bestandsomvang: Long? = null,
     val link: URI? = null,

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -54,6 +54,7 @@ import java.io.ByteArrayInputStream
 import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -143,7 +144,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.of(2020, 1, 1, 1, 1, 1),
+            OffsetDateTime.parse("2020-01-01T01:01:01Z"),
             listOf(),
             null
         )
@@ -236,7 +237,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )
@@ -328,7 +329,7 @@ internal class DocumentenApiPluginTest {
             "returnedAuthor",
             "returnedFileName",
             1L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )
@@ -466,7 +467,7 @@ internal class DocumentenApiPluginTest {
                 titel = "titel",
                 auteur = "auteur",
                 taal = "taal",
-                beginRegistratie = LocalDateTime.now(),
+                beginRegistratie = OffsetDateTime.now(),
                 status = DEFINITIEF
             )
         )

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,77 @@
 
 package com.ritense.documentenapi.client
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 internal class CreateDocumentResultTest {
+
+    private val objectMapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().build())
+        .registerModule(JavaTimeModule())
+
+    @Test
+    fun `should deserialize beginRegistratie with offset`() {
+        val json = """
+            {
+                "url": "https://www.example.com/847789d3-a8b3-469a-ae01-a49a6bd21783",
+                "auteur": "test",
+                "bestandsnaam": "test.txt",
+                "bestandsomvang": 123,
+                "beginRegistratie": "2026-03-23T14:37:41+01:00",
+                "bestandsdelen": [],
+                "lock": null
+            }
+        """.trimIndent()
+
+        val result = objectMapper.readValue<CreateDocumentResult>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.beginRegistratie)
+    }
+
+    @Test
+    fun `should deserialize beginRegistratie without offset`() {
+        val json = """
+            {
+                "url": "https://www.example.com/847789d3-a8b3-469a-ae01-a49a6bd21783",
+                "auteur": "test",
+                "bestandsnaam": "test.txt",
+                "bestandsomvang": 123,
+                "beginRegistratie": "2026-03-23T14:37:41",
+                "bestandsdelen": [],
+                "lock": null
+            }
+        """.trimIndent()
+
+        val result = objectMapper.readValue<CreateDocumentResult>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.UTC), result.beginRegistratie)
+    }
+
+    @Test
+    fun `should deserialize beginRegistratie with zoned datetime`() {
+        val json = """
+            {
+                "url": "https://www.example.com/847789d3-a8b3-469a-ae01-a49a6bd21783",
+                "auteur": "test",
+                "bestandsnaam": "test.txt",
+                "bestandsomvang": 123,
+                "beginRegistratie": "2026-03-23T14:37:41+01:00[Europe/Amsterdam]",
+                "bestandsdelen": [],
+                "lock": null
+            }
+        """.trimIndent()
+
+        val result = objectMapper.readValue<CreateDocumentResult>(json)
+
+        assertEquals(OffsetDateTime.of(2026, 3, 23, 14, 37, 41, 0, ZoneOffset.ofHours(1)), result.beginRegistratie)
+    }
 
     @Test
     fun `should get uuid from url`() {
@@ -29,7 +95,7 @@ internal class CreateDocumentResultTest {
             "",
             "",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )
@@ -51,7 +117,7 @@ internal class CreateDocumentResultTest {
             "",
             "",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(bestandsdeel),
             "847789d3-a8b3-469a-ae01-a49a6bd21783"
         )
@@ -66,7 +132,7 @@ internal class CreateDocumentResultTest {
             "",
             "",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             listOf(),
             null
         )

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
@@ -64,7 +64,7 @@ import reactor.core.publisher.Mono
 import java.io.InputStream
 import java.net.URI
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.function.Supplier
 import kotlin.test.assertEquals
@@ -207,7 +207,7 @@ DocumentenApiClientTest {
             "auteur",
             "bestandsnaam.jpg",
             0L,
-            LocalDateTime.now(),
+            OffsetDateTime.now(),
             bestandsdelen,
             "de9c883a-cdfc-493b-9c38-5824e334a1b1"
         )
@@ -403,7 +403,7 @@ DocumentenApiClientTest {
         assertEquals("formaat", result.formaat)
         assertEquals("nl", result.taal)
         assertEquals(4, result.versie)
-        assertEquals(LocalDateTime.of(2019, 8, 24, 14, 15, 22), result.beginRegistratie)
+        assertEquals(OffsetDateTime.parse("2019-08-24T14:15:22Z"), result.beginRegistratie)
         assertEquals("bestandsnaam", result.bestandsnaam)
         assertEquals(123, result.bestandsomvang)
         assertEquals(URI("http://example.com/link"), result.link)
@@ -765,7 +765,7 @@ DocumentenApiClientTest {
         assertEquals("formaat", result.formaat)
         assertEquals("nl", result.taal)
         assertEquals(4, result.versie)
-        assertEquals(LocalDateTime.of(2019, 8, 24, 14, 15, 22), result.beginRegistratie)
+        assertEquals(OffsetDateTime.parse("2019-08-24T14:15:22Z"), result.beginRegistratie)
         assertEquals("bestandsnaam", result.bestandsnaam)
         assertEquals(123, result.bestandsomvang)
         assertEquals(URI("http://example.com/link"), result.link)

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/service/DocumentenApiServiceTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/service/DocumentenApiServiceTest.kt
@@ -47,7 +47,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import java.net.URI
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class DocumentenApiServiceTest {
@@ -153,7 +153,7 @@ class DocumentenApiServiceTest {
         url = URI("http://localhost/informatieobjecttype/0e757153-fce3-44bc-a47f-494840784a16"),
         bronorganisatie = Rsin("404797441"),
         auteur = "y",
-        beginRegistratie = LocalDateTime.now(),
+        beginRegistratie = OffsetDateTime.now(),
         creatiedatum = LocalDate.now(),
         taal = "nl",
         titel = "titel",

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
@@ -54,6 +54,7 @@ import org.springframework.data.domain.Pageable
 import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ZaakDocumentServiceTest {
@@ -315,7 +316,7 @@ class ZaakDocumentServiceTest {
         url = uri,
         bronorganisatie = Rsin("404797441"),
         auteur = "y",
-        beginRegistratie = LocalDateTime.now(),
+        beginRegistratie = OffsetDateTime.now(),
         creatiedatum = LocalDate.now(),
         taal = "nl",
         titel = "titel",

--- a/documentation/release-notes/12.x.x/12.30.0/README.md
+++ b/documentation/release-notes/12.x.x/12.30.0/README.md
@@ -14,4 +14,4 @@
 
 ## Bugfixes
 
-* New bugfix.
+* Fixed deserialization of `beginRegistratie` in Documenten API responses


### PR DESCRIPTION
Backporting the changes for issue https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/591 / PR https://github.com/valtimo-platform/valtimo/pull/488

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/384

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed deserialization of date-time values in Documenten API responses to correctly handle ISO-8601 formatted timestamps with timezone information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->