### PR TITLE
Backporting process function to correlate messages across cases

### DIFF
--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/CorrelationService.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/CorrelationService.kt
@@ -33,9 +33,17 @@ interface CorrelationService {
     fun sendCatchEventMessage(message: String, businessKey: String, vararg variables: Any?): MessageCorrelationResult
     fun sendCatchEventMessage(message: String, businessKey: String, variables: Map<String, Any?>?): MessageCorrelationResult
 
+    fun sendGlobalCatchEventMessage(message: String): MessageCorrelationResult
+    fun sendGlobalCatchEventMessage(message: String, vararg variables: Any?): MessageCorrelationResult
+    fun sendGlobalCatchEventMessage(message: String, variables: Map<String, Any?>?): MessageCorrelationResult
+
     fun sendCatchEventMessageToAll(message: String, businessKey: String): List<MessageCorrelationResult>
     fun sendCatchEventMessageToAll(message: String, businessKey: String, vararg variables: Any?): List<MessageCorrelationResult>
     fun sendCatchEventMessageToAll(message: String, businessKey: String, variables: Map<String, Any?>?): List<MessageCorrelationResult>
+
+    fun sendGlobalCatchEventMessageToAll(message: String): List<MessageCorrelationResult>
+    fun sendGlobalCatchEventMessageToAll(message: String, vararg variables: Any?): List<MessageCorrelationResult>
+    fun sendGlobalCatchEventMessageToAll(message: String, variables: Map<String, Any?>?): List<MessageCorrelationResult>
 
     fun sendMessage(message: String, execution: DelegateExecution): MessageCorrelationResult
     fun sendMessageToAll(message: String, execution: DelegateExecution): List<MessageCorrelationResult>

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/CorrelationServiceImpl.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/CorrelationServiceImpl.kt
@@ -120,6 +120,24 @@ class CorrelationServiceImpl(
         return sendCatchEventMessage(message, businessKey, toVariableMap(*variables))
     }
 
+    override fun sendGlobalCatchEventMessage(message: String): MessageCorrelationResult {
+        return sendGlobalCatchEventMessage(message, null)
+    }
+
+    override fun sendGlobalCatchEventMessage(
+        message: String,
+        variables: Map<String, Any?>?
+    ): MessageCorrelationResult {
+        return correlate(message, null, variables)
+    }
+
+    override fun sendGlobalCatchEventMessage(
+        message: String,
+        vararg variables: Any?
+    ): MessageCorrelationResult {
+        return sendGlobalCatchEventMessage(message, toVariableMap(*variables))
+    }
+
     override fun sendCatchEventMessageToAll(message: String, businessKey: String): List<MessageCorrelationResult> {
         return sendCatchEventMessageToAll(message, businessKey, null)
     }
@@ -145,6 +163,24 @@ class CorrelationServiceImpl(
         vararg variables: Any?
     ): List<MessageCorrelationResult> {
         return sendCatchEventMessageToAll(message, businessKey, toVariableMap(*variables))
+    }
+
+    override fun sendGlobalCatchEventMessageToAll(message: String): List<MessageCorrelationResult> {
+        return sendGlobalCatchEventMessageToAll(message, null)
+    }
+
+    override fun sendGlobalCatchEventMessageToAll(
+        message: String,
+        variables: Map<String, Any?>?
+    ): List<MessageCorrelationResult> {
+        return correlateAll(message, null, variables)
+    }
+
+    override fun sendGlobalCatchEventMessageToAll(
+        message: String,
+        vararg variables: Any?
+    ): List<MessageCorrelationResult> {
+        return sendGlobalCatchEventMessageToAll(message, toVariableMap(*variables))
     }
 
     override fun sendMessage(message: String, execution: DelegateExecution): MessageCorrelationResult {
@@ -202,11 +238,11 @@ class CorrelationServiceImpl(
 
     private fun correlate(
         message: String,
-        businessKey: String,
+        businessKey: String?,
         variables: Map<String, Any?>?
     ): MessageCorrelationResult {
         val builder = runtimeService.createMessageCorrelation(message)
-        builder.processInstanceBusinessKey(businessKey)
+        businessKey?.let { builder.processInstanceBusinessKey(it) }
         variables?.run { builder.setVariables(variables) }
         return builder.correlateWithResult()
     }
@@ -226,11 +262,11 @@ class CorrelationServiceImpl(
 
     private fun correlateAll(
         message: String,
-        businessKey: String,
+        businessKey: String?,
         variables: Map<String, Any?>?
     ): List<MessageCorrelationResult> {
         val builder = runtimeService.createMessageCorrelation(message)
-        builder.processInstanceBusinessKey(businessKey)
+        businessKey?.let { builder.processInstanceBusinessKey(it) }
         variables?.run { builder.setVariables(variables) }
         return builder.correlateAllWithResult()
     }

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CorrelationServiceImplTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CorrelationServiceImplTest.kt
@@ -1,0 +1,564 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processdocument.service
+
+import com.ritense.document.domain.Document
+import com.ritense.document.domain.impl.JsonSchemaDocumentId
+import com.ritense.document.service.DocumentService
+import com.ritense.processdocument.domain.impl.CamundaProcessInstanceId
+import com.ritense.valtimo.camunda.domain.CamundaProcessDefinition
+import com.ritense.valtimo.camunda.service.CamundaRepositoryService
+import com.ritense.valtimo.camunda.service.CamundaRuntimeService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.camunda.bpm.engine.RepositoryService
+import org.camunda.bpm.engine.RuntimeService
+import org.camunda.bpm.engine.delegate.DelegateExecution
+import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder
+import org.camunda.bpm.engine.runtime.MessageCorrelationResult
+import org.camunda.bpm.engine.runtime.ProcessInstance
+import java.util.Optional
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class CorrelationServiceImplTest {
+
+    lateinit var runtimeService: RuntimeService
+    lateinit var camundaRuntimeService: CamundaRuntimeService
+    lateinit var documentService: DocumentService
+    lateinit var camundaRepositoryService: CamundaRepositoryService
+    lateinit var repositoryService: RepositoryService
+    lateinit var associationService: ProcessDocumentAssociationService
+    lateinit var correlationService: CorrelationServiceImpl
+
+    lateinit var builder: MessageCorrelationBuilder
+
+    val businessKey = UUID.randomUUID().toString()
+    val documentId = UUID.randomUUID()
+    val messageName = "test-message"
+    val processDefinitionId = UUID.randomUUID().toString()
+    val processInstanceId = UUID.randomUUID().toString()
+    val processName = "test-process-name"
+
+    @BeforeEach
+    fun setUp() {
+        runtimeService = mock(defaultAnswer = RETURNS_DEEP_STUBS)
+        camundaRuntimeService = mock()
+        documentService = mock()
+        camundaRepositoryService = mock()
+        repositoryService = mock()
+        associationService = mock()
+
+        correlationService = CorrelationServiceImpl(
+            runtimeService,
+            camundaRuntimeService,
+            documentService,
+            camundaRepositoryService,
+            repositoryService,
+            associationService
+        )
+
+        builder = mock()
+        whenever(runtimeService.createMessageCorrelation(any())).thenReturn(builder)
+        whenever(builder.processInstanceBusinessKey(any())).thenReturn(builder)
+        whenever(builder.processDefinitionId(any())).thenReturn(builder)
+        whenever(builder.setVariables(any())).thenReturn(builder)
+    }
+
+    // --- sendStartMessage ---
+
+    @Test
+    fun `sendStartMessage should correlate with businessKey and associate document`() {
+        val result = mockCorrelationResultWithProcessInstance()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionLookup()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendStartMessage(messageName, businessKey)
+
+        assertEquals(result, actual)
+        verify(builder).processInstanceBusinessKey(businessKey)
+        verify(builder).correlateWithResult()
+        verify(associationService).createProcessDocumentInstance(eq(processInstanceId), eq(documentId), eq(processName))
+    }
+
+    @Test
+    fun `sendStartMessage with variables map should correlate with businessKey and variables`() {
+        val variables = mapOf("key1" to "value1" as Any?)
+        val result = mockCorrelationResultWithProcessInstance()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionLookup()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendStartMessage(messageName, businessKey, variables)
+
+        assertEquals(result, actual)
+        verify(builder).processInstanceBusinessKey(businessKey)
+        verify(builder).setVariables(variables)
+        verify(builder).correlateWithResult()
+    }
+
+    @Test
+    fun `sendStartMessage with vararg variables should convert to map and correlate`() {
+        val result = mockCorrelationResultWithProcessInstance()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionLookup()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendStartMessage(messageName, businessKey, "key1", "value1")
+
+        assertEquals(result, actual)
+        verify(builder).setVariables(mapOf("key1" to "value1"))
+    }
+
+    // --- sendStartMessageWithProcessDefinitionKey ---
+
+    @Test
+    fun `sendStartMessageWithProcessDefinitionKey should correlate with process definition id`() {
+        val targetKey = "target-process-key"
+        val processInstance = mock<ProcessInstance>()
+        whenever(processInstance.processDefinitionId).thenReturn(processDefinitionId)
+        whenever(processInstance.processInstanceId).thenReturn(processInstanceId)
+        whenever(builder.correlateStartMessage()).thenReturn(processInstance)
+        mockLatestProcessDefinition()
+        mockProcessDefinitionLookup()
+        mockDocumentAndAssociation()
+
+        correlationService.sendStartMessageWithProcessDefinitionKey(messageName, targetKey, businessKey)
+
+        verify(builder).processDefinitionId(any())
+        verify(builder).processInstanceBusinessKey(businessKey)
+        verify(builder).correlateStartMessage()
+        verify(associationService).createProcessDocumentInstance(eq(processInstanceId), eq(documentId), eq(processName))
+    }
+
+    @Test
+    fun `sendStartMessageWithProcessDefinitionKey with variables map should set variables`() {
+        val targetKey = "target-process-key"
+        val variables = mapOf("key1" to "value1" as Any?)
+        val processInstance = mock<ProcessInstance>()
+        whenever(processInstance.processDefinitionId).thenReturn(processDefinitionId)
+        whenever(processInstance.processInstanceId).thenReturn(processInstanceId)
+        whenever(builder.correlateStartMessage()).thenReturn(processInstance)
+        mockLatestProcessDefinition()
+        mockProcessDefinitionLookup()
+        mockDocumentAndAssociation()
+
+        correlationService.sendStartMessageWithProcessDefinitionKey(messageName, targetKey, businessKey, variables)
+
+        verify(builder).setVariables(variables)
+    }
+
+    @Test
+    fun `sendStartMessageWithProcessDefinitionKey with vararg variables should convert to map`() {
+        val targetKey = "target-process-key"
+        val processInstance = mock<ProcessInstance>()
+        whenever(processInstance.processDefinitionId).thenReturn(processDefinitionId)
+        whenever(processInstance.processInstanceId).thenReturn(processInstanceId)
+        whenever(builder.correlateStartMessage()).thenReturn(processInstance)
+        mockLatestProcessDefinition()
+        mockProcessDefinitionLookup()
+        mockDocumentAndAssociation()
+
+        correlationService.sendStartMessageWithProcessDefinitionKey(messageName, targetKey, businessKey, "k1", "v1")
+
+        verify(builder).setVariables(mapOf("k1" to "v1"))
+    }
+
+    // --- sendCatchEventMessage with businessKey ---
+
+    @Test
+    fun `sendCatchEventMessage with businessKey should correlate and associate document`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendCatchEventMessage(messageName, businessKey)
+
+        assertEquals(result, actual)
+        verify(builder).processInstanceBusinessKey(businessKey)
+        verify(builder).correlateWithResult()
+        verify(associationService).createProcessDocumentInstance(eq(processInstanceId), eq(documentId), eq(processName))
+    }
+
+    @Test
+    fun `sendCatchEventMessage with businessKey and variables map should set variables`() {
+        val variables = mapOf("key1" to "value1" as Any?)
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendCatchEventMessage(messageName, businessKey, variables)
+
+        assertEquals(result, actual)
+        verify(builder).setVariables(variables)
+    }
+
+    @Test
+    fun `sendCatchEventMessage with businessKey and vararg variables should convert to map`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendCatchEventMessage(messageName, businessKey, "k1", "v1")
+
+        assertEquals(result, actual)
+        verify(builder).setVariables(mapOf("k1" to "v1"))
+    }
+
+    // --- sendGlobalCatchEventMessage ---
+
+    @Test
+    fun `sendGlobalCatchEventMessage should correlate without businessKey filter`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+
+        val actual = correlationService.sendGlobalCatchEventMessage(messageName)
+
+        assertEquals(result, actual)
+        verify(builder, never()).processInstanceBusinessKey(any())
+        verify(builder).correlateWithResult()
+    }
+
+    @Test
+    fun `sendGlobalCatchEventMessage should not associate document`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+
+        correlationService.sendGlobalCatchEventMessage(messageName)
+
+        verify(associationService, never()).createProcessDocumentInstance(any(), any(), any())
+    }
+
+    @Test
+    fun `sendGlobalCatchEventMessage with variables map should set variables`() {
+        val variables = mapOf("key1" to "value1" as Any?)
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+
+        val actual = correlationService.sendGlobalCatchEventMessage(messageName, variables)
+
+        assertEquals(result, actual)
+        verify(builder, never()).processInstanceBusinessKey(any())
+        verify(builder).setVariables(variables)
+    }
+
+    // --- sendCatchEventMessageToAll with businessKey ---
+
+    @Test
+    fun `sendCatchEventMessageToAll with businessKey should correlate all and associate documents`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result))
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendCatchEventMessageToAll(messageName, businessKey)
+
+        assertEquals(listOf(result), actual)
+        verify(builder).processInstanceBusinessKey(businessKey)
+        verify(builder).correlateAllWithResult()
+        verify(associationService).createProcessDocumentInstance(eq(processInstanceId), eq(documentId), eq(processName))
+    }
+
+    @Test
+    fun `sendCatchEventMessageToAll with businessKey and variables map should set variables`() {
+        val variables = mapOf("key1" to "value1" as Any?)
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result))
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendCatchEventMessageToAll(messageName, businessKey, variables)
+
+        assertEquals(listOf(result), actual)
+        verify(builder).setVariables(variables)
+    }
+
+    @Test
+    fun `sendCatchEventMessageToAll with businessKey and vararg variables should convert to map`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result))
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        val actual = correlationService.sendCatchEventMessageToAll(messageName, businessKey, "k1", "v1")
+
+        assertEquals(listOf(result), actual)
+        verify(builder).setVariables(mapOf("k1" to "v1"))
+    }
+
+    @Test
+    fun `sendCatchEventMessageToAll with businessKey should associate each result`() {
+        val processInstanceId1 = UUID.randomUUID().toString()
+        val processInstanceId2 = UUID.randomUUID().toString()
+        val result1 = mockCorrelationResultWithExecution(processInstanceId1)
+        val result2 = mockCorrelationResultWithExecution(processInstanceId2)
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result1, result2))
+
+        val processDef1 = mock<CamundaProcessDefinition>()
+        whenever(processDef1.name).thenReturn("process-1")
+        val processDef2 = mock<CamundaProcessDefinition>()
+        whenever(processDef2.name).thenReturn("process-2")
+
+        val defId1 = UUID.randomUUID().toString()
+        val defId2 = UUID.randomUUID().toString()
+        val pi1 = mock<ProcessInstance>()
+        whenever(pi1.processDefinitionId).thenReturn(defId1)
+        val pi2 = mock<ProcessInstance>()
+        whenever(pi2.processDefinitionId).thenReturn(defId2)
+
+        whenever(camundaRuntimeService.findProcessInstanceById(processInstanceId1)).thenReturn(pi1)
+        whenever(camundaRuntimeService.findProcessInstanceById(processInstanceId2)).thenReturn(pi2)
+        whenever(camundaRepositoryService.findProcessDefinitionById(defId1)).thenReturn(processDef1)
+        whenever(camundaRepositoryService.findProcessDefinitionById(defId2)).thenReturn(processDef2)
+
+        val document = mock<Document>()
+        val jsonSchemaDocumentId = mock<JsonSchemaDocumentId>()
+        whenever(jsonSchemaDocumentId.id).thenReturn(documentId)
+        whenever(document.id()).thenReturn(jsonSchemaDocumentId)
+        whenever(documentService[businessKey]).thenReturn(document)
+        whenever(associationService.findProcessDocumentInstance(any<CamundaProcessInstanceId>())).thenReturn(Optional.empty())
+
+        correlationService.sendCatchEventMessageToAll(messageName, businessKey)
+
+        verify(associationService).createProcessDocumentInstance(eq(processInstanceId1), eq(documentId), eq("process-1"))
+        verify(associationService).createProcessDocumentInstance(eq(processInstanceId2), eq(documentId), eq("process-2"))
+    }
+
+    // --- sendGlobalCatchEventMessageToAll ---
+
+    @Test
+    fun `sendGlobalCatchEventMessageToAll should correlate without businessKey filter`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result))
+
+        val actual = correlationService.sendGlobalCatchEventMessageToAll(messageName)
+
+        assertEquals(listOf(result), actual)
+        verify(builder, never()).processInstanceBusinessKey(any())
+        verify(builder).correlateAllWithResult()
+    }
+
+    @Test
+    fun `sendGlobalCatchEventMessageToAll should not associate document`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result))
+
+        correlationService.sendGlobalCatchEventMessageToAll(messageName)
+
+        verify(associationService, never()).createProcessDocumentInstance(any(), any(), any())
+    }
+
+    @Test
+    fun `sendGlobalCatchEventMessageToAll with variables map should set variables`() {
+        val variables = mapOf("key1" to "value1" as Any?)
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result))
+
+        val actual = correlationService.sendGlobalCatchEventMessageToAll(messageName, variables)
+
+        assertEquals(listOf(result), actual)
+        verify(builder, never()).processInstanceBusinessKey(any())
+        verify(builder).setVariables(variables)
+    }
+
+    @Test
+    fun `sendGlobalCatchEventMessageToAll with empty results should return empty list`() {
+        whenever(builder.correlateAllWithResult()).thenReturn(emptyList())
+
+        val actual = correlationService.sendGlobalCatchEventMessageToAll(messageName)
+
+        assertEquals(emptyList(), actual)
+    }
+
+    // --- sendMessage ---
+
+    @Test
+    fun `sendMessage should correlate using execution businessKey and variables`() {
+        val execution = mock<DelegateExecution>()
+        val executionBusinessKey = UUID.randomUUID().toString()
+        val executionVars = mapOf("var1" to "val1" as Any)
+        whenever(execution.businessKey).thenReturn(executionBusinessKey)
+        whenever(execution.variables).thenReturn(executionVars)
+
+        val result = mockCorrelationResultWithProcessInstance()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionLookup()
+        mockDocumentAndAssociation(executionBusinessKey)
+
+        val actual = correlationService.sendMessage(messageName, execution)
+
+        assertEquals(result, actual)
+        verify(builder).processInstanceBusinessKey(executionBusinessKey)
+        verify(builder).setVariables(executionVars)
+    }
+
+    @Test
+    fun `sendMessage with catch event result should associate using execution processInstanceId`() {
+        val execution = mock<DelegateExecution>()
+        whenever(execution.businessKey).thenReturn(businessKey)
+        whenever(execution.variables).thenReturn(emptyMap())
+
+        val result = mockCorrelationResultWithExecution()
+        whenever(result.processInstance).thenReturn(null)
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        correlationService.sendMessage(messageName, execution)
+
+        verify(associationService).createProcessDocumentInstance(eq(processInstanceId), eq(documentId), eq(processName))
+    }
+
+    // --- sendMessageToAll ---
+
+    @Test
+    fun `sendMessageToAll should correlate all using execution businessKey and variables`() {
+        val execution = mock<DelegateExecution>()
+        val executionBusinessKey = UUID.randomUUID().toString()
+        val executionVars = mapOf("var1" to "val1" as Any)
+        whenever(execution.businessKey).thenReturn(executionBusinessKey)
+        whenever(execution.variables).thenReturn(executionVars)
+
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateAllWithResult()).thenReturn(listOf(result))
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation(executionBusinessKey)
+
+        val actual = correlationService.sendMessageToAll(messageName, execution)
+
+        assertEquals(listOf(result), actual)
+        verify(builder).processInstanceBusinessKey(executionBusinessKey)
+        verify(builder).setVariables(executionVars)
+    }
+
+    // --- Variable conversion ---
+
+    @Test
+    fun `vararg variables with multiple pairs should produce correct map`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        correlationService.sendCatchEventMessage(messageName, businessKey, "k1", "v1", "k2", 42)
+
+        verify(builder).setVariables(mapOf("k1" to "v1", "k2" to 42))
+    }
+
+    @Test
+    fun `vararg variables with no arguments should not set variables`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        correlationService.sendCatchEventMessage(messageName, businessKey)
+
+        verify(builder, never()).setVariables(any())
+    }
+
+    @Test
+    fun `null variables map should not set variables`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+        mockDocumentAndAssociation()
+
+        correlationService.sendCatchEventMessage(messageName, businessKey, null)
+
+        verify(builder, never()).setVariables(any())
+    }
+
+    // --- Association skipping ---
+
+    @Test
+    fun `should not create association when one already exists`() {
+        val result = mockCorrelationResultWithExecution()
+        whenever(builder.correlateWithResult()).thenReturn(result)
+        mockProcessDefinitionNameByProcessInstanceId()
+
+        val document = mock<Document>()
+        val jsonSchemaDocumentId = mock<JsonSchemaDocumentId>()
+        whenever(jsonSchemaDocumentId.id).thenReturn(documentId)
+        whenever(document.id()).thenReturn(jsonSchemaDocumentId)
+        whenever(documentService[businessKey]).thenReturn(document)
+        whenever(associationService.findProcessDocumentInstance(any<CamundaProcessInstanceId>())).thenReturn(Optional.of(mock()))
+
+        correlationService.sendCatchEventMessage(messageName, businessKey)
+
+        verify(associationService, never()).createProcessDocumentInstance(any(), any(), any())
+    }
+
+    // --- Helper methods ---
+
+    private fun mockCorrelationResultWithProcessInstance(): MessageCorrelationResult {
+        val result = mock<MessageCorrelationResult>()
+        val processInstance = mock<ProcessInstance>()
+        whenever(processInstance.processDefinitionId).thenReturn(processDefinitionId)
+        whenever(processInstance.id).thenReturn(processInstanceId)
+        whenever(processInstance.processInstanceId).thenReturn(processInstanceId)
+        whenever(result.processInstance).thenReturn(processInstance)
+        return result
+    }
+
+    private fun mockCorrelationResultWithExecution(
+        execProcessInstanceId: String = processInstanceId
+    ): MessageCorrelationResult {
+        val result = mock<MessageCorrelationResult>(defaultAnswer = RETURNS_DEEP_STUBS)
+        whenever(result.execution.processInstanceId).thenReturn(execProcessInstanceId)
+        return result
+    }
+
+    private fun mockProcessDefinitionLookup() {
+        val processDef = mock<CamundaProcessDefinition>()
+        whenever(processDef.name).thenReturn(processName)
+        whenever(camundaRepositoryService.findProcessDefinitionById(processDefinitionId)).thenReturn(processDef)
+    }
+
+    private fun mockProcessDefinitionNameByProcessInstanceId() {
+        val processInstance = mock<ProcessInstance>()
+        whenever(processInstance.processDefinitionId).thenReturn(processDefinitionId)
+        whenever(camundaRuntimeService.findProcessInstanceById(processInstanceId)).thenReturn(processInstance)
+        mockProcessDefinitionLookup()
+    }
+
+    private fun mockDocumentAndAssociation(key: String = businessKey) {
+        val document = mock<Document>()
+        val jsonSchemaDocumentId = mock<JsonSchemaDocumentId>()
+        whenever(jsonSchemaDocumentId.id).thenReturn(documentId)
+        whenever(document.id()).thenReturn(jsonSchemaDocumentId)
+        whenever(documentService[key]).thenReturn(document)
+        whenever(associationService.findProcessDocumentInstance(any<CamundaProcessInstanceId>())).thenReturn(Optional.empty())
+    }
+
+    private fun mockLatestProcessDefinition() {
+        val processDef = mock<CamundaProcessDefinition>()
+        whenever(processDef.id).thenReturn(processDefinitionId)
+        whenever(camundaRepositoryService.findProcessDefinition(any())).thenReturn(processDef)
+    }
+}

--- a/documentation/features/process/correlation-service.md
+++ b/documentation/features/process/correlation-service.md
@@ -4,7 +4,7 @@ When modeling a process, correlating a message (e.g. to start another process) d
 
 ## How to use
 
-Valtimo provides several methods that can be used inside a BPMN, accessible through the `correlationService` bean. Which method to use depends on the use case. For more information on the separate use cases see the two sections below.
+Valtimo provides several methods that can be used inside a BPMN, accessible through the `correlationService` bean. Which method to use depends on the use case. For more information on the separate use cases see the three sections below.
 
 These methods can be used in expressions applied to message throw events like this:
 
@@ -19,24 +19,44 @@ The first argument is the key of the message that should be sent. In this exampl
 As shown in the example above, Valtimo provides a `sendStartMessage` method. The following variations are possible:
 
 ```kotlin
-    fun sendStartMessage(message: String): MessageCorrelationResult
-    fun sendStartMessage(message: String, businessKey: String?): MessageCorrelationResult
-    fun sendStartMessage(message: String, businessKey: String?, variables: Map<String, Any>?): MessageCorrelationResult
-    fun sendStartMessageWithProcessDefinitionKey(message: String,targetProcessDefinitionKey: String,businessKey: String?, variables: Map<String, Any>?): MessageCorrelationResult
+fun sendStartMessage(message: String, businessKey: String): MessageCorrelationResult
+fun sendStartMessage(message: String, businessKey: String, vararg variables: Any?): MessageCorrelationResult
+fun sendStartMessage(message: String, businessKey: String, variables: Map<String, Any?>?): MessageCorrelationResult
+fun sendStartMessageWithProcessDefinitionKey(message: String, targetProcessDefinitionKey: String, businessKey: String)
+fun sendStartMessageWithProcessDefinitionKey(message: String, targetProcessDefinitionKey: String, businessKey: String, vararg variables: Any?)
+fun sendStartMessageWithProcessDefinitionKey(message: String, targetProcessDefinitionKey: String, businessKey: String, variables: Map<String, Any?>?)
 ```
 
 Variables passed on will be stored as process variables for the process. Providing a target process definition key means the message will be correlated to a process definition matching that process definition key.
 
 ### Correlating message catch events
 
-There are two different ways to correlate message catch events. Either correlating a single message to a single catch event, or correlating a single message to any number of catch events. Valtimo supports both of these ways through the `sendCatchEventMessage` and `sendCatchEventMessageToAll` methods. The following variations are possible:
+There are different ways to correlate message catch events. Either correlating a single message to a single catch event, or correlating a single message to any number of catch events. These methods correlate within the same case (by business key). To correlate across all cases, see the next section. Valtimo supports both of these ways through the `sendCatchEventMessage` and `sendCatchEventMessageToAll` methods. The following variations are possible:
 
 ```kotlin
-    fun sendCatchEventMessage(message: String, businessKey: String): MessageCorrelationResult
-    fun sendCatchEventMessage(message: String, businessKey: String, variables: Map<String, Any>?): MessageCorrelationResult
-    
-    fun sendCatchEventMessageToAll(message: String, businessKey: String): List<MessageCorrelationResult>
-    fun sendCatchEventMessageToAll(message: String, businessKey: String, variables: Map<String,Any>?): List<MessageCorrelationResult>
+fun sendCatchEventMessage(message: String, businessKey: String): MessageCorrelationResult
+fun sendCatchEventMessage(message: String, businessKey: String, vararg variables: Any?): MessageCorrelationResult
+fun sendCatchEventMessage(message: String, businessKey: String, variables: Map<String, Any?>?): MessageCorrelationResult
+
+fun sendCatchEventMessageToAll(message: String, businessKey: String): List<MessageCorrelationResult>
+fun sendCatchEventMessageToAll(message: String, businessKey: String, vararg variables: Any?): List<MessageCorrelationResult>
+fun sendCatchEventMessageToAll(message: String, businessKey: String, variables: Map<String, Any?>?): List<MessageCorrelationResult>
 ```
 
 Variables passed on will be stored in the process. The provided business key will correlate the message to events with process instances matching that business key.
+
+### Correlating message catch events globally
+
+To correlate messages across all process instances regardless of which case they belong to, use the `sendGlobalCatchEventMessage` and `sendGlobalCatchEventMessageToAll` methods. These work the same as their non-global counterparts but without a business key filter:
+
+```kotlin
+fun sendGlobalCatchEventMessage(message: String): MessageCorrelationResult
+fun sendGlobalCatchEventMessage(message: String, vararg variables: Any?): MessageCorrelationResult
+fun sendGlobalCatchEventMessage(message: String, variables: Map<String, Any?>?): MessageCorrelationResult
+
+fun sendGlobalCatchEventMessageToAll(message: String): List<MessageCorrelationResult>
+fun sendGlobalCatchEventMessageToAll(message: String, vararg variables: Any?): List<MessageCorrelationResult>
+fun sendGlobalCatchEventMessageToAll(message: String, variables: Map<String, Any?>?): List<MessageCorrelationResult>
+```
+
+Since no business key is provided, these methods will not create a process-document association — though this is only relevant in uncommon cases where a process is started outside the normal flow, in which case managing that association is the responsibility of the caller.

--- a/documentation/nog-een-plek-geven/reference/process-beans.md
+++ b/documentation/nog-een-plek-geven/reference/process-beans.md
@@ -60,6 +60,10 @@ fun sendCatchEventMessage(message: String, businessKey: String)
 fun sendCatchEventMessage(message: String, businessKey: String, variables: Map<String, Any>?)
 fun sendCatchEventMessageToAll(message: String, businessKey: String)
 fun sendCatchEventMessageToAll(message: String, businessKey: String, variables: Map<String, Any>?)
+fun sendGlobalCatchEventMessage(message: String)
+fun sendGlobalCatchEventMessage(message: String, variables: Map<String, Any>?)
+fun sendGlobalCatchEventMessageToAll(message: String)
+fun sendGlobalCatchEventMessageToAll(message: String, variables: Map<String, Any>?)
 ```
 
 Information on all methods can be found [here](../../features/process/correlation-service.md).

--- a/documentation/release-notes/12.x.x/12.30.0/README.md
+++ b/documentation/release-notes/12.x.x/12.30.0/README.md
@@ -2,9 +2,9 @@
 
 ## New Features
 
-* **New feature title**
+* **Cross-case message correlation**
 
-  New feature explanation.
+  New `sendGlobalCatchEventMessage` and `sendGlobalCatchEventMessageToAll` methods on `correlationService` allow messages to be correlated to process instances across all cases, without requiring a business key. See [correlating messages](../../features/process/correlation-service.md) for details.
 
 ## Enhancements
 


### PR DESCRIPTION
Backporting the changes for issue https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/441 / PR https://github.com/valtimo-platform/valtimo/pull/515

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/388

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps  
Same steps as https://github.com/valtimo-platform/valtimo/pull/515 - But because we can't import cases into Valtimo 12, I've created some test cases and committed them under branch `test/issue-441-backport`. Only the linking of the forms don't work, so you will have to do that manually.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
