### PR TITLE
Fix verzoek with empty kvk

### DIFF
--- a/backend/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
+++ b/backend/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
@@ -118,9 +118,9 @@ class VerzoekPluginEventListener(
             val document = createDocument(caseDefinitionId, verzoekProperty, verzoekObject)
             withLoggingContext(JsonSchemaDocument::class, document.id()) {
                 val zaakTypeUrl = zaaktypeUrlProvider.getZaaktypeUrl(document.definitionId().caseDefinitionId())
-                val initiatorType = if (verzoekObjectData.has("kvk")) {
+                val initiatorType = if (verzoekObjectData.has("kvk") && verzoekObjectData["kvk"].textValue().isNotBlank()) {
                     "kvk"
-                } else if (verzoekObjectData.has("bsn")) {
+                } else if (verzoekObjectData.has("bsn") && verzoekObjectData["bsn"].textValue().isNotBlank()) {
                     "bsn"
                 } else {
                     null

--- a/backend/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
+++ b/backend/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
@@ -118,9 +118,9 @@ class VerzoekPluginEventListener(
             val document = createDocument(caseDefinitionId, verzoekProperty, verzoekObject)
             withLoggingContext(JsonSchemaDocument::class, document.id()) {
                 val zaakTypeUrl = zaaktypeUrlProvider.getZaaktypeUrl(document.definitionId().caseDefinitionId())
-                val initiatorType = if (verzoekObjectData.has("kvk") && verzoekObjectData["kvk"].textValue().isNotBlank()) {
+                val initiatorType = if (verzoekObjectData.hasNonNull("kvk") && verzoekObjectData["kvk"].asText().isNotBlank()) {
                     "kvk"
-                } else if (verzoekObjectData.has("bsn") && verzoekObjectData["bsn"].textValue().isNotBlank()) {
+                } else if (verzoekObjectData.hasNonNull("bsn") && verzoekObjectData["bsn"].asText().isNotBlank()) {
                     "bsn"
                 } else {
                     null


### PR DESCRIPTION
The bug:
1. Have verzoek object in Objecten API
2. Verzoek object contains `{..."kvk": ""...}`
3. Configure Valtimo with verzoek plugin to receive that object
4. The bug: `pv.initiatorType` will be set to 'kvk' even though kvk is not present