### PR TITLE
Workflow finalize release

### DIFF
--- a/.github/workflows/backend_publish_release.yml
+++ b/.github/workflows/backend_publish_release.yml
@@ -17,6 +17,8 @@ jobs:
     needs: [build_run_tests]
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref_name, 'release/') }}
+    outputs:
+      version_release: ${{ steps.version.outputs.version_release }}
     env:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -83,3 +85,11 @@ jobs:
         with:
           name: build-reports
           path: backend/build/reports
+
+  trigger_template_releases:
+    needs: [publish]
+    if: ${{ needs.publish.outputs.version_release != '' }}
+    uses: ./.github/workflows/trigger_backend_template_releases.yml
+    with:
+      version: ${{ needs.publish.outputs.version_release }}
+    secrets: inherit

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -1,0 +1,168 @@
+name: Finalize release
+
+# Runs after either backend or frontend publish release completes.
+# Waits until both have succeeded, then:
+# 1. Finalizes release notes (renames next-minor, updates date and SUMMARY.md)
+# 2. Tags the release branch with the semver version
+# 3. Merges the release branch into the stable branch (v12-stable or v13-stable)
+# 4. Creates a new empty next-minor template on the stable branch
+
+on:
+  workflow_run:
+    workflows: ["Backend - Publish release", "Frontend - Publish release"]
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'release/') }}
+
+    steps:
+      - name: "Parse release/x.y.z branch into semver and stable branch name"
+        id: version
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          SEMVER="${BRANCH#release/}"
+          MAJOR=$(echo "$SEMVER" | cut -d. -f1)
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "stable_branch=v${MAJOR}-stable" >> "$GITHUB_OUTPUT"
+
+      - name: "Verify both backend and frontend publish workflows succeeded on this branch"
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = '${{ github.event.workflow_run.head_branch }}';
+
+            const backendRuns = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'backend_publish_release.yml',
+              branch: branch,
+              status: 'success',
+              per_page: 1,
+            });
+
+            const frontendRuns = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'frontend_publish_release.yml',
+              branch: branch,
+              status: 'success',
+              per_page: 1,
+            });
+
+            const bothDone = backendRuns.data.total_count > 0 && frontendRuns.data.total_count > 0;
+            console.log(`Backend success: ${backendRuns.data.total_count > 0}, Frontend success: ${frontendRuns.data.total_count > 0}`);
+            core.setOutput('both_done', bothDone.toString());
+
+      - name: "Checkout the release branch"
+        if: steps.check.outputs.both_done == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: "Rename release-notes"
+        if: steps.check.outputs.both_done == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.semver }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          mv "${NOTES_DIR}/next-minor" "${NOTES_DIR}/${VERSION}"
+          sed -i "s/# ${MAJOR}.XX.X/# ${VERSION}/" "${NOTES_DIR}/${VERSION}/README.md"
+          RELEASE_DATE=$(date +"%d-%m-%Y")
+          sed -i "s/Release date xx-xx-xxxx/Release date ${RELEASE_DATE}/" "${NOTES_DIR}/${VERSION}/README.md"
+
+      - name: "Insert a link to the new release notes in SUMMARY.md"
+        if: steps.check.outputs.both_done == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.semver }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          FIRST_ENTRY="  \* \[${MAJOR}\."
+          NEW_LINE="  * [${VERSION}](release-notes/${MAJOR}.x.x/${VERSION}/README.md)"
+          sed -i "0,/${FIRST_ENTRY}/s||${NEW_LINE}\n&|" documentation/SUMMARY.md
+
+      - name: "Commit release notes changes to the release branch"
+        if: steps.check.outputs.both_done == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.semver }}"
+          git add documentation/
+          git commit -m "Release notes for ${VERSION}"
+          git push
+
+      - name: "Create a git tag for the release version and push it"
+        if: steps.check.outputs.both_done == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.semver }}"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists, skipping"
+          else
+            git tag "$VERSION"
+            git push origin "$VERSION"
+            echo "Tagged and pushed $VERSION"
+          fi
+
+      - name: "Merge release branch into stable branch (e.g. v12-stable or v13-stable)"
+        if: steps.check.outputs.both_done == 'true'
+        run: |
+          STABLE="${{ steps.version.outputs.stable_branch }}"
+          RELEASE="${{ github.event.workflow_run.head_branch }}"
+          git fetch origin "$STABLE"
+          git checkout "$STABLE"
+          git merge "$RELEASE" --no-edit
+          git push origin "$STABLE"
+          echo "Merged $RELEASE into $STABLE"
+
+      - name: "v13+: Create next-minor release notes template on the stable branch"
+        if: steps.check.outputs.both_done == 'true' && !startsWith(steps.version.outputs.semver, '12.')
+        run: |
+          VERSION="${{ steps.version.outputs.semver }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          STABLE="${{ steps.version.outputs.stable_branch }}"
+          NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
+          mkdir -p "${NOTES_DIR}/next-minor"
+          printf '%s\n' \
+            "# ${MAJOR}.XX.X" \
+            "" \
+            "{% hint style=\"info\" %}" \
+            "**Release date xx-xx-xxxx**" \
+            "{% endhint %}" \
+            "" \
+            "" \
+            > "${NOTES_DIR}/next-minor/README.md"
+          git add "${NOTES_DIR}/next-minor/README.md"
+          git commit -m "Add empty next-minor release notes template"
+          git push origin "$STABLE"
+
+      - name: "v12: Create next rc branch with next-minor release notes template"
+        if: steps.check.outputs.both_done == 'true' && startsWith(steps.version.outputs.semver, '12.')
+        run: |
+          VERSION="${{ steps.version.outputs.semver }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          NEXT_MINOR=$((MINOR + 1))
+          RC_BRANCH="rc/${MAJOR}.${NEXT_MINOR}.0"
+          STABLE="${{ steps.version.outputs.stable_branch }}"
+          NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
+          git checkout -b "$RC_BRANCH"
+          mkdir -p "${NOTES_DIR}/next-minor"
+          printf '%s\n' \
+            "# ${MAJOR}.XX.X" \
+            "" \
+            "{% hint style=\"info\" %}" \
+            "**Release date xx-xx-xxxx**" \
+            "{% endhint %}" \
+            "" \
+            "" \
+            > "${NOTES_DIR}/next-minor/README.md"
+          git add "${NOTES_DIR}/next-minor/README.md"
+          git commit -m "Add empty next-minor release notes template"
+          git push origin "$RC_BRANCH"
+          echo "Created branch $RC_BRANCH with next-minor template"

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -17,6 +17,9 @@ permissions:
   contents: write
   actions: read
 
+concurrency:
+  group: finalize-release-${{ github.event.workflow_run.head_branch }}
+
 jobs:
   finalize:
     runs-on: ubuntu-latest
@@ -77,6 +80,10 @@ jobs:
           NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ ! -d "${NOTES_DIR}/next-minor" ]; then
+            echo "next-minor already renamed, skipping"
+            exit 0
+          fi
           mv "${NOTES_DIR}/next-minor" "${NOTES_DIR}/${VERSION}"
           sed -i "s/# ${MAJOR}.XX.X/# ${VERSION}/" "${NOTES_DIR}/${VERSION}/README.md"
           RELEASE_DATE=$(date +"%d-%m-%Y")
@@ -96,8 +103,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.semver }}"
           git add documentation/
-          git commit -m "Release notes for ${VERSION}"
-          git push
+          git diff --cached --quiet && echo "No release notes changes to commit" || (git commit -m "Release notes for ${VERSION}" && git push)
 
       - name: "Create a git tag for the release version and push it"
         if: steps.check.outputs.both_done == 'true'
@@ -154,6 +160,10 @@ jobs:
           NEXT_MINOR=$((MINOR + 1))
           RC_BRANCH="rc/${MAJOR}.${NEXT_MINOR}.0"
           NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
+          if git ls-remote --exit-code origin "$RC_BRANCH" >/dev/null 2>&1; then
+            echo "Branch $RC_BRANCH already exists, skipping"
+            exit 0
+          fi
           git checkout "$RELEASE_BRANCH"
           git checkout -b "$RC_BRANCH"
           mkdir -p "${NOTES_DIR}/next-minor"

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -5,7 +5,8 @@ name: Finalize release
 # 1. Finalizes release notes (renames next-minor, updates date and SUMMARY.md)
 # 2. Tags the release branch with the semver version
 # 3. Merges the release branch into the stable branch (v12-stable or v13-stable)
-# 4. Creates a new empty next-minor template on the stable branch
+# 4. v13+: Merges stable into next-minor branch and adds empty release notes template
+# 4. v12: Creates a new rc/{major}.{next_minor}.0 branch from the release branch with empty release notes template
 
 on:
   workflow_run:
@@ -17,7 +18,7 @@ permissions:
   actions: read
 
 jobs:
-  tag:
+  finalize:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'release/') }}
 
@@ -120,13 +121,16 @@ jobs:
           git push origin "$STABLE"
           echo "Merged $RELEASE into $STABLE"
 
-      - name: "v13+: Create next-minor release notes template on the stable branch"
+      - name: "v13+: Merge stable into next-minor branch, then add release notes template"
         if: steps.check.outputs.both_done == 'true' && !startsWith(steps.version.outputs.semver, '12.')
         run: |
           VERSION="${{ steps.version.outputs.semver }}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           STABLE="${{ steps.version.outputs.stable_branch }}"
           NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
+          git fetch origin next-minor
+          git checkout next-minor
+          git merge "$STABLE" --no-edit
           mkdir -p "${NOTES_DIR}/next-minor"
           printf '%s\n' \
             "# ${MAJOR}.XX.X" \
@@ -139,9 +143,9 @@ jobs:
             > "${NOTES_DIR}/next-minor/README.md"
           git add "${NOTES_DIR}/next-minor/README.md"
           git commit -m "Add empty next-minor release notes template"
-          git push origin "$STABLE"
+          git push origin next-minor
 
-      - name: "v12: Create next rc branch with next-minor release notes template"
+      - name: "v12: Create next rc branch from release branch with next-minor release notes template"
         if: steps.check.outputs.both_done == 'true' && startsWith(steps.version.outputs.semver, '12.')
         run: |
           VERSION="${{ steps.version.outputs.semver }}"
@@ -149,8 +153,9 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           NEXT_MINOR=$((MINOR + 1))
           RC_BRANCH="rc/${MAJOR}.${NEXT_MINOR}.0"
-          STABLE="${{ steps.version.outputs.stable_branch }}"
+          RELEASE="${{ github.event.workflow_run.head_branch }}"
           NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
+          git checkout "$RELEASE"
           git checkout -b "$RC_BRANCH"
           mkdir -p "${NOTES_DIR}/next-minor"
           printf '%s\n' \

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -21,13 +21,14 @@ jobs:
   finalize:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'release/') }}
+    env:
+      RELEASE_BRANCH: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: "Parse release/x.y.z branch into semver and stable branch name"
         id: version
         run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
-          SEMVER="${BRANCH#release/}"
+          SEMVER="${RELEASE_BRANCH#release/}"
           MAJOR=$(echo "$SEMVER" | cut -d. -f1)
           echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
           echo "stable_branch=v${MAJOR}-stable" >> "$GITHUB_OUTPUT"
@@ -37,7 +38,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branch = '${{ github.event.workflow_run.head_branch }}';
+            const branch = process.env.RELEASE_BRANCH;
 
             const backendRuns = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
@@ -65,7 +66,7 @@ jobs:
         if: steps.check.outputs.both_done == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ env.RELEASE_BRANCH }}
           fetch-depth: 0
 
       - name: "Rename release-notes"
@@ -114,12 +115,11 @@ jobs:
         if: steps.check.outputs.both_done == 'true'
         run: |
           STABLE="${{ steps.version.outputs.stable_branch }}"
-          RELEASE="${{ github.event.workflow_run.head_branch }}"
           git fetch origin "$STABLE"
           git checkout "$STABLE"
-          git merge "$RELEASE" --no-edit
+          git merge "$RELEASE_BRANCH" --no-edit
           git push origin "$STABLE"
-          echo "Merged $RELEASE into $STABLE"
+          echo "Merged $RELEASE_BRANCH into $STABLE"
 
       - name: "v13+: Merge stable into next-minor branch, then add release notes template"
         if: steps.check.outputs.both_done == 'true' && !startsWith(steps.version.outputs.semver, '12.')
@@ -153,9 +153,8 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           NEXT_MINOR=$((MINOR + 1))
           RC_BRANCH="rc/${MAJOR}.${NEXT_MINOR}.0"
-          RELEASE="${{ github.event.workflow_run.head_branch }}"
           NOTES_DIR="documentation/release-notes/${MAJOR}.x.x"
-          git checkout "$RELEASE"
+          git checkout "$RELEASE_BRANCH"
           git checkout -b "$RC_BRANCH"
           mkdir -p "${NOTES_DIR}/next-minor"
           printf '%s\n' \

--- a/.github/workflows/frontend_publish_release.yml
+++ b/.github/workflows/frontend_publish_release.yml
@@ -47,3 +47,12 @@ jobs:
       project_version: ${{ needs.determine_version.outputs.project_version }}
       frontend_libraries_build_artifact_name: ${{ needs.build_and_test_libs.outputs.build_artifact_name }}
     secrets: inherit
+
+  trigger_template_releases:
+    needs:
+      - publish
+      - determine_version
+    uses: ./.github/workflows/trigger_frontend_template_releases.yml
+    with:
+      version: ${{ needs.determine_version.outputs.project_version }}
+    secrets: inherit

--- a/.github/workflows/trigger_backend_template_releases.yml
+++ b/.github/workflows/trigger_backend_template_releases.yml
@@ -1,0 +1,38 @@
+name: Trigger backend template releases
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'The version to release (e.g. 12.30.0.RELEASE)'
+        required: true
+        type: string
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          - generiekzaakafhandelcomponent/gzac-backend-template
+          - generiekzaakafhandelcomponent/gzac-evenementenvergunning-demo-backend
+          - valtimo-platform/valtimo-backend-template
+    steps:
+      - name: Determine target branch
+        id: branch
+        run: |
+          MAJOR=$(echo "${{ inputs.version }}" | cut -d. -f1)
+          echo "ref=v/${MAJOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger release workflow
+        if: ${{ secrets.TEMPLATE_RELEASE_PAT != '' }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.TEMPLATE_RELEASE_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ matrix.repo }}/actions/workflows/release.yml/dispatches" \
+            -d '{"ref": "${{ steps.branch.outputs.ref }}", "inputs": {"version": "${{ inputs.version }}"}}'
+
+      - name: Skip - PAT not configured
+        if: ${{ secrets.TEMPLATE_RELEASE_PAT == '' }}
+        run: echo "TEMPLATE_RELEASE_PAT not configured, skipping trigger for ${{ matrix.repo }}"

--- a/.github/workflows/trigger_backend_template_releases.yml
+++ b/.github/workflows/trigger_backend_template_releases.yml
@@ -1,5 +1,7 @@
 name: Trigger backend template releases
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/trigger_backend_template_releases.yml
+++ b/.github/workflows/trigger_backend_template_releases.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    env:
+      TEMPLATE_RELEASE_PAT: ${{ secrets.TEMPLATE_RELEASE_PAT }}
     strategy:
       matrix:
         repo:
@@ -27,14 +29,14 @@ jobs:
           echo "ref=v/${MAJOR}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger release workflow
-        if: ${{ secrets.TEMPLATE_RELEASE_PAT != '' }}
+        if: ${{ env.TEMPLATE_RELEASE_PAT != '' }}
         run: |
-          curl -X POST \
+          curl -f -sS -X POST \
             -H "Authorization: token ${{ secrets.TEMPLATE_RELEASE_PAT }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ matrix.repo }}/actions/workflows/release.yml/dispatches" \
             -d '{"ref": "${{ steps.branch.outputs.ref }}", "inputs": {"version": "${{ inputs.version }}"}}'
 
       - name: Skip - PAT not configured
-        if: ${{ secrets.TEMPLATE_RELEASE_PAT == '' }}
+        if: ${{ env.TEMPLATE_RELEASE_PAT == '' }}
         run: echo "TEMPLATE_RELEASE_PAT not configured, skipping trigger for ${{ matrix.repo }}"

--- a/.github/workflows/trigger_frontend_template_releases.yml
+++ b/.github/workflows/trigger_frontend_template_releases.yml
@@ -1,5 +1,7 @@
 name: Trigger frontend template releases
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/trigger_frontend_template_releases.yml
+++ b/.github/workflows/trigger_frontend_template_releases.yml
@@ -1,0 +1,38 @@
+name: Trigger frontend template releases
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'The version to release (e.g. 12.30.0)'
+        required: true
+        type: string
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          - generiekzaakafhandelcomponent/gzac-frontend-template
+          - generiekzaakafhandelcomponent/gzac-evenementenvergunning-demo-frontend
+          - valtimo-platform/valtimo-frontend-template
+    steps:
+      - name: Determine target branch
+        id: branch
+        run: |
+          MAJOR=$(echo "${{ inputs.version }}" | cut -d. -f1)
+          echo "ref=v/${MAJOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger release workflow
+        if: ${{ secrets.TEMPLATE_RELEASE_PAT != '' }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.TEMPLATE_RELEASE_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ matrix.repo }}/actions/workflows/release.yml/dispatches" \
+            -d '{"ref": "${{ steps.branch.outputs.ref }}", "inputs": {"version": "${{ inputs.version }}"}}'
+
+      - name: Skip - PAT not configured
+        if: ${{ secrets.TEMPLATE_RELEASE_PAT == '' }}
+        run: echo "TEMPLATE_RELEASE_PAT not configured, skipping trigger for ${{ matrix.repo }}"

--- a/.github/workflows/trigger_frontend_template_releases.yml
+++ b/.github/workflows/trigger_frontend_template_releases.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    env:
+      TEMPLATE_RELEASE_PAT: ${{ secrets.TEMPLATE_RELEASE_PAT }}
     strategy:
       matrix:
         repo:
@@ -27,14 +29,14 @@ jobs:
           echo "ref=v/${MAJOR}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger release workflow
-        if: ${{ secrets.TEMPLATE_RELEASE_PAT != '' }}
+        if: ${{ env.TEMPLATE_RELEASE_PAT != '' }}
         run: |
-          curl -X POST \
+          curl -f -sS -X POST \
             -H "Authorization: token ${{ secrets.TEMPLATE_RELEASE_PAT }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ matrix.repo }}/actions/workflows/release.yml/dispatches" \
             -d '{"ref": "${{ steps.branch.outputs.ref }}", "inputs": {"version": "${{ inputs.version }}"}}'
 
       - name: Skip - PAT not configured
-        if: ${{ secrets.TEMPLATE_RELEASE_PAT == '' }}
+        if: ${{ env.TEMPLATE_RELEASE_PAT == '' }}
         run: echo "TEMPLATE_RELEASE_PAT not configured, skipping trigger for ${{ matrix.repo }}"

--- a/documentation/release-notes/13.x.x/next-minor/README.md
+++ b/documentation/release-notes/13.x.x/next-minor/README.md
@@ -1,0 +1,6 @@
+# 13.XX.X
+
+{% hint style="info" %}
+**Release date xx-xx-xxxx**
+{% endhint %}
+


### PR DESCRIPTION
## Automate post-release pipeline

### Finalize release workflow (`finalize_release.yml`)

Triggered automatically when either publish workflow completes. Waits until **both** backend and frontend have succeeded, then:

1. **Release notes** — Renames 
   1. `/release-notes/13.x.x/next-minor/README.md` to the release version `/release-notes/13.x.x/13.xx.x/README.md `
   3.  Sets the release date
   4.  Adds a link in `SUMMARY.md`
5. **Git tag** — Tags the release branch with the semver version (e.g. `13.24.0`)
6. **Merge to stable** — Merges the release branch into `v{major}-stable` (no squash)
7. **Prepare next release**:
   - **v13+**: Merges v{major}-stable into the next-minor branch, then creates a new empty /release-notes/13.x.x/next-minor/README.md
   - **v12**: Creates a new rc/12.{next_minor}.0 branch from the release branch with an empty /release-notes/12.x.x/next-minor/README.md


### Template trigger workflows

After publishing, the backend/frontend workflows try to trigger release builds in 6 template repos across two orgs:

| Backend templates | Frontend templates |
|---|---|
| `gzac-backend-template` | `gzac-frontend-template` |
| `gzac-evenementenvergunning-demo-backend` | `gzac-evenementenvergunning-demo-frontend` |
| `valtimo-backend-template` | `valtimo-frontend-template` |
