### PR TITLE
Fix outbox circuit breaker never recovering from OPEN state

### DIFF
--- a/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
+++ b/backend/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisher.kt
@@ -29,6 +29,7 @@ import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
 
@@ -96,38 +97,41 @@ class RabbitMessagePublisher(
         }
 
         // Phase 3: collect results per message
-        return pending.map { (message, correlationData) ->
-            val future = correlationData.future.toCompletableFuture()
-            if (!future.isDone) {
-                return@map MessagePublishResult(
-                    messageId = message.id,
-                    success = false,
-                    error = MessagePublishingFailed("Outbox message delivery was not confirmed in time: routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
-                )
-            }
-            val result = future.get()
-                ?: return@map MessagePublishResult(
-                    messageId = message.id,
-                    success = false,
-                    error = MessagePublishingFailed("Outbox message confirmation result was null: routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
-                )
-            if (!result.isAck) {
-                return@map MessagePublishResult(
-                    messageId = message.id,
-                    success = false,
-                    error = MessagePublishingFailed("Outbox message was not acknowledged: reason=${result.reason}, routingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
-                )
-            }
-            val returned = correlationData.returned
-            if (returned != null) {
-                return@map MessagePublishResult(
-                    messageId = message.id,
-                    success = false,
-                    error = MessagePublishingFailed("Could not deliver outbox message: returnedRoutingKey=${returned.routingKey}, code=${returned.replyCode}, msg=${returned.replyText}, configuredRoutingKey=${routingKey}, msgId=${message.id}, correlationId=${correlationData.id}")
-                )
-            }
-            MessagePublishResult(messageId = message.id, success = true)
+        return pending.map { (message, correlationData) -> collectResult(message, correlationData) }
+    }
+
+    private fun collectResult(message: OutboxMessage, correlationData: CorrelationData): MessagePublishResult {
+        val ctx = "routingKey=$routingKey, msgId=${message.id}, correlationId=${correlationData.id}"
+
+        fun failure(reason: String) = MessagePublishResult(
+            messageId = message.id,
+            success = false,
+            error = MessagePublishingFailed("$reason: $ctx")
+        )
+
+        val future = correlationData.future.toCompletableFuture()
+        if (!future.isDone) {
+            return failure("Outbox message delivery was not confirmed in time")
         }
+
+        val result = try {
+            future.get()
+        } catch (e: ExecutionException) {
+            return failure("Confirmation future failed, cause=${e.cause?.message ?: e.message}")
+        } catch (_: CancellationException) {
+            return failure("Confirmation future was cancelled")
+        } ?: return failure("Outbox message confirmation result was null")
+
+        if (!result.isAck) {
+            return failure("Outbox message was not acknowledged, reason=${result.reason}")
+        }
+
+        val returned = correlationData.returned
+        if (returned != null) {
+            return failure("Could not deliver outbox message, returnedRoutingKey=${returned.routingKey}, code=${returned.replyCode}, msg=${returned.replyText}")
+        }
+
+        return MessagePublishResult(messageId = message.id, success = true)
     }
 
     companion object {

--- a/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherTest.kt
+++ b/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.outbox.rabbitmq
 
 import com.ritense.outbox.OutboxMessage

--- a/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherTest.kt
+++ b/backend/outbox/outbox-rabbitmq/src/test/kotlin/com/ritense/outbox/rabbitmq/RabbitMessagePublisherTest.kt
@@ -212,6 +212,67 @@ class RabbitMessagePublisherTest {
     }
 
     @Test
+    fun `publishBatch should handle ExecutionException per message`() {
+        val rabbitTemplate = getMockedRabbitTemplate()
+        var callCount = 0
+
+        whenever(rabbitTemplate.convertAndSend(any<String>(), eq("test"), any<String>(), any<CorrelationData>())).thenAnswer { answer ->
+            callCount++
+            val correlationData = answer.getArgument(3, CorrelationData::class.java)
+            if (callCount == 2) {
+                correlationData.future.completeExceptionally(RuntimeException("broker error"))
+            } else {
+                correlationData.future.complete(CorrelationData.Confirm(true, null))
+            }
+        }
+
+        val publisher = RabbitMessagePublisher(rabbitTemplate, "test")
+        val messages = listOf(
+            OutboxMessage(message = "ok1"),
+            OutboxMessage(message = "fail"),
+            OutboxMessage(message = "ok2")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        Assertions.assertThat(results[0].success).isTrue()
+        Assertions.assertThat(results[1].success).isFalse()
+        Assertions.assertThat(results[1].error!!.message).contains("Confirmation future failed")
+        Assertions.assertThat(results[1].error!!.message).contains("broker error")
+        Assertions.assertThat(results[2].success).isTrue()
+    }
+
+    @Test
+    fun `publishBatch should handle CancellationException per message`() {
+        val rabbitTemplate = getMockedRabbitTemplate()
+        var callCount = 0
+
+        whenever(rabbitTemplate.convertAndSend(any<String>(), eq("test"), any<String>(), any<CorrelationData>())).thenAnswer { answer ->
+            callCount++
+            val correlationData = answer.getArgument(3, CorrelationData::class.java)
+            if (callCount == 2) {
+                correlationData.future.toCompletableFuture().cancel(true)
+            } else {
+                correlationData.future.complete(CorrelationData.Confirm(true, null))
+            }
+        }
+
+        val publisher = RabbitMessagePublisher(rabbitTemplate, "test")
+        val messages = listOf(
+            OutboxMessage(message = "ok1"),
+            OutboxMessage(message = "cancelled"),
+            OutboxMessage(message = "ok2")
+        )
+
+        val results = publisher.publishBatch(messages)
+
+        Assertions.assertThat(results[0].success).isTrue()
+        Assertions.assertThat(results[1].success).isFalse()
+        Assertions.assertThat(results[1].error!!.message).contains("cancelled")
+        Assertions.assertThat(results[2].success).isTrue()
+    }
+
+    @Test
     fun `publishBatch should return empty list for empty input`() {
         val rabbitTemplate = getMockedRabbitTemplate()
         val publisher = RabbitMessagePublisher(rabbitTemplate, "test")

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
@@ -107,6 +107,7 @@ class OutboxAutoConfiguration {
             .slidingWindowSize(props.slidingWindowSize)
             .waitDurationInOpenState(Duration.ofSeconds(props.waitDurationInOpenStateSeconds))
             .permittedNumberOfCallsInHalfOpenState(props.permittedNumberOfCallsInHalfOpenState)
+            .automaticTransitionFromOpenToHalfOpenEnabled(true)
             .build()
         return CircuitBreaker.of("outboxPollingPublisher", config)
     }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicator.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicator.kt
@@ -23,8 +23,8 @@ import org.springframework.boot.actuate.health.Health
 /**
  * Exposes the outbox publisher circuit breaker state via the /actuator/health endpoint.
  *
- * Reports DOWN when the circuit breaker is OPEN (publisher is failing),
- * UP when CLOSED or HALF_OPEN (normal operation or recovery testing).
+ * Always reports UP so the outbox status does not affect the overall application health.
+ * The circuit breaker state is included as informational details.
  *
  * Only active when spring-boot-starter-actuator is on the classpath.
  */
@@ -40,22 +40,13 @@ class OutboxPublisherHealthIndicator(
         }
 
         val metrics = circuitBreaker.metrics
-        val details = mapOf(
-            "circuitBreakerState" to circuitBreaker.state.name,
-            // failureRate is -1.0 until minimumNumberOfCalls is reached
-            "failureRate" to "${metrics.failureRate}%",
-            "slidingWindow" to mapOf(
+        builder.up()
+            .withDetail("circuitBreakerState", circuitBreaker.state.name)
+            .withDetail("failureRate", "${metrics.failureRate}%")
+            .withDetail("slidingWindow", mapOf(
                 "successful" to metrics.numberOfSuccessfulCalls,
                 "failed" to metrics.numberOfFailedCalls,
                 "rejected" to metrics.numberOfNotPermittedCalls
-            )
-        )
-
-        when (circuitBreaker.state) {
-            CircuitBreaker.State.CLOSED -> builder.up().withDetails(details)
-            CircuitBreaker.State.HALF_OPEN -> builder.up().withDetails(details)
-            CircuitBreaker.State.OPEN -> builder.down().withDetails(details)
-            else -> builder.unknown().withDetails(details)
-        }
+            ))
     }
 }

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxMessageRepositoryIntTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxMessageRepositoryIntTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -115,7 +116,7 @@ class OutboxMessageRepositoryIntTest : BaseIntegrationTest() {
         }
 
         // Second transaction should skip the locked messages and get the 3rd
-        locksAcquired.await()
+        withTimeout(2_000) { locksAcquired.await() }
         val batch2Ref = async(Dispatchers.IO) {
             TransactionTemplate(platformTransactionManager).execute {
                 outboxMessageRepository.findOutboxMessages(2)

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicatorTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/health/OutboxPublisherHealthIndicatorTest.kt
@@ -46,13 +46,13 @@ class OutboxPublisherHealthIndicatorTest {
     }
 
     @Test
-    fun `should report DOWN when circuit breaker is OPEN`() {
+    fun `should report UP when circuit breaker is OPEN`() {
         val circuitBreaker = createCircuitBreaker()
         circuitBreaker.transitionToOpenState()
         val indicator = OutboxPublisherHealthIndicator(circuitBreaker)
         val health = indicator.health()
 
-        assertThat(health.status).isEqualTo(Status.DOWN)
+        assertThat(health.status).isEqualTo(Status.UP)
         assertThat(health.details["circuitBreakerState"]).isEqualTo("OPEN")
     }
 

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/publisher/PollingPublisherServiceTest.kt
@@ -304,6 +304,60 @@ class PollingPublisherServiceTest {
         assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.CLOSED)
     }
 
+    @Test
+    fun `should recover from OPEN state after wait duration elapses`() {
+        val circuitBreaker = CircuitBreaker.of(
+            "test-recovery",
+            CircuitBreakerConfig.custom()
+                .failureRateThreshold(100f)
+                .minimumNumberOfCalls(1)
+                .slidingWindowSize(1)
+                .waitDurationInOpenState(Duration.ofSeconds(1))
+                .permittedNumberOfCallsInHalfOpenState(1)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .build()
+        )
+
+        val failMsg = OutboxMessage(message = "fail")
+        val okMsg = OutboxMessage(message = "ok")
+        // 1st call: failure (opens circuit), 2nd call: success (HALF_OPEN recovery)
+        whenever(outboxService.getOldestMessages(any()))
+            .thenReturn(listOf(failMsg))
+            .thenReturn(listOf(okMsg))
+            .thenReturn(emptyList())
+        whenever(messagePublisher.publishBatch(listOf(failMsg))).thenReturn(
+            listOf(MessagePublishResult(messageId = failMsg.id, success = false, error = RuntimeException("fail")))
+        )
+        whenever(messagePublisher.publishBatch(listOf(okMsg))).thenReturn(
+            listOf(MessagePublishResult(messageId = okMsg.id, success = true))
+        )
+
+        val service = PollingPublisherService(
+            outboxService, messagePublisher, transactionManager,
+            batchSize = 5,
+            circuitBreaker = circuitBreaker
+        )
+
+        // First poll: failure opens the circuit breaker
+        service.pollAndPublishAll()
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.OPEN)
+
+        // Poll while OPEN: should skip entirely
+        service.pollAndPublishAll()
+        verify(outboxService, times(1)).getOldestMessages(any())
+
+        // Wait for automatic OPEN → HALF_OPEN transition (1s wait duration + 500ms margin)
+        val deadline = System.currentTimeMillis() + 1500
+        while (circuitBreaker.state != CircuitBreaker.State.HALF_OPEN) {
+            assertThat(System.currentTimeMillis()).isLessThan(deadline)
+            Thread.sleep(50)
+        }
+
+        // Poll in HALF_OPEN: should succeed and close the circuit breaker
+        service.pollAndPublishAll()
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.CLOSED)
+    }
+
     private fun createCircuitBreaker(
         failureThreshold: Float,
         minimumCalls: Int,

--- a/documentation/release-notes/12.x.x/12.29.0/README.md
+++ b/documentation/release-notes/12.x.x/12.29.0/README.md
@@ -30,3 +30,11 @@ The following will be removed in 14.0:
 * `OutboxMessageRepository.findOutboxMessage()` — use `findOutboxMessages(batchSize)`
 * `ValtimoOutboxService.getOldestMessage()` — use `getOldestMessages(batchSize)`
 * `ValtimoOutboxService.deleteMessage(id)` — use `deleteMessages(ids)`
+
+## Known issues
+
+This version has the following known issues:
+
+* **Outbox circuit breaker never recovers from OPEN state**
+  * Discovered in version 12.29.0
+  * Fixed in 12.30.0. Workaround: Disable the circuit breaker using the `valtimo.outbox.publisher.polling.circuit-breaker.enabled` property.

--- a/documentation/release-notes/12.x.x/12.30.0/README.md
+++ b/documentation/release-notes/12.x.x/12.30.0/README.md
@@ -14,4 +14,4 @@
 
 ## Bugfixes
 
-* New bugfix.
+* Fixed outbox circuit breaker never recovering from OPEN state.


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/385

Backport of #524 to v12. The outbox circuit breaker's `automaticTransitionFromOpenToHalfOpenEnabled` was not enabled, causing the circuit breaker to stay in OPEN state permanently once tripped. This PR enables that setting so the circuit breaker automatically transitions to HALF_OPEN after the configured wait duration, allowing recovery.

Additionally guards per-message `future.get()` against `ExecutionException` and `CancellationException` so a single failed future no longer breaks the entire batch result collection.

Specify the code branch location: `outbox`, `outbox/outbox-rabbitmq`

**Relevant comments:**
> Added a known issue entry to the 12.29.0 release notes and the fix to the 12.30.0 release notes.

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes

### Tests
Unit tests have been added that cover these changes
- [x] Yes

Integration tests have been added that cover these changes
- [ ] Not applicable

Describe the testing steps
- [x] Run `PollingPublisherServiceTest` — verify the `should recover from OPEN state after wait duration elapses` test passes
- [x] Run `RabbitMessagePublisherTest` — verify `ExecutionException` and `CancellationException` tests pass
- [x] Verify all existing outbox tests still pass

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Not applicable

Valtimo access control checks have been implemented
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed outbox circuit breaker recovery from OPEN state; it now automatically transitions to Half-Open.
  * Health indicator now consistently reports UP status while displaying circuit breaker state as a detail.

* **Documentation**
  * Added known issue entry for version 12.29.0 regarding circuit breaker recovery with workaround guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->