### PR TITLE
feat: improve devMode

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -61,9 +61,9 @@ Thumbs.db
 
 /.nx
 
-# rebuild temp files
-
-.rebuilding-*
+# rebuild lock files (per-library)
+.rebuilding-*.lock
+.rebuilding.lock
 
 
 # other

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -187,616 +187,124 @@
       }
     },
     "dist/valtimo/access-control": {
-      "name": "@valtimo/access-control",
-      "version": "13.0.1",
-      "dev": true,
-      "dependencies": {
-        "jwt-decode": "4.0.0",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/access-control-management": {
-      "name": "@valtimo/access-control-management",
-      "version": "13.0.1",
-      "dev": true,
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/account": {
-      "name": "@valtimo/account",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "moment": "2.30.1",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/analyse": {
-      "name": "@valtimo/analyse",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/bootstrap": {
-      "name": "@valtimo/bootstrap",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/building-block-management": {
-      "name": "@valtimo/building-block-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "ajv": "8.17.1",
-        "tslib": "2.8.1",
-        "vanilla-jsoneditor": "3.10.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/case": {
-      "name": "@valtimo/case",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@ngx-translate/core": "16.0.4",
-        "@ngx-translate/http-loader": "16.0.1",
-        "angular-split": "19.0.0",
-        "moment": "2.30.1",
-        "muuri": "0.9.5",
-        "ngx-csv": "0.3.2",
-        "tslib": "2.8.1",
-        "uuid": "11.1.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/case-management": {
-      "name": "@valtimo/case-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/case-migration": {
-      "name": "@valtimo/case-migration",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/choice-field": {
-      "name": "@valtimo/choice-field",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/components": {
-      "name": "@valtimo/components",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@carbon/charts-angular": "1.23.6",
-        "@carbon/grid": "11.35.0",
-        "@carbon/icons": "11.59.0",
-        "@carbon/styles": "1.80.0",
-        "@carbon/themes": "11.51.0",
-        "@floating-ui/dom": "1.7.4",
-        "@formio/angular": "7.0.0",
-        "@foxythemes/bootstrap-datetime-picker-bs4": "2.3.5",
-        "@mdi/font": "7.4.47",
-        "@ng-bootstrap/ng-bootstrap": "11.0.1",
-        "@ngx-translate/core": "16.0.4",
-        "@ngx-translate/http-loader": "16.0.1",
-        "@tadashi/currency": "3.4.0",
-        "@types/topojson": "3.2.6",
-        "ajv": "8.17.1",
-        "bpmn-js": "18.6.1",
-        "carbon-components-angular": "5.57.6",
-        "deepmerge-ts": "7.1.5",
-        "flatpickr": "4.6.13",
-        "formiojs": "4.19.5",
-        "heatmap.js-fixed": "2.0.2",
-        "jquery": "3.7.1",
-        "jwt-decode": "4.0.0",
-        "lodash": "4.17.21",
-        "moment": "2.30.1",
-        "monaco-editor": "0.50.0",
-        "muuri": "0.9.5",
-        "ng-multiselect-dropdown": "1.0.0-beta.19",
-        "ngx-skeleton-loader": "11.0.0",
-        "ngx-spinner": "19.0.0",
-        "semver": "7.7.1",
-        "tslib": "2.8.1",
-        "uuid": "11.1.0",
-        "vanilla-jsoneditor": "3.10.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20",
-        "@angular/elements": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/dashboard": {
-      "name": "@valtimo/dashboard",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@carbon/charts-angular": "1.23.6",
-        "@ngx-translate/core": "16.0.4",
-        "@ngx-translate/http-loader": "16.0.1",
-        "@types/topojson": "3.2.6",
-        "d3": "7.9.0",
-        "d3-cloud": "1.2.7",
-        "d3-sankey": "0.12.3",
-        "d3-shape": "3.2.0",
-        "moment": "2.30.1",
-        "muuri": "0.9.5",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/dashboard-management": {
-      "name": "@valtimo/dashboard-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/decision": {
-      "name": "@valtimo/decision",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@bpmn-io/dmn-migrate": "0.5.0",
-        "dmn-js": "17.2.0",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/document": {
-      "name": "@valtimo/document",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/form-flow-management": {
-      "name": "@valtimo/form-flow-management",
-      "version": "13.0.1",
-      "dev": true,
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/form-management": {
-      "name": "@valtimo/form-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/form-view-model": {
-      "name": "@valtimo/form-view-model",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@formio/angular": "7.0.0",
-        "formiojs": "4.19.5",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/iko": {
-      "name": "@valtimo/iko",
-      "version": "13.0.0",
-      "dev": true,
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/keycloak": {
-      "name": "@valtimo/keycloak",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "jwt-decode": "4.0.0",
-        "keycloak-angular": "19.0.2",
-        "keycloak-js": "26.1.5",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/layout": {
-      "name": "@valtimo/layout",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@foxythemes/bootstrap-datetime-picker-bs4": "2.3.5",
-        "bootstrap": "4.6.2",
-        "components-jqueryui": "1.12.1",
-        "csp-header": "6.1.0",
-        "jquery": "3.7.1",
-        "lodash": "4.17.21",
-        "moment": "2.30.1",
-        "ol": "10.7.0",
-        "perfect-scrollbar": "1.5.6",
-        "popper.js": "1.16.1",
-        "select2": "4.1.0-rc.0",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/logging": {
-      "name": "@valtimo/logging",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/migration": {
-      "name": "@valtimo/migration",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "bpmn-js": "18.6.1",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/milestone": {
-      "name": "@valtimo/milestone",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "ngx-color-picker": "17.0.0",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/object": {
-      "name": "@valtimo/object",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/object-management": {
-      "name": "@valtimo/object-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/plugin": {
-      "name": "@valtimo/plugin",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/plugin-management": {
-      "name": "@valtimo/plugin-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/process": {
-      "name": "@valtimo/process",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "bpmn-js": "18.6.1",
-        "heatmap.js-fixed": "2.0.2",
-        "jquery": "3.7.1",
-        "moment": "2.30.1",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/process-link": {
-      "name": "@valtimo/process-link",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/process-management": {
-      "name": "@valtimo/process-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@bpmn-io/properties-panel": "3.26.4",
-        "bpmn-js": "18.6.1",
-        "bpmn-js-properties-panel": "5.35.0",
-        "camunda-bpmn-js-behaviors": "1.10.0",
-        "camunda-bpmn-moddle": "7.0.1",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/resource": {
-      "name": "@valtimo/resource",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/security": {
-      "name": "@valtimo/security",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "csp-header": "6.1.0",
-        "moment": "2.30.1",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/shared": {
-      "name": "@valtimo/shared",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "csp-header": "6.1.0",
-        "deepmerge-ts": "7.1.5",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/sse": {
-      "name": "@valtimo/sse",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/swagger": {
-      "name": "@valtimo/swagger",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "immutable": "4.3.7",
-        "swagger-ui": "5.21.0",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/task": {
-      "name": "@valtimo/task",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "lodash": "4.17.21",
-        "moment": "2.30.1",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/task-management": {
-      "name": "@valtimo/task-management",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "lodash": "4.17.21",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/teams": {
-      "name": "@valtimo/teams",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "dist/valtimo/zgw": {
-      "name": "@valtimo/zgw",
-      "version": "13.0.1",
-      "dev": true,
-      "license": "EUPL-1.2",
-      "dependencies": {
-        "@angular/forms": "19.2.20",
-        "@ngx-translate/core": "16.0.4",
-        "carbon-components-angular": "5.57.6",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
-      }
+      "dev": true
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.3.3",
@@ -2266,12 +1774,13 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -4731,9 +4240,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4819,9 +4328,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5567,9 +5076,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7998,13 +7507,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.10.1.tgz",
-      "integrity": "sha512-mevhQXYM5RwpH9UX8VDZw8ePFZSryuXZ5uU5crQPXLTKBkNok6kxlrVI0nRydbFZ1cIUc0nA//PUQPtCoBp6kw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.10.2.tgz",
+      "integrity": "sha512-vTl8gWyeZaj887/NSWYs3as4K8wXHar5wY/606XRBjR2UgmJBokBgKjq7S23LW9tsYjsT4MjQKC8idjgw17xvg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-error": "^1.10.1",
+        "@swagger-api/apidom-error": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8012,14 +7521,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.10.1.tgz",
-      "integrity": "sha512-gTj48Q5GAcBZpiLTDueBfjg4xfyeGwuWNjmJ7YneoI9478LD2l23kP8sZauCegV0PflzzO15M2hTkNTwX1alDQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.10.2.tgz",
+      "integrity": "sha512-qryNBGHNWDvSRyK1w5rox0UOrHrVBjZOHgeXFpGHF+oBO7ntSc/H7BSiYMDR+KQESkzMcAxn4tZMLYItaBt06w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
@@ -8029,37 +7538,37 @@
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.10.1.tgz",
-      "integrity": "sha512-VMm/a65GVBv+PLTnlAef+6sryui333FfoBtPP/wHE1M1cY7hJGJDKA7WIxjxgcX0shgqTVHx2m/2/cJT3EN0ng==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.10.2.tgz",
+      "integrity": "sha512-SWyPyL5xwTUsDzPi0A5zwTFwqPezvlwj4opEqruqjESNTYupUA7+vt4Mdj7IlDaRYRG1qyCWQgKhIBXznVUD4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.10.1.tgz",
-      "integrity": "sha512-YIzrhTt/5EsfcjxWvGogJNepMNt3A4+O8Hnqkv5TT1gV4nbM9RNlMOoNezZfOv59SCQsbIM7bP/zab5wwVotEA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.10.2.tgz",
+      "integrity": "sha512-zySHPqIXF4HZ3VWbHwTxO+H1e9dJw7mGHzoX+tZjx5wVyLQO3kZDCAAXzz3c3/TIY21Y2Zkpkez3q9hjFyuLvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
         "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.10.1.tgz",
-      "integrity": "sha512-wIgv6sf26ipUYFP65t72FIT96kTgBWiWiLVqVnsEEqkOzHVBG0C6cfRHBBg/xrbfxhk4naVoNDs5dNvFaa1RCg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.10.2.tgz",
+      "integrity": "sha512-MsZ4GWmWN7wkWv7G9Pwk8sHU1j0bwk7xoGeaZmNCylbTfYvGkg6jJGMHdAdQNCQXbbpfLeKt1O+3YCN//JUQ7w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8067,15 +7576,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.10.1.tgz",
-      "integrity": "sha512-SfYxcZt8oCSxmLIh+Itb/cyCCiFo6C50NIqcXK8cAH1LuS4uN8vnJcf/g9dsLi6X0uL3tFco1Im2cW3FNa+yTA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.10.2.tgz",
+      "integrity": "sha512-fQSwDlIR85tbnLXAjtV/ypSGUBfrzFcZ4NbH6BL1DSTR4uEunVxAULdD4wlhCt9gGNDl/zxZD3vQtlYDkXDFmw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8083,15 +7592,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.10.1.tgz",
-      "integrity": "sha512-HfQHr6cF58wNI2x77XkcuEycbv7zeYg43kHV6Bekp2up24nuexMyX+kMg1JdBS+lrBq0DpYVOKBesUWTLyiLqg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.10.2.tgz",
+      "integrity": "sha512-obWHe3pyAj65Nf9ISwnbtJ4C5mZ15C6mtQXxzHVW5maVZqlqt3s/YbPY87EqK9ArdNOwOZHkQt2Uth02GMmjxA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8099,15 +7608,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.10.1.tgz",
-      "integrity": "sha512-ztMMhW+7f548AH/VbyBOvA9FvPQ+F/RwIEN2rw9M3Lq/hjHaXTzYE2Bt5q8TNHis46NPyLYQR6lD+MANsII0aA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.10.2.tgz",
+      "integrity": "sha512-yqNmXeObF2OLAusgGEapXz2CrGjXwkcfG3DYcQDtOvgRytvGZxC2EkCUR+wEXCVNYhoJ7QpVzzTJOHs3jOvptg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8115,15 +7624,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.10.1.tgz",
-      "integrity": "sha512-2X0wc36PbKo6zbygG19Vw4H2nDo7hT9zxlyNCaBiWdYT1gKxhG/IbftfEaiBOBlpYIXbfmo/7/yJe0OFqJjwvg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.10.2.tgz",
+      "integrity": "sha512-I1FaBoDFMjybF4QVsesIYl8OilkwycZ0mQ0jf1P++zfTRG27uIePB8M+Iuj6iqMsE3qpkjjJJ6ZLnrLPdKvmRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8131,15 +7640,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.10.1.tgz",
-      "integrity": "sha512-JWQJS2eKJgzA/zomZ1Rx8tfIr8H/hCY7CmH5AsYLp0kn4RkABODvbnR19eMTIF0aNuI7SB9DvQe28EfpYMCAyw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.10.2.tgz",
+      "integrity": "sha512-lg9XfRlJRNoBa2EDGpEFc7HvFV39G6RG0/SbjQY0BE/WZer10wmfTCU7l3RUNJXRFGKH6/O/nsYgP7AFjTanXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8147,14 +7656,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.10.1.tgz",
-      "integrity": "sha512-jynGmvUNNuqy7AJb5n8mXjWgmo8mPDNuIYMgije3U4eThdmOpd4iD4iO0EVV5ltfYDlUWepQaiSn2NPn4TSzVQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.10.2.tgz",
+      "integrity": "sha512-C50KnSKynrmHky/oOB6+hHyZVpwng78Fz5aZjay3h8X5C/PJHmm3sDJFvF3/9wkYHO3N9sPp7cpu4Xm9VJ4/wQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.10.1",
-        "@swagger-api/apidom-core": "^1.10.1",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8162,15 +7671,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.10.1.tgz",
-      "integrity": "sha512-ucF0/vVPdN9hNpEqNiu+QQ1ijI1Leng+Ma6wzzML8kQxiqdHiisYiOA7NlBS0iFR6ibjjTx5/ivFZp25pcOXlA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.10.2.tgz",
+      "integrity": "sha512-/wiP8+2lF8UJRrkoQ9HvKnMbnqijk2uY/hAg+/Bo73T9NGKkEa29jYVUKYNYj7gJBw4hhkUHfHFWuZUpxPC4ZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8178,15 +7687,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.10.1.tgz",
-      "integrity": "sha512-oAr+yyLAOWEu8QdTg4os5ktZSNM0lDfoJmOmbZdSxFKv9xd9KSAqcf4e3/v8OWgvX2V9JIxwE0Jo2sI8j4h7Hg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.10.2.tgz",
+      "integrity": "sha512-firN/uvnVxQgACqcyzV3NU9qjbMvNMJkpmm3wOat3URmaFMaFBT3qjbU1pFHBGbnXI3+I9pQJZHmJSwqNzfUbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8194,16 +7703,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.10.1.tgz",
-      "integrity": "sha512-zlGSW/XCtjfn+vjLPVSt+KsPouIOkoXifzWk0P/oAf13JQC9JZJ2MHrqwyw24PqQCf7zjqvHwXhrS/6/3usevg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.10.2.tgz",
+      "integrity": "sha512-FK5kYvo/1uwAByumRVRsynBlnKxUUImfsjPEFgRCW6yhbCGRqN47NaZ7GYFHpbhjC3OmMN5/etYj6B0jnZx7Gg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8211,15 +7720,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.10.1.tgz",
-      "integrity": "sha512-82TW6iwMrRcY09MQI8ZzSbPx7gPo0Qw4R9eQAixhnZ+icp+2VVFMM38pGpZQ5wGLLmbMi+wXnIKqJNw64y3Ihw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.10.2.tgz",
+      "integrity": "sha512-ziyv85QbJYHRdc9oTEFBy3pxwxg7BW/a9GrwH01/SmuXVQPjLjwzRb+SjCxLogJppm0yjxOkDFI2VWPp2RADFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8227,17 +7736,17 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.10.1.tgz",
-      "integrity": "sha512-u8A+AqMy2lvRRxl11fqeTDHSbWUgU7kCoz0G7p6K3HoJ7hLb7q97+tldNmxvAGjE1ljylx55sSswEfAUZk9oZA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.10.2.tgz",
+      "integrity": "sha512-ngcmO4dH77JT5hZB04OJdyTzgKnt2lNhAZQ+4wXjum/xhszjUmDhOeYfXdHw3Lm7MxsEsTesWzLYQ5LKADc41A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.10.1",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-json-pointer": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.1",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-json-pointer": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8245,18 +7754,18 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.10.1.tgz",
-      "integrity": "sha512-q+xnEfGWIIqGX+ldd6rgyvtaah22XHVZ2ROcfGKsLHjZNoxc1p94VBMaJmUYYx5GAXRZD9Yn65xUQ29nHHsJBw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.10.2.tgz",
+      "integrity": "sha512-3SWJ5ipWwn+w11HTUESWex/522jy2aGLzBqqMgH36sy+Wdwx+9Mw2bgSDqkxmNC5+jpzOGUOIWoQAMuCpS/Gzg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.10.1",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-json-pointer": "^1.10.1",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.1",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-json-pointer": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8264,144 +7773,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.10.1.tgz",
-      "integrity": "sha512-P7sikA/ck0rMaeWGYTTzlnjSmLOoN/YRLDEv334po2/A5Js/FmBvfHJflLDZ4Hn6X2mhbdoF7arLJ0P3VAK86w==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.10.2.tgz",
+      "integrity": "sha512-kzhJUGzsJ38Uohj5xRQDkQC08rqNhatbqgD30LZ0/UWryJ9nAsjqK2ovuP9t+5WKcDE4iwcYeGSt1NA2XgEZwg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.10.1.tgz",
-      "integrity": "sha512-3S9gbqVLE2rkd7jzDThVX6uW6zFGuL0BLJOpduxkwhezgZwyf/EpB29oSzH8ZHuwZHWAsPGiqtivfCp1o5KIxA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.10.2.tgz",
+      "integrity": "sha512-i3CmSxJ/iG67ybRDAJ9xpuMrOMFvC/obX2lI36E0VZzBTb+llw4Zd5qFmBqNnImLpwdmk11Z1V7i+5HM+J7ijQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.10.1.tgz",
-      "integrity": "sha512-e02QuxdkgyCHB+kAskWOKD3doy8FwEheNFPg8te58SvKwxJ/32TwmWQSUT0zmDK6omzFV/HaFzUSfau5UZLquw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.10.2.tgz",
+      "integrity": "sha512-HwiUkwvo5i2hV2SS6KWrdj62BdceZGfhuXhr1il8akWekpU4jXPtr5pv4gOnKKJN7VgjAmwt/DlcCSRo1+9jVA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.10.1.tgz",
-      "integrity": "sha512-S7+1zLGZDX6KuimlRCAfe0df5HxY1ruchyU2VFB/mOikKf3UoDDdlaT/lXRJtyw9aoSuXuYV7ysEyAOLffGgxQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.10.2.tgz",
+      "integrity": "sha512-w8VTVuE7GPbRqWxvMgRoTb726JRsMhFPMfTBf8+MJ4pQThjk78dSXPV2Zlse71b2DWBuQy2sr6zGyLUNs/3ePQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.10.1.tgz",
-      "integrity": "sha512-6j1Uufq52yGJR4xkWYAA2jlv6YjNev+z7Z9BrQCDm7Y9y69zh1HHMncuUwTe1wnypd2hcwLu6IBT0ykBPnNn3Q==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.10.2.tgz",
+      "integrity": "sha512-FDNjqmn2vV1jFoVVwQDO0XPPm8R5xzmcyY/6yBLFmKZADin3smSKVZ+njYHmfRjpspXwN0AwI0drdvuH0FZLJg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.10.1.tgz",
-      "integrity": "sha512-2XQG9HVkINBnpwE1Oln4KRDCt6ZB7V1/9If9RAK42wIgpGsHGwgRqsGs39a4tqTL0luXRKyaMVQ2yJ7k4Kq3Ew==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.10.2.tgz",
+      "integrity": "sha512-x/0vM2nDDzYzFnXr69+so/KSH+2py2TiZd1K49pWcX8cHsPV1Y4Ppih7GVOMymd8m/IOCjLYlV7qt4eWDwdldg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.10.1.tgz",
-      "integrity": "sha512-rNE/52HEgYDbLpJ0ydKcXUiQVe1FWz2FN7TgcSplrlwcQdLdO4wwMgMhDgxZfeSDYrsss3rJCqgI8jJFMhIlDQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.10.2.tgz",
+      "integrity": "sha512-2bVACmU9ZmAVVnqQWSc3Bs+xG0HHLU1tfZbYL8xNgSi8kw4HcnejF5mWtN+MLFzTaBmWCi2In7P7BYNR8+2Dyg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.10.1.tgz",
-      "integrity": "sha512-++u3KvXmZKyBgNzLR58yr/9D3OPxBg/njrz/L8ncfIRTfdBHYRFP8XA0ktb+3W7RQAFgcG1bB5czq7Y+brLg5g==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.10.2.tgz",
+      "integrity": "sha512-oHpbf+iqBcDS3qtsipMpgCwAeckKMxg0qFKYTCRZyJdctRgupJTxVeir6t/SGo0Ny0a1iknt2LN0u5frEen0kg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.10.1.tgz",
-      "integrity": "sha512-hi1Ly/4fWwn7bhWr9l59BJa/dTC6bnb2+0Ogt1fHsyLuHLA71hxKX5FLRKVUcVTITunJg5mIgtBxG928MMJmdA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.10.2.tgz",
+      "integrity": "sha512-VnwEkarKfsJYRF0zCI9AGiSIyBUXqS2d32KQuhVCt/HeuF1XO9sjeLjGiosA/24YVOnO0ul5TpiNFQn0pw89mA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.10.1",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -8411,144 +7920,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.10.1.tgz",
-      "integrity": "sha512-V0D9OrDTT7HXht8c48ngHcZCae1HYcvjyhX/xfG9/UyrEIY6IqGxhr5Bh7SRvNLLQ+3WuN8+o6PzBFtaU0tWAw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.10.2.tgz",
+      "integrity": "sha512-+d/o/8TrNBjvFzgPb0RQhrCc8gOWnrHZF+xvCO5gwp+4MUr1XP1AJIox1e6t1SO+j7IQjiF2ocx2r7eFE5QC7w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.10.1.tgz",
-      "integrity": "sha512-02pJp2Dz9fYzxA/GYthoUSGrMp1cqrfvsi1UfDVqnPuO4A/hFMLtpTIXs1YseRdrPiDLQF12+3uKH8wrNmZ1Zg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.10.2.tgz",
+      "integrity": "sha512-3ieUeX8/WywkUzdOO1U1QKQDNmpZFfOeTAeb4ISDd/PKOVwuEx/b0w5I8EuOu97tKAe3UUesEdii+pJlkcFlFw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.10.1.tgz",
-      "integrity": "sha512-ceJej3P0S0WGGK07BAbdxkTp16+MHiU0kLjvUaj7QME/UBXoTaLFl0YRvGy1nHbnOHx7qQloC6JR5fUzm8pXdQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.10.2.tgz",
+      "integrity": "sha512-z0c7IgMPLSDhE+ldTb54Xlhq+yPF0w/8LHXyeHX4V6BS1VG3Utb+mM/qTVfy1Eo+p1KGNlwNDEPsBp6jIaVb5Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.10.1.tgz",
-      "integrity": "sha512-QHq7sBJEsVZyCTpHp4auVdK/9kClwI7NUGIHo0k3TmQZqVwg0uv3CQRkrTw50m5SauQG/ZfTxvnBPDqu004P6Q==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.10.2.tgz",
+      "integrity": "sha512-bx/kEIXWtpHu+4LEiyNdt0v8ER5EVwPjhQdlpOaC5qghnRH9aUYOTawZtVHsNHAQWTIMNn9DdPKYQgttQKD0Pw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.10.1.tgz",
-      "integrity": "sha512-I0Sa1TMfYpqkfDDtLCLfhTpLtYdI9xjzhUTnM5bGooO7ylZ0+6rZ/kUvt7mHJvGzN5hEpwznDzQabA96rZd5mA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.10.2.tgz",
+      "integrity": "sha512-e86JUXHGGEVsO4/xpy/GRSvYXGN30hLt1lMUhjzCFuE95N6/K3hmQHE3rA/H7ot1ajCWUhzukW5rGQac79NIjA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.10.1.tgz",
-      "integrity": "sha512-btALgBVEggG0yUVPmMR+EfFOo4dT6qPBA0Rc9Sl6mXsQmuyp08w0pFS1bEWCulpFs4AluLNOO3Eca/nk3SvItA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.10.2.tgz",
+      "integrity": "sha512-ucfc13Ai31tJ0ruAm1YiHhqENgcBuiOXL00OhoICWA56ggAcnA5WfWmvtsXVMlZsTHVbhZP3XpsH5rui2N8u5w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.10.1.tgz",
-      "integrity": "sha512-lF/7vamKL71HAu+ivfQpLk/rbV3EUHlibSUusOZgn5w8LRsKvRlM5F+EbMUCEE3L+ZHvbX3r7I7BHfjMPG8KeA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.10.2.tgz",
+      "integrity": "sha512-7o8j93qgf9yYAaaJ/GpH+5sB3fC9EmvmjTCqlw5YWXp+cRgCn9q7f80Sv4+NjbracUafB6qL4i9F/m+Xs0XZaQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.10.1.tgz",
-      "integrity": "sha512-2IkryVZCuJk5hgggS4wugqsUrCAlGTeYOa34Aw0oH1E+2KC0CRXx8s19/UstdwEWx49kEMoh/QOx3Tb0Kp4idQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.10.2.tgz",
+      "integrity": "sha512-blDIeVmo8bpXYV/C+b6PYi54yS+5jPEZTFsK5jQ2NzpCPrkBPacp/KTuHBUBzJsYj4bj/ivRL3+JXGw4YovUHw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.10.1.tgz",
-      "integrity": "sha512-HVnq38OnU3nodluWbXTXf7PY5BSp2X07q1Ppx/vxPJaxQ43QxD+EZYvuh2HF7M072f9JuxZzlZQO1btFk7qD2g==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.10.2.tgz",
+      "integrity": "sha512-I5eCls8XS3SVEwH/cuL6T3iar1TPaFYh3gXwS/2rzP1aZQNKSHDP3y3ney7nAomKG4dFvE8Q248FL36arG7T/w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.10.1",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
         "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
@@ -8580,46 +8089,46 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.10.1.tgz",
-      "integrity": "sha512-JVbUI6tlndxoP9oW7Xyhm6N1hevtTK23cIZAUDDPfZ9nYjdV6OPleT5aKsVBw3ZtBXtvriTZ/vODdqL7H28Z8A==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.10.2.tgz",
+      "integrity": "sha512-H5UqOmae9CXdiLJbbh1j+/hwvcECmr6ci2XtUKTQpFviemvsIDZmPV1DKUAxCfzGr2iOkDO6SZc+/OEWlETqiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.10.1",
-        "@swagger-api/apidom-error": "^1.10.1",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
         "@types/ramda": "~0.30.0",
-        "axios": "^1.12.2",
+        "axios": "^1.15.0",
         "minimatch": "^10.2.1",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^1.10.1",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.10.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-2": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.1",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.10.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.1"
+        "@swagger-api/apidom-json-pointer": "^1.10.2",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
@@ -9608,6 +9117,7 @@
       "version": "8.31.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
       "integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10797,9 +10307,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.6.0.tgz",
-      "integrity": "sha512-2YkS7NuiJceSEbyEOdSNLE9tsGd+f4+f7C+Nik/MCk27SYdwIMPT/yRKvg++FZhQXgk0KWJKJyXX9RhVV0RGqA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+      "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10842,9 +10352,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
-      "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10909,9 +10419,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
-      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -10921,9 +10431,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11154,9 +10664,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -11381,14 +10891,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -14550,9 +14060,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.334",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -14855,16 +14365,16 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
-      "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
+        "es-abstract": "^1.24.2",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -14876,8 +14386,7 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0",
-        "safe-array-concat": "^1.1.3"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15246,9 +14755,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15384,9 +14893,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15489,9 +14998,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15607,13 +15116,20 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
-      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
+      "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
         "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -16226,9 +15742,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -16703,9 +16219,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18635,9 +18151,9 @@
       }
     },
     "node_modules/karma-coverage-istanbul-reporter/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18744,9 +18260,9 @@
       }
     },
     "node_modules/karma-coverage/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18850,9 +18366,9 @@
       }
     },
     "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21122,9 +20638,9 @@
       }
     },
     "node_modules/npm-run-all/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23558,9 +23074,9 @@
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -25223,9 +24739,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.2.tgz",
-      "integrity": "sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==",
+      "version": "5.55.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.3.tgz",
+      "integrity": "sha512-dS1N+i3bA1v+c4UDb750MlN5vCO82G6vxh8HeTsPsTdJ1BLsN1zxSyDlIdBBqUjqZ/BxEwM8UrFf98aaoVnZFQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",

--- a/frontend/scripts/dev-mode.js
+++ b/frontend/scripts/dev-mode.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,7 +213,9 @@ function buildLib(libName, {safeSwap = false} = {}) {
           if (!fs.existsSync(realDest) && fs.existsSync(backupDest)) {
             fs.renameSync(backupDest, realDest);
           }
-        } catch { /* best effort */ }
+        } catch {
+          /* best effort */
+        }
       }
     }
 

--- a/frontend/scripts/dev-mode.js
+++ b/frontend/scripts/dev-mode.js
@@ -1,23 +1,111 @@
-const {spawn, spawnSync} = require('child_process');
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Dev mode coordinator — builds libraries in dependency order, watches for changes,
+ * and rebuilds in the correct order with per-library locks and a centralized queue.
+ *
+ * Key improvements over the previous approach:
+ * - Single process coordinates all rebuilds (no race conditions between separate rebuild-lib.js processes)
+ * - Dependency graph parsed at runtime from package.json build scripts
+ * - Per-library lock files (.rebuilding-<lib>.lock) prevent concurrent builds of the same library
+ * - Dependency-aware queue: a library only builds after all its dependencies finish
+ * - Debouncing: rapid file changes are coalesced into a single rebuild
+ * - Cascade: when a library finishes rebuilding, dependents that need rebuilding are queued
+ */
+
+const {spawn} = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const net = require('net');
+const {getLibDependencyGraph} = require('./lib-dependency-graph');
 
-const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
-const orderedScriptNames = Object.keys(pkg.scripts);
-const watchScripts = orderedScriptNames.filter(name => name.startsWith('libs:watch:'));
+// ── Configuration ──────────────────────────────────────────────────────────────
 
-let current = 0;
-let activeProcesses = [];
-let hasStartedApp = false;
-
-const rebuildLockFilePath = path.resolve(__dirname, '../.rebuilding.lock');
+const FRONTEND_ROOT = path.resolve(__dirname, '..');
+const LOCK_DIR = FRONTEND_ROOT;
+const NG_BIN = path.join(FRONTEND_ROOT, 'node_modules', '.bin', 'ng');
+const PORT_TO_CHECK = 4200;
+const DEBOUNCE_MS = 600;
+const MAX_PARALLEL_BUILDS = 3;
 
 const skipInitialBuild = process.env.SKIP_BUILD === 'true';
 
-const PORT_TO_CHECK = 4200;
+// ── Dependency graph ───────────────────────────────────────────────────────────
 
-function checkPortInUse(port = PORT_TO_CHECK) {
+const graph = getLibDependencyGraph();
+const {libLevels, levels, sortedLevelNumbers, levelBuildModes, dependsOn, dependents, allLibs} =
+  graph;
+
+console.log(
+  `\n📦 Loaded dependency graph: ${allLibs.length} libraries across ${sortedLevelNumbers.length} levels\n`
+);
+for (const levelNum of sortedLevelNumbers) {
+  const libs = levels.get(levelNum);
+  const mode = levelBuildModes.get(levelNum);
+  console.log(`  Level ${levelNum} (${mode}): ${libs.join(', ')}`);
+}
+console.log('');
+
+// ── State ──────────────────────────────────────────────────────────────────────
+
+const activeProcesses = [];
+let hasStartedApp = false;
+let isCleaningUp = false;
+
+// Build queue state
+const building = new Set(); // libs currently building
+const queued = new Map(); // lib -> {resolve, reject} or just a boolean; libs waiting to build
+const debounceTimers = new Map(); // lib -> timer
+const pendingRebuilds = new Set(); // libs that need a rebuild (debounced, waiting to enter queue)
+const swappedLibs = new Set(); // libs whose dist was swapped since the last webpack notification
+
+// ── Lock file helpers ──────────────────────────────────────────────────────────
+
+function lockFilePath(libName) {
+  return path.join(LOCK_DIR, `.rebuilding-${libName}.lock`);
+}
+
+function createLock(libName) {
+  try {
+    fs.writeFileSync(lockFilePath(libName), `building:${Date.now()}`);
+  } catch (err) {
+    console.error(`  ⚠ Failed to create lock for ${libName}: ${err.message}`);
+  }
+}
+
+function removeLock(libName) {
+  try {
+    if (fs.existsSync(lockFilePath(libName))) {
+      fs.rmSync(lockFilePath(libName));
+    }
+  } catch (err) {
+    // Ignore — may already be removed
+  }
+}
+
+function removeAllLocks() {
+  for (const lib of allLibs) {
+    removeLock(lib);
+  }
+}
+
+// ── Port check ─────────────────────────────────────────────────────────────────
+
+function checkPortInUse(port) {
   return new Promise(resolve => {
     const server = net.createServer();
     server.once('error', () => resolve(true));
@@ -29,155 +117,485 @@ function checkPortInUse(port = PORT_TO_CHECK) {
   });
 }
 
-function getLibraryNameFromScript(scriptName) {
-  return scriptName.replace('libs:watch:', '');
+// ── Build a single library ─────────────────────────────────────────────────────
+
+/**
+ * Build a library. When `safeSwap` is true (used during watcher rebuilds), the build
+ * writes to a temporary directory and then atomically swaps it into the real dist folder.
+ * This prevents the dev server from seeing a deleted dist directory mid-build and
+ * triggers only a single recompilation instead of multiple.
+ */
+function buildLib(libName, {safeSwap = false} = {}) {
+  const fullName = `@valtimo/${libName}`;
+  const realDest = path.join(FRONTEND_ROOT, 'dist', 'valtimo', libName);
+  const tmpDest = path.join(FRONTEND_ROOT, 'dist', `.tmp-${libName}`);
+  const ngPackagePath = path.join(FRONTEND_ROOT, 'projects', 'valtimo', libName, 'ng-package.json');
+
+  return new Promise((resolve, reject) => {
+    console.log(`  🔨 Building ${fullName}...`);
+    createLock(libName);
+
+    let originalNgPackage = null;
+
+    // If safeSwap, redirect the build output to a temp directory by patching the
+    // "dest" field in ng-package.json. Uses string replacement to preserve the
+    // original file format (trailing commas, comments, etc.).
+    if (safeSwap) {
+      try {
+        originalNgPackage = fs.readFileSync(ngPackagePath, 'utf8');
+        const relativeTmpDest = path.relative(path.dirname(ngPackagePath), tmpDest);
+        const patched = originalNgPackage.replace(
+          /("dest"\s*:\s*)"[^"]*"/,
+          `$1"${relativeTmpDest}"`
+        );
+        if (patched === originalNgPackage) {
+          throw new Error('Could not find "dest" field in ng-package.json');
+        }
+        fs.writeFileSync(ngPackagePath, patched);
+      } catch (err) {
+        console.error(`  ⚠ Failed to set up temp dest for ${libName}: ${err.message}`);
+        // Fall back to normal build
+        safeSwap = false;
+        originalNgPackage = null;
+      }
+    }
+
+    const buildProc = spawn(NG_BIN, ['build', fullName], {
+      shell: true,
+      cwd: FRONTEND_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    buildProc.stdout.on('data', data => {
+      stdout += data.toString();
+    });
+
+    buildProc.stderr.on('data', data => {
+      stderr += data.toString();
+    });
+
+    function restoreNgPackage() {
+      if (originalNgPackage !== null) {
+        try {
+          fs.writeFileSync(ngPackagePath, originalNgPackage);
+        } catch (err) {
+          console.error(`  ⚠ Failed to restore ng-package.json for ${libName}: ${err.message}`);
+        }
+      }
+    }
+
+    function swapDist() {
+      if (!safeSwap) return;
+      try {
+        // Atomic swap: rename real dist out, rename temp dist in, remove old.
+        // This avoids the window where dist is deleted (which crashes webpack).
+        const backupDest = `${realDest}.old`;
+        if (fs.existsSync(realDest)) {
+          fs.renameSync(realDest, backupDest);
+        }
+        fs.renameSync(tmpDest, realDest);
+        // Clean up old dist
+        if (fs.existsSync(backupDest)) {
+          fs.rmSync(backupDest, {recursive: true, force: true});
+        }
+        // Track this lib for a batched webpack notification later.
+        // We don't touch files here — instead we wait until the entire queue drains
+        // so webpack gets a single recompilation trigger rather than one per library.
+        swappedLibs.add(libName);
+      } catch (err) {
+        console.error(`  ⚠ Failed to swap dist for ${libName}: ${err.message}`);
+        // Fallback: try to restore the old dist if the swap failed halfway
+        const backupDest = `${realDest}.old`;
+        try {
+          if (!fs.existsSync(realDest) && fs.existsSync(backupDest)) {
+            fs.renameSync(backupDest, realDest);
+          }
+        } catch { /* best effort */ }
+      }
+    }
+
+    buildProc.on('error', err => {
+      restoreNgPackage();
+      removeLock(libName);
+      reject(err);
+    });
+
+    buildProc.on('exit', code => {
+      restoreNgPackage();
+      if (code === 0 || stdout.includes('Built Angular Package')) {
+        swapDist();
+        removeLock(libName);
+        console.log(`  ✅ Built ${fullName}`);
+        resolve();
+      } else {
+        // Clean up temp on failure
+        if (safeSwap) {
+          try {
+            fs.rmSync(tmpDest, {recursive: true, force: true});
+          } catch {
+            // ignore
+          }
+        }
+        removeLock(libName);
+        console.error(`  ❌ Build failed for ${fullName} (exit code ${code})`);
+        if (stderr) {
+          const lines = stderr.split('\n');
+          const tail = lines.slice(-30).join('\n');
+          console.error(tail);
+        }
+        reject(new Error(`Build failed for ${fullName}`));
+      }
+    });
+  });
 }
 
-function createRebuildLock() {
-  if (!fs.existsSync(rebuildLockFilePath)) {
-    fs.writeFileSync(rebuildLockFilePath, 'rebuilding');
+// ── Initial build: all libs in dependency order ────────────────────────────────
+
+/**
+ * Build a set of libraries in parallel, respecting any intra-set dependency edges.
+ * Libraries with no intra-set dependencies start immediately; others wait until
+ * their dependencies within the set have completed.
+ */
+function buildParallelWithDeps(libs) {
+  return new Promise((resolveAll, rejectAll) => {
+    const libSet = new Set(libs);
+    const done = new Set();
+    const inFlight = new Set();
+    const failures = [];
+
+    function tryStart() {
+      if (done.size + failures.length === libs.length) {
+        if (failures.length > 0) {
+          rejectAll(failures);
+        } else {
+          resolveAll();
+        }
+        return;
+      }
+
+      for (const lib of libs) {
+        if (done.has(lib) || inFlight.has(lib) || failures.some(f => f.lib === lib)) continue;
+
+        // Check if all intra-set dependencies are done
+        const deps = dependsOn.get(lib);
+        let ready = true;
+        if (deps) {
+          for (const dep of deps) {
+            if (libSet.has(dep) && !done.has(dep)) {
+              ready = false;
+              break;
+            }
+          }
+        }
+
+        if (!ready) continue;
+
+        inFlight.add(lib);
+        buildLib(lib)
+          .then(() => {
+            inFlight.delete(lib);
+            done.add(lib);
+            tryStart();
+          })
+          .catch(err => {
+            inFlight.delete(lib);
+            failures.push({lib, error: err});
+            tryStart();
+          });
+      }
+    }
+
+    tryStart();
+  });
+}
+
+async function initialBuildAll() {
+  if (skipInitialBuild) {
+    console.log('⏭  Skipping initial library builds (SKIP_BUILD=true)\n');
+    return;
   }
-}
 
-function removeRebuildLock() {
-  if (fs.existsSync(rebuildLockFilePath)) {
-    try {
-      fs.rmSync(rebuildLockFilePath);
-    } catch (err) {
-      console.error(`Failed to remove rebuild lock: ${err.message}`);
+  console.log('🏗  Building all libraries in dependency order...\n');
+
+  for (const levelNum of sortedLevelNumbers) {
+    const libs = levels.get(levelNum);
+    const mode = levelBuildModes.get(levelNum);
+    console.log(`\n── Level ${levelNum} (${mode}): ${libs.join(', ')} ──`);
+
+    if (mode === 'parallel') {
+      // Build in parallel, but respect any intra-level dependency edges
+      try {
+        await buildParallelWithDeps(libs);
+      } catch (failures) {
+        console.error(`\n❌ ${failures.length} build(s) failed at level ${levelNum}:`);
+        for (const f of failures) {
+          console.error(`   ${f.error.message}`);
+        }
+        process.exit(1);
+      }
+    } else {
+      // Build libs sequentially in the order they appear in package.json
+      for (const lib of libs) {
+        try {
+          await buildLib(lib);
+        } catch (err) {
+          console.error(`\n❌ Build failed at level ${levelNum}: ${err.message}`);
+          process.exit(1);
+        }
+      }
     }
   }
+
+  console.log('\n✅ All libraries built successfully.\n');
 }
 
-function getChokidarCommand(libName) {
-  const pathGlob = `projects/valtimo/${libName}/**/*`;
-  const rebuildScriptPath = path.resolve(__dirname, 'rebuild-lib.js');
+// ── Rebuild queue ──────────────────────────────────────────────────────────────
 
-  return `chokidar "${pathGlob}" --polling --await-write-finish --delay 300 -c "node ${rebuildScriptPath} ${libName}"`;
-}
-
-async function runNext() {
-  if (current >= watchScripts.length) {
-    if (!hasStartedApp) {
-      console.log('\nAll libs are watching. Checking if app should start...\n');
-      const inUse = await checkPortInUse(PORT_TO_CHECK);
-
-      if (!inUse) {
-        console.log('Launching app with: npm run start\n');
-        const startProc = spawn('npm run start', {
-          stdio: 'inherit',
-          shell: true,
-        });
-
-        startProc.on('error', err => {
-          console.error('Failed to start app:', err);
-        });
-
-        activeProcesses.push(startProc);
-        hasStartedApp = true;
-      } else {
-        console.log(`Port ${PORT_TO_CHECK} in use. Skipping npm start.`);
-        hasStartedApp = true;
+/**
+ * Notify webpack that rebuilt libraries have new output. Touches the entry file of
+ * every library that was swapped since the last notification. Called once when the
+ * queue is fully drained (nothing building, nothing queued) so that webpack
+ * recompiles exactly once rather than once per library.
+ */
+function notifyWebpack() {
+  if (swappedLibs.size === 0) return;
+  const now = new Date();
+  // Libraries use either public_api.d.ts or public-api.d.ts (inconsistent naming).
+  const candidates = ['public_api.d.ts', 'public-api.d.ts', 'index.d.ts'];
+  for (const libName of swappedLibs) {
+    const libDist = path.join(FRONTEND_ROOT, 'dist', 'valtimo', libName);
+    for (const candidate of candidates) {
+      const entryFile = path.join(libDist, candidate);
+      try {
+        if (fs.existsSync(entryFile)) {
+          fs.utimesSync(entryFile, now, now);
+          break;
+        }
+      } catch {
+        // ignore — best effort
       }
+    }
+  }
+  swappedLibs.clear();
+}
+
+/**
+ * Check whether all dependencies of `libName` are done (not building and not queued).
+ */
+function depsReady(libName) {
+  const deps = dependsOn.get(libName);
+  if (!deps) return true;
+  for (const dep of deps) {
+    if (building.has(dep) || queued.has(dep)) return false;
+  }
+  return true;
+}
+
+/**
+ * Process the rebuild queue: start builds for any queued libraries whose dependencies
+ * are all finished. Respects MAX_PARALLEL_BUILDS.
+ */
+function processQueue() {
+  if (queued.size === 0) {
+    // Queue drained — if nothing is building either, notify webpack once for all swapped libs.
+    if (building.size === 0) {
+      notifyWebpack();
     }
     return;
   }
 
-  const script = watchScripts[current];
-  const libName = getLibraryNameFromScript(script);
-  const chokidarCmd = getChokidarCommand(libName);
-  const initialBuildCmd = `ng build @valtimo/${libName}`;
+  for (const [libName] of queued) {
+    if (building.size >= MAX_PARALLEL_BUILDS) break;
+    if (building.has(libName)) continue;
+    if (!depsReady(libName)) continue;
 
-  if (!skipInitialBuild) {
-    console.log(`\nBuilding library initially: @valtimo/${libName}`);
-    createRebuildLock();
+    // Remove from queue and start building
+    queued.delete(libName);
+    building.add(libName);
 
-    const buildProc = spawn(initialBuildCmd, {shell: true});
-    let output = '';
-
-    buildProc.stdout.on('data', data => {
-      const str = data.toString();
-      process.stdout.write(str);
-      output += str;
-
-      if (str.includes('Built Angular Package')) {
-        console.log(`Initial library build done for: @valtimo/${libName}\n`);
-        buildProc.stdout.removeAllListeners();
-        removeRebuildLock();
-        buildProc.kill();
-
-        const watcherProc = spawn(chokidarCmd, {
-          stdio: 'inherit',
-          shell: true,
-        });
-
-        watcherProc.on('error', err => {
-          console.error(`Watcher error for @valtimo/${libName}:`, err);
-        });
-
-        activeProcesses.push(watcherProc);
-        current++;
-        runNext();
-      }
-    });
-
-    buildProc.stderr.on('data', data => {
-      process.stderr.write(data.toString());
-    });
-
-    buildProc.on('error', err => {
-      console.error(`Failed to start build for @valtimo/${libName}:`, err);
-      removeRebuildLock();
-      process.exit(1);
-    });
-
-    buildProc.on('exit', code => {
-      if (code !== 0 && code !== null && !output.includes('Built Angular Package')) {
-        console.error(`Build failed for @valtimo/${libName} with code ${code}`);
-        removeRebuildLock();
-        process.exit(1);
-      }
-    });
-  } else {
-    console.log(`\nSkipping initial library build for: @valtimo/${libName}, starting watcher...\n`);
-    const watcherProc = spawn(chokidarCmd, {
-      stdio: 'inherit',
-      shell: true,
-    });
-
-    watcherProc.on('error', err => {
-      console.error(`Watcher error for @valtimo/${libName}:`, err);
-    });
-
-    activeProcesses.push(watcherProc);
-    current++;
-    runNext();
+    buildLib(libName, {safeSwap: true})
+      .then(() => {
+        building.delete(libName);
+        // Queue dependents that were also pending
+        const deps = dependents.get(libName);
+        if (deps) {
+          for (const dep of deps) {
+            if (pendingRebuilds.has(dep)) {
+              pendingRebuilds.delete(dep);
+              enqueue(dep);
+            }
+          }
+        }
+        processQueue();
+      })
+      .catch(() => {
+        building.delete(libName);
+        processQueue();
+      });
   }
 }
 
-let isCleaningUp = false;
+/**
+ * Add a library to the rebuild queue.
+ */
+function enqueue(libName) {
+  if (building.has(libName)) {
+    // Already building — mark as needing another rebuild after this one finishes
+    pendingRebuilds.add(libName);
+    return;
+  }
+
+  if (queued.has(libName)) {
+    // Already queued — no need to add again
+    return;
+  }
+
+  queued.set(libName, true);
+  processQueue();
+}
+
+/**
+ * Called when a source file changes for a library. Debounces and enqueues.
+ * Ignores events for libraries that are already building or queued to avoid
+ * spurious re-triggers from intermediate build artifacts.
+ */
+function onLibSourceChange(libName) {
+  if (building.has(libName) || queued.has(libName)) {
+    return;
+  }
+
+  // Clear any existing debounce timer
+  if (debounceTimers.has(libName)) {
+    clearTimeout(debounceTimers.get(libName));
+  }
+
+  debounceTimers.set(
+    libName,
+    setTimeout(() => {
+      debounceTimers.delete(libName);
+      console.log(`\n📝 Change detected in @valtimo/${libName} — queuing rebuild`);
+      enqueue(libName);
+    }, DEBOUNCE_MS)
+  );
+}
+
+// ── File watchers using chokidar ───────────────────────────────────────────────
+
+function startWatchers() {
+  console.log('👀 Starting file watchers for all libraries...\n');
+
+  // We use Node's native fs.watch with recursive option (supported on macOS and Windows).
+  // This avoids the overhead of chokidar subprocesses and gives us in-process change detection.
+  for (const libName of allLibs) {
+    const libSrcDir = path.join(FRONTEND_ROOT, 'projects', 'valtimo', libName);
+
+    if (!fs.existsSync(libSrcDir)) {
+      console.warn(`  ⚠ Source directory not found for ${libName}: ${libSrcDir}`);
+      continue;
+    }
+
+    try {
+      const watcher = fs.watch(libSrcDir, {recursive: true}, (eventType, filename) => {
+        if (!filename) return;
+        // Ignore non-source files
+        if (
+          !filename.endsWith('.ts') &&
+          !filename.endsWith('.html') &&
+          !filename.endsWith('.scss') &&
+          !filename.endsWith('.css') &&
+          !filename.endsWith('.json')
+        ) {
+          return;
+        }
+        // Ignore spec files, test files, and ng-package.json (modified during safeSwap builds)
+        if (filename.endsWith('.spec.ts')) return;
+        if (filename === 'ng-package.json') return;
+
+        onLibSourceChange(libName);
+      });
+
+      watcher.on('error', err => {
+        console.error(`  ⚠ Watcher error for ${libName}: ${err.message}`);
+      });
+
+      activeProcesses.push({kill: () => watcher.close(), killed: false});
+    } catch (err) {
+      console.error(`  ⚠ Failed to start watcher for ${libName}: ${err.message}`);
+    }
+  }
+
+  console.log(`  Started watchers for ${allLibs.length} libraries.\n`);
+}
+
+// ── Start the dev server ───────────────────────────────────────────────────────
+
+async function startDevServer() {
+  const inUse = await checkPortInUse(PORT_TO_CHECK);
+
+  if (inUse) {
+    console.log(`Port ${PORT_TO_CHECK} already in use. Skipping app start.\n`);
+    hasStartedApp = true;
+    return;
+  }
+
+  console.log('🚀 Starting Angular dev server (npm run start)...\n');
+
+  const startProc = spawn('npm', ['run', 'start'], {
+    stdio: 'inherit',
+    shell: true,
+    cwd: FRONTEND_ROOT,
+  });
+
+  startProc.on('error', err => {
+    console.error('Failed to start app:', err);
+  });
+
+  activeProcesses.push(startProc);
+  hasStartedApp = true;
+}
+
+// ── Cleanup ────────────────────────────────────────────────────────────────────
 
 function cleanup() {
   if (isCleaningUp) return;
   isCleaningUp = true;
 
-  console.log('\nCleaning up child processes and temp files...\n');
-  activeProcesses.forEach(p => {
+  console.log('\n🧹 Cleaning up child processes and lock files...\n');
+
+  for (const p of activeProcesses) {
     try {
       if (p && !p.killed) {
         p.kill();
       }
     } catch (err) {
-      console.error('Failed to kill process:', err);
+      // Ignore cleanup errors
     }
-  });
+  }
 
-  removeRebuildLock();
+  removeAllLocks();
   process.exit();
 }
 
 process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
-process.on('exit', cleanup);
 
-runNext();
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+async function main() {
+  // Clean any stale lock files from previous runs
+  removeAllLocks();
+
+  await initialBuildAll();
+  startWatchers();
+  await startDevServer();
+
+  console.log('✨ Dev mode is running. Edit any library source to trigger a rebuild.\n');
+}
+
+main().catch(err => {
+  console.error('Dev mode failed:', err);
+  cleanup();
+});

--- a/frontend/scripts/lib-dependency-graph.js
+++ b/frontend/scripts/lib-dependency-graph.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,8 +286,7 @@ function getLibDependencyGraph(packageJsonPath) {
   }
 
   const frontendRoot = path.dirname(packageJsonPath);
-  const {libLevels, levels, sortedLevelNumbers, levelBuildModes} =
-    parseBuildOrder(packageJsonPath);
+  const {libLevels, levels, sortedLevelNumbers, levelBuildModes} = parseBuildOrder(packageJsonPath);
   const {dependsOn, dependents} = buildDependencyMap(
     libLevels,
     levels,

--- a/frontend/scripts/lib-dependency-graph.js
+++ b/frontend/scripts/lib-dependency-graph.js
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parses the build order from package.json scripts (libs:build-N:* and libs:build:*)
+ * and the libs-build-all command to derive the full dependency graph.
+ *
+ * The libs-build-all script determines whether each level is built sequentially (run-s)
+ * or in parallel (run-p). For sequential levels, libraries within the level depend on
+ * each other in the order they appear in package.json. For parallel levels, libraries
+ * within the level have no mutual dependencies.
+ *
+ * Build levels from package.json:
+ *   libs:build-1:*  -> level 1 (sequential)
+ *   libs:build-2:*  -> level 2 (parallel)
+ *   libs:build-3:*  -> level 3 (sequential)
+ *   libs:build-4:*  -> level 4 (sequential)
+ *   libs:build-5:*  -> level 5 (sequential)
+ *   libs:build-6:*  -> level 6 (sequential)
+ *   libs:build-7:*  -> level 7 (sequential)
+ *   libs:build:*    -> level 8 (parallel, leaf libraries)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BUILD_SCRIPT_PATTERN = /^libs:build(-(\d+))?:(.+)$/;
+
+/**
+ * Parse the libs-build-all script to determine which levels use run-p (parallel)
+ * and which use run-s (sequential).
+ *
+ * The script looks like:
+ *   rimraf dist && run-s libs:build-1:* && run-p ... libs:build-2:* && run-s libs:build-3:* ...
+ *
+ * Returns a Map<number, 'parallel' | 'sequential'> for numbered levels,
+ * plus a mode for the unnumbered libs:build:* group.
+ */
+function parseBuildModes(buildAllScript) {
+  const modes = new Map();
+  let leafMode = 'sequential';
+
+  // Split on && to get each step
+  const steps = buildAllScript.split('&&').map(s => s.trim());
+
+  for (const step of steps) {
+    // Check if this step references libs:build-N:* or libs:build:*
+    const levelMatch = step.match(/libs:build-(\d+):\*/);
+    const leafMatch = step.match(/(?:^|\s)libs:build:\*/);
+
+    if (levelMatch) {
+      const level = parseInt(levelMatch[1], 10);
+      const isParallel = step.includes('run-p') || step.includes('-p');
+      modes.set(level, isParallel ? 'parallel' : 'sequential');
+    } else if (leafMatch) {
+      const isParallel = step.includes('run-p') || step.includes('-p');
+      leafMode = isParallel ? 'parallel' : 'sequential';
+    }
+  }
+
+  return {modes, leafMode};
+}
+
+function parseBuildOrder(packageJsonPath) {
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const scriptNames = Object.keys(pkg.scripts);
+
+  // Map: libName -> level number
+  const libLevels = new Map();
+  // Map: level number -> [libName, ...] (preserves order from package.json)
+  const levels = new Map();
+
+  let maxNumberedLevel = 0;
+
+  for (const name of scriptNames) {
+    const match = name.match(BUILD_SCRIPT_PATTERN);
+    if (!match) continue;
+
+    const levelStr = match[2]; // undefined for libs:build:*, digit string for libs:build-N:*
+    const libName = match[3];
+
+    // Skip non-library entries like copy-version
+    if (libName === 'copy-version') continue;
+
+    let level;
+    if (levelStr) {
+      level = parseInt(levelStr, 10);
+      maxNumberedLevel = Math.max(maxNumberedLevel, level);
+    } else {
+      level = -1; // placeholder for leaf libs
+    }
+
+    // A library might appear in both libs:build-N and libs:build — the numbered one is the
+    // authoritative build level; the unnumbered one is a "leaf" build.
+    if (level !== -1) {
+      libLevels.set(libName, level);
+      if (!levels.has(level)) levels.set(level, []);
+      levels.get(level).push(libName);
+    } else if (!libLevels.has(libName)) {
+      libLevels.set(libName, -1);
+    }
+  }
+
+  // Assign unnumbered libs to level maxNumberedLevel + 1
+  const leafLevel = maxNumberedLevel + 1;
+  for (const [libName, level] of libLevels) {
+    if (level === -1) {
+      libLevels.set(libName, leafLevel);
+      if (!levels.has(leafLevel)) levels.set(leafLevel, []);
+      levels.get(leafLevel).push(libName);
+    }
+  }
+
+  // Sort levels
+  const sortedLevelNumbers = [...levels.keys()].sort((a, b) => a - b);
+
+  // Parse parallel/sequential modes from libs-build-all script
+  const buildAllScript = pkg.scripts['libs-build-all'] || '';
+  const {modes: levelModes, leafMode} = parseBuildModes(buildAllScript);
+
+  // Build the mode map including the leaf level
+  const levelBuildModes = new Map();
+  for (const levelNum of sortedLevelNumbers) {
+    if (levelNum === leafLevel) {
+      levelBuildModes.set(levelNum, leafMode);
+    } else {
+      levelBuildModes.set(levelNum, levelModes.get(levelNum) || 'sequential');
+    }
+  }
+
+  return {libLevels, levels, sortedLevelNumbers, levelBuildModes};
+}
+
+/**
+ * For parallel levels, scan TypeScript source files to detect actual import dependencies
+ * between libraries at the same level. This catches hidden intra-level dependencies that
+ * the package.json build order doesn't encode (e.g. bootstrap -> account at leaf level).
+ */
+function scanImportsForParallelLevels(levels, sortedLevelNumbers, levelBuildModes, frontendRoot) {
+  const VALTIMO_IMPORT = /@valtimo\/([a-z-]+)/g;
+  // intraLevelDeps: Map<libName, Set<libName>> — only for parallel levels
+  const intraLevelDeps = new Map();
+
+  for (const levelNum of sortedLevelNumbers) {
+    if (levelBuildModes.get(levelNum) !== 'parallel') continue;
+
+    const libsAtLevel = new Set(levels.get(levelNum));
+
+    for (const libName of libsAtLevel) {
+      const libSrcDir = path.join(frontendRoot, 'projects', 'valtimo', libName, 'src');
+      if (!fs.existsSync(libSrcDir)) continue;
+
+      const tsFiles = findTsFiles(libSrcDir);
+      const deps = new Set();
+
+      for (const file of tsFiles) {
+        const content = fs.readFileSync(file, 'utf8');
+        let match;
+        VALTIMO_IMPORT.lastIndex = 0;
+        while ((match = VALTIMO_IMPORT.exec(content)) !== null) {
+          const depName = match[1];
+          // Only track if the dependency is in the same parallel level
+          if (depName !== libName && libsAtLevel.has(depName)) {
+            deps.add(depName);
+          }
+        }
+      }
+
+      if (deps.size > 0) {
+        intraLevelDeps.set(libName, deps);
+      }
+    }
+  }
+
+  return intraLevelDeps;
+}
+
+/**
+ * Recursively find all .ts files in a directory (excluding spec files).
+ */
+function findTsFiles(dir) {
+  const results = [];
+  try {
+    const entries = fs.readdirSync(dir, {withFileTypes: true});
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...findTsFiles(fullPath));
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts')) {
+        results.push(fullPath);
+      }
+    }
+  } catch {
+    // Ignore read errors
+  }
+  return results;
+}
+
+/**
+ * Builds the dependency map.
+ *
+ * - Every library depends on ALL libraries at lower levels.
+ * - For sequential levels, libraries also depend on earlier libraries within the same level
+ *   (because run-s builds them in order).
+ * - For parallel levels, source imports are scanned to detect hidden intra-level dependencies.
+ */
+function buildDependencyMap(libLevels, levels, sortedLevelNumbers, levelBuildModes, frontendRoot) {
+  // dependsOn: libName -> Set<libName>
+  const dependsOn = new Map();
+  // dependents: libName -> Set<libName> (reverse map)
+  const dependents = new Map();
+
+  for (const libName of libLevels.keys()) {
+    dependsOn.set(libName, new Set());
+    dependents.set(libName, new Set());
+  }
+
+  // Inter-level dependencies: each lib depends on all libs at lower levels
+  for (const libName of libLevels.keys()) {
+    const myLevel = libLevels.get(libName);
+    for (const levelNum of sortedLevelNumbers) {
+      if (levelNum >= myLevel) break;
+      for (const depLib of levels.get(levelNum)) {
+        dependsOn.get(libName).add(depLib);
+        dependents.get(depLib).add(libName);
+      }
+    }
+  }
+
+  // Intra-level dependencies for sequential levels
+  for (const levelNum of sortedLevelNumbers) {
+    if (levelBuildModes.get(levelNum) !== 'sequential') continue;
+
+    const libs = levels.get(levelNum);
+    for (let i = 1; i < libs.length; i++) {
+      // libs[i] depends on libs[i-1] (sequential chain)
+      dependsOn.get(libs[i]).add(libs[i - 1]);
+      dependents.get(libs[i - 1]).add(libs[i]);
+    }
+  }
+
+  // Intra-level dependencies for parallel levels (detected from source imports)
+  const intraLevelDeps = scanImportsForParallelLevels(
+    levels,
+    sortedLevelNumbers,
+    levelBuildModes,
+    frontendRoot
+  );
+
+  for (const [libName, deps] of intraLevelDeps) {
+    for (const dep of deps) {
+      dependsOn.get(libName).add(dep);
+      dependents.get(dep).add(libName);
+    }
+  }
+
+  return {dependsOn, dependents};
+}
+
+/**
+ * Returns the full graph info:
+ * - libLevels: Map<libName, levelNumber>
+ * - levels: Map<levelNumber, libName[]>
+ * - sortedLevelNumbers: number[]
+ * - levelBuildModes: Map<levelNumber, 'parallel' | 'sequential'>
+ * - dependsOn: Map<libName, Set<libName>>
+ * - dependents: Map<libName, Set<libName>>
+ * - allLibs: string[]
+ */
+function getLibDependencyGraph(packageJsonPath) {
+  if (!packageJsonPath) {
+    packageJsonPath = path.resolve(__dirname, '../package.json');
+  }
+
+  const frontendRoot = path.dirname(packageJsonPath);
+  const {libLevels, levels, sortedLevelNumbers, levelBuildModes} =
+    parseBuildOrder(packageJsonPath);
+  const {dependsOn, dependents} = buildDependencyMap(
+    libLevels,
+    levels,
+    sortedLevelNumbers,
+    levelBuildModes,
+    frontendRoot
+  );
+  const allLibs = [...libLevels.keys()];
+
+  return {
+    libLevels,
+    levels,
+    sortedLevelNumbers,
+    levelBuildModes,
+    dependsOn,
+    dependents,
+    allLibs,
+  };
+}
+
+module.exports = {getLibDependencyGraph};

--- a/frontend/scripts/rebuild-lib.js
+++ b/frontend/scripts/rebuild-lib.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/scripts/rebuild-lib.js
+++ b/frontend/scripts/rebuild-lib.js
@@ -1,35 +1,74 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Standalone library rebuild script.
+ *
+ * Usage: node rebuild-lib.js <lib-name>
+ *
+ * Uses a per-library lock file (.rebuilding-<lib>.lock) to prevent concurrent builds
+ * of the same library. If the lock file exists (another build is in progress), the
+ * rebuild is skipped.
+ *
+ * NOTE: In dev mode, rebuilds are coordinated by dev-mode.js which handles dependency
+ * ordering and queuing. This script is kept for standalone / manual use only.
+ */
+
 const {spawn} = require('child_process');
 const fs = require('fs').promises;
+const fsSync = require('fs');
 const path = require('path');
 
 const libName = process.argv[2];
-const fullLibName = `@valtimo/${libName}`;
-const rebuildLockFile = path.resolve(__dirname, '../.rebuilding.lock');
-const libRebuildLockFile = path.resolve(__dirname, `../.rebuilding-lib.lock`);
 
-async function createLockFile(lockFile) {
+if (!libName) {
+  console.error('Usage: node rebuild-lib.js <lib-name>');
+  process.exit(1);
+}
+
+const fullLibName = `@valtimo/${libName}`;
+const lockFile = path.resolve(__dirname, `../.rebuilding-${libName}.lock`);
+
+async function createLockFile() {
   try {
-    await fs.writeFile(lockFile, 'rebuilding');
-    console.log(`Created lock file: ${lockFile}`);
+    await fs.writeFile(lockFile, `building:${Date.now()}`);
   } catch (err) {
     console.error(`Failed to create lock file: ${lockFile}`, err.message);
   }
 }
 
-async function removeLockFile(lockFile) {
+async function removeLockFile() {
   try {
     await fs.rm(lockFile);
-    console.log(`Removed lock file: ${lockFile}`);
   } catch (err) {
-    console.error(`Failed to remove lock file: ${lockFile}`, err.message);
+    // Ignore if already removed
   }
 }
 
+function isLocked() {
+  return fsSync.existsSync(lockFile);
+}
+
 async function rebuild() {
-  await createLockFile(rebuildLockFile);
+  if (isLocked()) {
+    console.log(`Build already in progress for ${fullLibName} — skipping.`);
+    return;
+  }
 
-  await createLockFile(libRebuildLockFile);
-
+  await createLockFile();
   console.log(`Rebuilding ${fullLibName}`);
 
   try {
@@ -38,14 +77,7 @@ async function rebuild() {
 
       buildProc.on('exit', async code => {
         if (code === 0) {
-          console.log(`Build completed for: ${libName}`);
-
-          await removeLockFile(libRebuildLockFile);
-
-          console.log(`Library built successfully. Removing general lock file.`);
-
-          await removeLockFile(rebuildLockFile);
-
+          console.log(`Build completed for: ${fullLibName}`);
           resolve();
         } else {
           reject(new Error(`Build failed for ${fullLibName} with exit code ${code}`));
@@ -54,9 +86,8 @@ async function rebuild() {
     });
   } catch (err) {
     console.error(`Error during rebuild of ${fullLibName}:`, err.message);
-
-    // On error, remove only the library-specific lock file to allow retry
-    await removeLockFile(libRebuildLockFile);
+  } finally {
+    await removeLockFile();
   }
 }
 


### PR DESCRIPTION
- DevMode no longer crashes when you edit multiple libraries at the same time. Previously, changing files in several libraries in quick succession would cause build failures and break the dev server, forcing a restart. Now it handles this gracefully.
- Libraries are built in the correct order automatically. The build system now reads the dependency tree from package.json at startup and makes sure a library is never built before the libraries it depends on are finished. Before, builds ran independently with no awareness of each other.
- The dev server no longer shows "Cannot find module" errors during rebuilds. Previously, rebuilding a library would briefly delete its output folder, causing the dev server to fail and sometimes not recover. Now the build happens in a temporary folder and gets swapped in atomically, so the dev server never sees a broken state.
- One coordinated process instead of many independent ones. The old approach spawned a separate watcher and rebuilder for each library, all competing with each other. Now a single process coordinates everything with a queue, avoiding race conditions.
- Rapid edits are batched together. If you save a file multiple times quickly, or edit several files across libraries in a short burst, the system debounces and groups the work instead of kicking off redundant builds.
- The dev server recompiles exactly once after a batch of rebuilds, not once per library. This makes the feedback loop faster when multiple libraries change at the same time.