### PR TITLE
Enhance form-flow to redirect to newly created case

### DIFF
--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/common/ValtimoFormFlow.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/common/ValtimoFormFlow.kt
@@ -30,7 +30,6 @@ import com.ritense.formflow.expression.FormFlowBean
 import com.ritense.formflow.service.FormFlowService
 import com.ritense.processdocument.domain.impl.request.StartProcessForDocumentRequest
 import com.ritense.processdocument.service.ProcessDocumentService
-import com.ritense.valtimo.contract.json.MapperSingleton
 import com.ritense.valtimo.service.OperatonTaskService
 import com.ritense.valueresolver.ValueResolverService
 import java.util.Objects
@@ -99,14 +98,14 @@ open class ValtimoFormFlow(
     open fun startCase(
         formFlowInstanceId: FormFlowInstanceId,
         submissionSavePath: Map<String, String>
-    ) {
+    ): Map<String, Any> {
         val formFlowInstance = formFlowService.getInstanceById(formFlowInstanceId)
         val documentDefinitionName = getRequiredAdditionalProperty(
             formFlowInstance.getAdditionalProperties(),
             "documentDefinitionName"
         ).toString()
 
-        val submission = MapperSingleton.get().readValue<JsonNode>(formFlowInstance.getSubmissionDataContext())
+        val submission = objectMapper.readValue<JsonNode>(formFlowInstance.getSubmissionDataContext())
 
         val submissionValues = submissionSavePath.entries
             .associate { it.key to getValue(submission, it.value) }
@@ -119,11 +118,11 @@ open class ValtimoFormFlow(
                     documentDefinitionName,
                     formFlowInstance.formFlowDefinition.id.caseDefinitionId!!.key,
                     formFlowInstance.formFlowDefinition.id.caseDefinitionId!!.versionTag.version,
-                    submittedByType["doc"] as JsonNode
+                    submittedByType["doc"] as JsonNode? ?: objectMapper.createObjectNode()
                 )
             )
         }.also { result ->
-            if (result.errors().size > 0) {
+            if (result.errors().isNotEmpty()) {
                 throw RuntimeException(
                     "Could not create document for document definition $documentDefinitionName\n" +
                         REASON +
@@ -149,6 +148,7 @@ open class ValtimoFormFlow(
                     startProcessForDocumentResult.errors().joinToString(separator = "\n - ")
             )
         }
+        return mapOf("documentId" to startProcessForDocumentResult.resultingDocument().get().id().id)
     }
 
     /**
@@ -165,7 +165,7 @@ open class ValtimoFormFlow(
             "documentId"
         ).toString()
 
-        val submission = MapperSingleton.get().readValue<JsonNode>(formFlowInstance.getSubmissionDataContext())
+        val submission = objectMapper.readValue<JsonNode>(formFlowInstance.getSubmissionDataContext())
         val submissionValues = submissionSavePath.entries
             .associate { it.key to getValue(submission, it.value) }
             .filter { it.value !is MissingNode }

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowCompleteResult.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowCompleteResult.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.formflow.domain.instance
+
+data class FormFlowCompleteResult(
+    val nextStep: FormFlowStepInstance?,
+    val onCompleteResult: List<Any>
+)

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowInstance.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowInstance.kt
@@ -75,23 +75,24 @@ class FormFlowInstance(
     fun complete(
         currentFormFlowStepInstanceId: FormFlowStepInstanceId,
         submissionData: JSONObject
-    ): FormFlowStepInstance? {
+    ): FormFlowCompleteResult {
         return withLoggingContext(FormFlowStepInstance::class.java.canonicalName to currentFormFlowStepInstanceId.toString()) {
             if (this.currentFormFlowStepInstanceId != currentFormFlowStepInstanceId) {
-                return getCurrentStep()
+                return FormFlowCompleteResult(getCurrentStep(), emptyList())
             }
 
             val formFlowStepInstance = getCurrentStep()
 
-            formFlowStepInstance.complete(submissionData.toString())
+            val onCompleteResult = formFlowStepInstance.complete(submissionData.toString())
 
             val nextStep = navigateToNextStep()
             check(nextStep != null || formFlowStepInstance.definition.onComplete.isNotEmpty()) {
                 "Form flow end reached but no action was taken because the 'onComplete' is empty. For form flow step: '${formFlowStepInstance.definition.id}'"
             }
-            nextStep
+            FormFlowCompleteResult(nextStep, onCompleteResult)
         }
     }
+
 
     /**
      * This method navigates to the previous step (if present).

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowStepInstance.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowStepInstance.kt
@@ -73,8 +73,8 @@ data class FormFlowStepInstance(
     val definition: FormFlowStep
         get() = instance.formFlowDefinition.getStepByKey(stepKey)
 
-    fun back() {
-        processExpressions<Any>(definition.onBack)
+    fun back(): List<Any> {
+        return processExpressions<Any>(definition.onBack).filterNotNull()
     }
 
     fun saveTemporary(incompleteSubmissionData: String) {
@@ -82,11 +82,11 @@ data class FormFlowStepInstance(
         this.submissionOrder = nextSubmissionOrder(instance)
     }
 
-    fun open() {
-        processExpressions<Any>(definition.onOpen)
+    fun open(): List<Any> {
+        return processExpressions<Any>(definition.onOpen).filterNotNull()
     }
 
-    fun complete(submissionData: String) {
+    fun complete(submissionData: String): List<Any> {
         val previousStep = instance.getHistory().firstOrNull { it.order == order - 1 }
         val previousStepSubmissionDataChanged = previousStep?.submissionOrder ?: -1 >= submissionOrder
         if (this.submissionData != submissionData || previousStepSubmissionDataChanged) {
@@ -95,10 +95,11 @@ data class FormFlowStepInstance(
         this.submissionData = submissionData
         this.temporarySubmissionData = null
 
-        processExpressions<Any>(definition.onComplete)
+        val result = processExpressions<Any>(definition.onComplete)
         ApplicationEventPublisherHolder.getInstance().publishEvent(
             FormFlowStepCompletedEvent(this)
         )
+        return result.filterNotNull()
     }
 
     fun determineNextStep(): FormFlowNextStep? {

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/FormFlowResource.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/FormFlowResource.kt
@@ -61,12 +61,13 @@ class FormFlowResource(
             FormFlowInstanceId.existingId(instanceId)
         ) ?: return ResponseEntity
             .badRequest()
-            .body(GetFormFlowStateResult(null, null, "No form flow instance can be found for the given instance id"))
+            .body(GetFormFlowStateResult(errorMessage = "No form flow instance can be found for the given instance id"))
 
         val stepInstance = instance.getCurrentStep()
+        val openResult = stepInstance.open()
         formFlowService.save(instance)
 
-        return ResponseEntity.ok(GetFormFlowStateResult(instance.id.id, openStep(stepInstance)))
+        return ResponseEntity.ok(GetFormFlowStateResult(instance.id.id, toStepResult(stepInstance), toResultList(openResult)))
     }
 
     @PostMapping(
@@ -84,13 +85,16 @@ class FormFlowResource(
         val instance = formFlowService.getByInstanceIdIfExists(FormFlowInstanceId.existingId(formFlowId))!!
         val verifiedSubmissionData = formFlowValtimoService.getVerifiedSubmissionData(submissionData, instance)
 
-        val stepInstance = instance.complete(
+        val completeResult = instance.complete(
             FormFlowStepInstanceId.existingId(stepInstanceId),
             toJsonObject(verifiedSubmissionData)
         )
         formFlowService.save(instance)
 
-        return ResponseEntity.ok(CompleteStepResult(instance.id.id, openStep(stepInstance)))
+        val nextStep = completeResult.nextStep
+        val onCompleteResult = toResultList(completeResult.onCompleteResult)
+        val onOpenResult = nextStep?.let { toResultList(it.open()) }
+        return ResponseEntity.ok(CompleteStepResult(instance.id.id, nextStep?.let { toStepResult(it) }, onOpenResult, onCompleteResult))
     }
 
     @PostMapping(
@@ -112,7 +116,8 @@ class FormFlowResource(
         val stepInstance = instance.back()
         formFlowService.save(instance)
 
-        return ResponseEntity.ok(GetFormFlowStateResult(instance.id.id, openStep(stepInstance)))
+        val openResult = stepInstance?.let { toResultList(it.open()) }
+        return ResponseEntity.ok(GetFormFlowStateResult(instance.id.id, stepInstance?.let { toStepResult(it) }, onOpenResult = openResult))
     }
 
     @PostMapping(
@@ -153,8 +158,9 @@ class FormFlowResource(
         formFlowService.save(instance)
 
         val stepInstance = instance.navigateToStep(FormFlowStepInstanceId.existingId(targetStepInstanceId))
+        val openResult = toResultList(stepInstance.open())
 
-        return ResponseEntity.ok(GetFormFlowStateResult(instance.id.id, openStep(stepInstance)))
+        return ResponseEntity.ok(GetFormFlowStateResult(instance.id.id, toStepResult(stepInstance), openResult))
     }
 
     @GetMapping("/v1/form-flow/instance/{formFlowId}/breadcrumbs")
@@ -164,21 +170,20 @@ class FormFlowResource(
     ): ResponseEntity<FormFlowBreadcrumbsResponse> {
         val instance = formFlowService.getByInstanceIdIfExists(FormFlowInstanceId.existingId(formFlowId))!!
         val breadcrumbs = formFlowService.getBreadcrumbs(instance)
-        val response = FormFlowBreadcrumbsResponse.of(instance.currentFormFlowStepInstanceId!!.id, breadcrumbs)
+        val response = FormFlowBreadcrumbsResponse.of(instance.currentFormFlowStepInstanceId?.id, breadcrumbs)
         return ResponseEntity.ok(response)
     }
 
-    private fun openStep(stepInstance: FormFlowStepInstance?): FormFlowStepResult? {
-        return if (stepInstance != null) {
-            stepInstance.open()
-            FormFlowStepResult(
-                stepInstance.id.id,
-                stepInstance.definition.type.name,
-                formFlowService.getTypeProperties(stepInstance)
-            )
-        } else {
-            null
-        }
+    private fun toStepResult(stepInstance: FormFlowStepInstance): FormFlowStepResult {
+        return FormFlowStepResult(
+            stepInstance.id.id,
+            stepInstance.definition.type.name,
+            formFlowService.getTypeProperties(stepInstance)
+        )
+    }
+
+    private fun toResultList(expressionResults: List<Any>): List<Any>? {
+        return expressionResults.ifEmpty { null }
     }
 
     private fun toJsonObject(jsonNode: JsonNode?): JSONObject {

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/dto/FormFlowBreadcrumbsResponse.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/dto/FormFlowBreadcrumbsResponse.kt
@@ -28,7 +28,9 @@ data class FormFlowBreadcrumbsResponse(
             val currentStepIndex = if (currentStepInstanceId == null) {
                 breadcrumbs.size
             } else {
-                breadcrumbs.indexOfFirst { it.stepInstanceId == currentStepInstanceId }
+                breadcrumbs
+                    .indexOfFirst { it.stepInstanceId == currentStepInstanceId }
+                    .takeIf { it >= 0 } ?: 0
             }
             return FormFlowBreadcrumbsResponse(
                 currentStepIndex = currentStepIndex,

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/dto/FormFlowBreadcrumbsResponse.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/dto/FormFlowBreadcrumbsResponse.kt
@@ -24,10 +24,17 @@ data class FormFlowBreadcrumbsResponse(
     val breadcrumbs: List<FormFlowBreadcrumbResponse>
 ) {
     companion object {
-        fun of(currentStepInstanceId: UUID, breadcrumbs: List<FormFlowBreadcrumb>) = FormFlowBreadcrumbsResponse(
-            currentStepIndex = breadcrumbs.indexOfFirst { it.stepInstanceId == currentStepInstanceId },
-            breadcrumbs = breadcrumbs.map { FormFlowBreadcrumbResponse.of(it) }
-        )
+        fun of(currentStepInstanceId: UUID?, breadcrumbs: List<FormFlowBreadcrumb>): FormFlowBreadcrumbsResponse {
+            val currentStepIndex = if (currentStepInstanceId == null) {
+                breadcrumbs.size
+            } else {
+                breadcrumbs.indexOfFirst { it.stepInstanceId == currentStepInstanceId }
+            }
+            return FormFlowBreadcrumbsResponse(
+                currentStepIndex = currentStepIndex,
+                breadcrumbs = breadcrumbs.map { FormFlowBreadcrumbResponse.of(it) }
+            )
+        }
     }
 }
 

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/result/CompleteStepResult.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/result/CompleteStepResult.kt
@@ -18,7 +18,9 @@ package com.ritense.formflow.web.rest.result
 
 import java.util.UUID
 
-class CompleteStepResult(
+data class CompleteStepResult(
     val id: UUID,
-    val step: FormFlowStepResult?
+    val step: FormFlowStepResult?,
+    val onOpenResult: List<Any>? = null,
+    val onCompleteResult: List<Any>? = null,
 )

--- a/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/result/GetFormFlowStateResult.kt
+++ b/backend/form-flow/src/main/kotlin/com/ritense/formflow/web/rest/result/GetFormFlowStateResult.kt
@@ -21,5 +21,6 @@ import java.util.UUID
 class GetFormFlowStateResult(
     val id: UUID? = null,
     val step: FormFlowStepResult? = null,
+    val onOpenResult: List<Any>? = null,
     val errorMessage: String? = null
 )

--- a/backend/form-flow/src/test/kotlin/com/ritense/formflow/domain/FormFlowInstanceTest.kt
+++ b/backend/form-flow/src/test/kotlin/com/ritense/formflow/domain/FormFlowInstanceTest.kt
@@ -77,8 +77,8 @@ internal class FormFlowInstanceTest : BaseTest() {
         val result = instance.complete(instance.currentFormFlowStepInstanceId!!, JSONObject("{\"data\":\"data\"}"))
 
         assertThat(instance.getHistory()[0].submissionData, equalTo("{\"data\":\"data\"}"))
-        assertNotNull(result)
-        assertEquals("test2", result!!.stepKey)
+        assertNotNull(result.nextStep)
+        assertEquals("test2", result.nextStep!!.stepKey)
     }
 
     @Test
@@ -102,7 +102,7 @@ internal class FormFlowInstanceTest : BaseTest() {
         val result = instance.complete(instance.currentFormFlowStepInstanceId!!, JSONObject("{\"data\":\"data\"}"))
 
         assertThat(instance.getHistory()[0].submissionData, equalTo("{\"data\":\"data\"}"))
-        assertNull(result)
+        assertNull(result.nextStep)
     }
 
     @Test
@@ -155,9 +155,9 @@ internal class FormFlowInstanceTest : BaseTest() {
             formFlowDefinition = definition
         )
 
-        val stepInstance = instance.complete(FormFlowStepInstanceId.newId(), JSONObject("{\"data\": \"data\"}"))
+        val result = instance.complete(FormFlowStepInstanceId.newId(), JSONObject("{\"data\": \"data\"}"))
 
-        assertEquals("step1", stepInstance!!.definition.id.key)
+        assertEquals("step1", result.nextStep!!.definition.id.key)
     }
 
     @Test

--- a/backend/form-flow/src/test/kotlin/com/ritense/formflow/event/FormFlowStepCompletedIntTest.kt
+++ b/backend/form-flow/src/test/kotlin/com/ritense/formflow/event/FormFlowStepCompletedIntTest.kt
@@ -72,12 +72,12 @@ internal class FormFlowStepCompletedIntTest : BaseIntegrationTest() {
 
     private fun completeStep(instance: FormFlowInstance): FormFlowStepInstance {
         instance.getCurrentStep().open()
-        val formFlowStepInstance = instance.complete(
+        val result = instance.complete(
             instance.currentFormFlowStepInstanceId!!,
             JSONObject("""{"test":"data"}""")
         )
         formFlowService.save(instance)
-        return formFlowStepInstance!!
+        return result.nextStep!!
     }
 
 }

--- a/backend/form-flow/src/test/kotlin/com/ritense/formflow/rest/FormFlowResourceTest.kt
+++ b/backend/form-flow/src/test/kotlin/com/ritense/formflow/rest/FormFlowResourceTest.kt
@@ -20,6 +20,7 @@ import com.ritense.formflow.domain.definition.FormFlowStep
 import com.ritense.formflow.domain.definition.FormFlowStepId
 import com.ritense.formflow.domain.definition.configuration.FormFlowStepType
 import com.ritense.formflow.domain.definition.configuration.step.FormStepTypeProperties
+import com.ritense.formflow.domain.instance.FormFlowCompleteResult
 import com.ritense.formflow.domain.instance.FormFlowInstance
 import com.ritense.formflow.domain.instance.FormFlowInstanceId
 import com.ritense.formflow.domain.instance.FormFlowStepInstance
@@ -134,7 +135,7 @@ class FormFlowResourceTest : BaseTest() {
 
     @Test
     fun `should complete step`() {
-        whenever(formFlowInstance.complete(any(), any())).thenReturn(stepInstance)
+        whenever(formFlowInstance.complete(any(), any())).thenReturn(FormFlowCompleteResult(stepInstance, emptyList()))
 
         mockMvc.perform(post("/api/v1/form-flow/instance/{flowId}/step/instance/{stepId}", formFlowInstance.id.id, formFlowInstance.getCurrentStep().id.id))
             .andDo(print())
@@ -193,5 +194,90 @@ class FormFlowResourceTest : BaseTest() {
             .andExpect(status().isNoContent)
 
         verify(formFlowInstance).saveTemporary(any())
+    }
+
+    @Test
+    fun `should return onCompleteResult when flow completes`() {
+        val documentId = UUID.randomUUID()
+        whenever(formFlowInstance.complete(any(), any())).thenReturn(
+            FormFlowCompleteResult(null, listOf(mapOf("documentId" to documentId)))
+        )
+
+        mockMvc.perform(post("/api/v1/form-flow/instance/{flowId}/step/instance/{stepId}", formFlowInstance.id.id, formFlowInstance.getCurrentStep().id.id))
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(formFlowInstance.id.id.toString()))
+            .andExpect(jsonPath("$.step").doesNotExist())
+            .andExpect(jsonPath("$.onCompleteResult").isArray)
+            .andExpect(jsonPath("$.onCompleteResult[0].documentId").value(documentId.toString()))
+            .andExpect(jsonPath("$.onOpenResult").doesNotExist())
+    }
+
+    @Test
+    fun `should not return results when onComplete result is empty`() {
+        whenever(formFlowInstance.complete(any(), any())).thenReturn(
+            FormFlowCompleteResult(stepInstance, emptyList())
+        )
+
+        mockMvc.perform(post("/api/v1/form-flow/instance/{flowId}/step/instance/{stepId}", formFlowInstance.id.id, formFlowInstance.getCurrentStep().id.id))
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.step").isNotEmpty)
+            .andExpect(jsonPath("$.onCompleteResult").doesNotExist())
+            .andExpect(jsonPath("$.onOpenResult").doesNotExist())
+    }
+
+    @Test
+    fun `should return separate onCompleteResult and onOpenResult when completing to next step`() {
+        val nextStepInstance: FormFlowStepInstance = mock()
+        val nextStepInstanceId = FormFlowStepInstanceId.newId()
+        val nextStep = FormFlowStep(
+            FormFlowStepId("step2"),
+            type = FormFlowStepType("form", FormStepTypeProperties("second-form-definition"))
+        )
+        whenever(nextStepInstance.id).thenReturn(nextStepInstanceId)
+        whenever(nextStepInstance.definition).thenReturn(nextStep)
+        whenever(nextStepInstance.open()).thenReturn(listOf(mapOf("openKey" to "openValue")))
+
+        whenever(formFlowInstance.complete(any(), any())).thenReturn(
+            FormFlowCompleteResult(nextStepInstance, listOf(mapOf("completeKey" to "completeValue")))
+        )
+
+        mockMvc.perform(post("/api/v1/form-flow/instance/{flowId}/step/instance/{stepId}", formFlowInstance.id.id, formFlowInstance.getCurrentStep().id.id))
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.step.id").value(nextStepInstanceId.id.toString()))
+            .andExpect(jsonPath("$.onCompleteResult").isArray)
+            .andExpect(jsonPath("$.onCompleteResult[0].completeKey").value("completeValue"))
+            .andExpect(jsonPath("$.onOpenResult").isArray)
+            .andExpect(jsonPath("$.onOpenResult[0].openKey").value("openValue"))
+
+        verify(nextStepInstance).open()
+    }
+
+    @Test
+    fun `should return onOpenResult in getFormFlowState`() {
+        whenever(stepInstance.open()).thenReturn(listOf(mapOf("onOpenKey" to "onOpenValue")))
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/form-flow/instance/{instanceId}", formFlowInstanceId.id.toString())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.onOpenResult").isArray)
+            .andExpect(jsonPath("$.onOpenResult[0].onOpenKey").value("onOpenValue"))
+    }
+
+    @Test
+    fun `should return onOpenResult when navigating back`() {
+        whenever(formFlowInstance.back()).thenReturn(stepInstance)
+        whenever(stepInstance.open()).thenReturn(listOf(mapOf("backOpenKey" to "backOpenValue")))
+
+        mockMvc.perform(post("/api/v1/form-flow/instance/{flowId}/back", formFlowInstance.id.id))
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.onOpenResult").isArray)
+            .andExpect(jsonPath("$.onOpenResult[0].backOpenKey").value("backOpenValue"))
     }
 }

--- a/documentation/release-notes/13.x.x/13.24.0/README.md
+++ b/documentation/release-notes/13.x.x/13.24.0/README.md
@@ -6,9 +6,11 @@
 
 ## New Features
 
-* **New feature title**
+* **Redirect to case detail after form flow completion**
 
-  New feature explanation.
+  When a case is created via a form flow, the user is now automatically redirected to the newly created case detail page
+  after completing the last step. Previously, the user was returned to the case list without any indication of which case
+  was created.
 
 ## Enhancements
 

--- a/frontend/projects/valtimo/case/src/lib/components/case-process-start-modal/case-process-start-modal.component.html
+++ b/frontend/projects/valtimo/case/src/lib/components/case-process-start-modal/case-process-start-modal.component.html
@@ -39,7 +39,7 @@
       @if (formFlowInstanceId) {
         <valtimo-form-flow
           [formFlowInstanceId]="formFlowInstanceId"
-          (formFlowComplete)="formFlowSubmitted()"
+          (formFlowComplete)="formFlowSubmitted($event)"
         ></valtimo-form-flow>
       }
 

--- a/frontend/projects/valtimo/case/src/lib/components/case-process-start-modal/case-process-start-modal.component.ts
+++ b/frontend/projects/valtimo/case/src/lib/components/case-process-start-modal/case-process-start-modal.component.ts
@@ -244,9 +244,16 @@ export class CaseProcessStartModalComponent implements OnInit, OnDestroy {
     });
   }
 
-  public formFlowSubmitted(): void {
-    this.formFlowComplete.emit(null);
-    this.closeCdsModal();
+  public formFlowSubmitted(result?: any[]): void {
+    const documentId = result
+      ?.filter(item => item?.documentId)
+      ?.map(item => item.documentId)?.[0];
+    if (documentId) {
+      this.submitCompleted({documentId, errors: []});
+    } else {
+      this.formFlowComplete.emit(null);
+      this.closeCdsModal();
+    }
   }
 
   public isUserAdmin(): void {

--- a/frontend/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
+++ b/frontend/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
@@ -234,7 +234,7 @@ export class FormFlowComponent implements OnInit, OnDestroy {
       this.FormFlowCustomComponentId$.next('');
       this.formFlowInstanceId$.next(null);
       this.formFlowStepInstanceId = null;
-      this.formFlowComplete.emit(null);
+      this.formFlowComplete.emit(formFlowInstance.onCompleteResult ?? null);
     } else {
       this.getBreadcrumbs();
       this.modalService.scrollToTop();

--- a/frontend/projects/valtimo/process-link/src/lib/models/form-link.model.ts
+++ b/frontend/projects/valtimo/process-link/src/lib/models/form-link.model.ts
@@ -37,6 +37,8 @@ interface FormFlowDefinition {
 interface FormFlowInstance {
   id: string;
   step?: FormFlowStep;
+  onOpenResult?: any[];
+  onCompleteResult?: any[];
 }
 
 interface FormFlowCreateRequest {


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/167

* **Redirect to case detail after form flow completion**

  When a case is created via a form flow, the user is now automatically redirected to the newly created case detail page after completing the last step. Previously, the user was returned to the case list without any indication of which case was created.

  This is supported out of the box for form flows that use `valtimoFormFlow.startCase(..)` as the `onComplete`  expression on the final step. The `documentId` returned by the expression is passed to the frontend, which navigates to the case detail page if the user has permission to view it.

* **Form flow expression results are now included in API responses**

  The form flow REST API now returns the results of `onComplete` and `onOpen` SpEL expressions in the response body. The `/complete` endpoint returns both `onCompleteResult` and `onOpenResult` fields, while the `/open`, `/back`, and `/navigateToStep` endpoints return `onOpenResult`. This allows the frontend (or API consumers) to act on data produced by step lifecycle expressions.

* **Example form-flow**
```
{
    "startStep": "step1",
    "steps": [
        {
            "key": "step1",
            "nextSteps": [],
            "onComplete": [
                "${valtimoFormFlow.startCase(instance.id, {'doc:/voornaam':'/voornaam', 'doc:/achternaam':'/achternaam'})}"
            ],
            "type": {
                "name": "form",
                "properties": {
                    "definition": "start-form-bezwaar"
                }
            }
        }
    ]
}
```