### PR TITLE
Improvements on the documenten-api-preview plugin.

### DIFF
--- a/backend/app/gzac/docker-compose.yaml
+++ b/backend/app/gzac/docker-compose.yaml
@@ -105,6 +105,8 @@ services:
         container_name: gotenberg-pdf-conversion-api
         ports:
             - "3000:3000"
+        environment:
+            API_TIMEOUT: "240s"
 
     # ZGW
 

--- a/backend/app/gzac/src/main/resources/application.yml
+++ b/backend/app/gzac/src/main/resources/application.yml
@@ -228,7 +228,11 @@ valtimo:
             - image/jpeg
             - image/png
             - application/msword
+            - application/vnd.ms-excel
+            - application/vnd.ms-powerpoint
             - application/vnd.openxmlformats-officedocument.wordprocessingml.document
+            - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+            - application/vnd.openxmlformats-officedocument.presentationml.presentation
 
     outbox:
         enabled: true

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPlugin.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPlugin.kt
@@ -21,6 +21,7 @@ import com.ritense.documentenapi.DocumentenApiPlugin
 import com.ritense.documentenapi.client.DocumentInformatieObject
 import com.ritense.documentenapipreview.DocumentenApiPreviewPlugin.Companion.PLUGIN_KEY
 import com.ritense.documentenapipreview.client.PdfConversionClient
+import com.ritense.documentenapipreview.domain.PdfArchiveMethod
 import com.ritense.documentenapipreview.domain.PdfFile
 import com.ritense.plugin.annotation.Plugin
 import com.ritense.plugin.annotation.PluginProperty
@@ -46,6 +47,12 @@ class DocumentenApiPreviewPlugin(
     @PluginProperty(key = DOCUMENTEN_API_CONFIGURATION_ID, secret = false)
     lateinit var documentenApiConfigurationId: String
 
+    @PluginProperty(key = PDF_ARCHIVE_METHOD, secret = false, required = false)
+    var pdfArchiveMethod: PdfArchiveMethod = PdfArchiveMethod.NONE
+
+    @PluginProperty(key = PDF_ARCHIVE_UNIVERSAL_ACCESSIBILITY, secret = false, required = false)
+    var pdfArchiveUniversalAccessibility: Boolean = false
+
     fun generatePreview(caseDocumentId: UUID, documentId: String): PdfFile {
         val documentenApiPlugin = getDocumentenApiPlugin()
         val documentStream = documentenApiPlugin.downloadInformatieObject(caseDocumentId, documentId)
@@ -58,7 +65,12 @@ class DocumentenApiPreviewPlugin(
             return PdfFile(documentInformatieObject.bestandsnaam!!, documentStream)
         }
 
-        val pdfStream = pdfConversionClient.convertDocument(pdfConversionUrl, documentStream, documentInformatieObject.bestandsnaam)
+        val pdfStream = pdfConversionClient.convertDocument(
+            pdfConversionUrl,
+            documentStream,
+            documentInformatieObject.bestandsnaam,
+            pdfArchiveMethod,
+            pdfArchiveUniversalAccessibility)
 
         return PdfFile(createFilename(documentInformatieObject), pdfStream)
     }
@@ -78,6 +90,9 @@ class DocumentenApiPreviewPlugin(
         const val PLUGIN_KEY = "documentenapipreview"
         const val PDF_CONVERSION_URL_PROPERTY = "pdfConversionUrl"
         const val DOCUMENTEN_API_CONFIGURATION_ID = "documentenApiConfigurationId"
+        const val PDF_ARCHIVE_METHOD = "pdfArchive"
+        const val PDF_ARCHIVE_UNIVERSAL_ACCESSIBILITY = "pdfArchiveUniversalAccessibility"
+
 
         fun findConfigurationByDocumentenApiConfiguration(documentenApiConfigurationId: String) = { properties: JsonNode ->
             documentenApiConfigurationId == properties[DOCUMENTEN_API_CONFIGURATION_ID].textValue()

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPlugin.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPlugin.kt
@@ -90,7 +90,7 @@ class DocumentenApiPreviewPlugin(
         const val PLUGIN_KEY = "documentenapipreview"
         const val PDF_CONVERSION_URL_PROPERTY = "pdfConversionUrl"
         const val DOCUMENTEN_API_CONFIGURATION_ID = "documentenApiConfigurationId"
-        const val PDF_ARCHIVE_METHOD = "pdfArchive"
+        const val PDF_ARCHIVE_METHOD = "pdfArchiveMethod"
         const val PDF_ARCHIVE_UNIVERSAL_ACCESSIBILITY = "pdfArchiveUniversalAccessibility"
 
 

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPlugin.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPlugin.kt
@@ -50,8 +50,8 @@ class DocumentenApiPreviewPlugin(
     @PluginProperty(key = PDF_ARCHIVE_METHOD, secret = false, required = false)
     var pdfArchiveMethod: PdfArchiveMethod = PdfArchiveMethod.NONE
 
-    @PluginProperty(key = PDF_ARCHIVE_UNIVERSAL_ACCESSIBILITY, secret = false, required = false)
-    var pdfArchiveUniversalAccessibility: Boolean = false
+    @PluginProperty(key = PDF_UNIVERSAL_ACCESSIBILITY, secret = false, required = false)
+    var pdfUniversalAccessibility: Boolean = false
 
     fun generatePreview(caseDocumentId: UUID, documentId: String): PdfFile {
         val documentenApiPlugin = getDocumentenApiPlugin()
@@ -70,7 +70,7 @@ class DocumentenApiPreviewPlugin(
             documentStream,
             documentInformatieObject.bestandsnaam,
             pdfArchiveMethod,
-            pdfArchiveUniversalAccessibility)
+            pdfUniversalAccessibility)
 
         return PdfFile(createFilename(documentInformatieObject), pdfStream)
     }
@@ -91,7 +91,7 @@ class DocumentenApiPreviewPlugin(
         const val PDF_CONVERSION_URL_PROPERTY = "pdfConversionUrl"
         const val DOCUMENTEN_API_CONFIGURATION_ID = "documentenApiConfigurationId"
         const val PDF_ARCHIVE_METHOD = "pdfArchiveMethod"
-        const val PDF_ARCHIVE_UNIVERSAL_ACCESSIBILITY = "pdfArchiveUniversalAccessibility"
+        const val PDF_UNIVERSAL_ACCESSIBILITY = "pdfUniversalAccessibility"
 
 
         fun findConfigurationByDocumentenApiConfiguration(documentenApiConfigurationId: String) = { properties: JsonNode ->

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.documentenapipreview.client
 
+import com.ritense.documentenapipreview.domain.PdfArchiveMethod
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.zgw.ClientTools
 import org.springframework.core.io.InputStreamResource
@@ -37,12 +38,20 @@ class PdfConversionClient(
         baseUrl: URI,
         document: InputStream,
         fileName: String? = null,
+        pdfArchiveMethod: PdfArchiveMethod = PdfArchiveMethod.NONE,
+        pdfArchiveUniversalAccessibility: Boolean = false,
     ): InputStream {
+
+
         val bodyBuilder = MultipartBodyBuilder().apply {
             part("files", InputStreamResource(document)).filename(fileName ?: "file_name_unknown")
             part("exportFormFields", "false")
-            part("pdfa", "PDF/A-1b")
-            part("pdfua", "true")
+            part("pdfa", convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod))
+            if (pdfArchiveUniversalAccessibility) {
+                part("pdfua", "true")
+            } else {
+                part("pdfua", "false")
+            }
         }
 
         val result = restClient()
@@ -57,6 +66,15 @@ class PdfConversionClient(
             .body<Resource>()!!
 
         return result.inputStream
+    }
+
+    private fun convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod: PdfArchiveMethod): String {
+        return when (pdfArchiveMethod) {
+            PdfArchiveMethod.NONE -> "None"
+            PdfArchiveMethod.PDFA1B -> "PDF/A-1b"
+            PdfArchiveMethod.PDFA2B -> "PDF/A-2b"
+            PdfArchiveMethod.PDFA3B -> "PDF/A-3b"
+        }
     }
 
     private fun restClient(): RestClient {

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
@@ -46,14 +46,8 @@ class PdfConversionClient(
         val bodyBuilder = MultipartBodyBuilder().apply {
             part("files", InputStreamResource(document)).filename(fileName ?: "file_name_unknown")
             part("exportFormFields", "false")
-            if (pdfArchiveMethod != PdfArchiveMethod.NONE) {
-                part("pdfa", convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod))
-            }
-            if (pdfUniversalAccessibility) {
-                part("pdfua", "true")
-            } else {
-                part("pdfua", "false")
-            }
+            convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod)?.let { part("pdfa", it) }
+            part("pdfua", pdfUniversalAccessibility.toString())
         }
 
         val result = restClient()
@@ -70,9 +64,9 @@ class PdfConversionClient(
         return result.inputStream
     }
 
-    private fun convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod: PdfArchiveMethod): String {
+    private fun convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod: PdfArchiveMethod): String? {
         return when (pdfArchiveMethod) {
-            PdfArchiveMethod.NONE -> "None"
+            PdfArchiveMethod.NONE -> null
             PdfArchiveMethod.PDFA1B -> "PDF/A-1b"
             PdfArchiveMethod.PDFA2B -> "PDF/A-2b"
             PdfArchiveMethod.PDFA3B -> "PDF/A-3b"

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
@@ -46,7 +46,9 @@ class PdfConversionClient(
         val bodyBuilder = MultipartBodyBuilder().apply {
             part("files", InputStreamResource(document)).filename(fileName ?: "file_name_unknown")
             part("exportFormFields", "false")
-            part("pdfa", convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod))
+            if (pdfArchiveMethod != PdfArchiveMethod.NONE) {
+                part("pdfa", convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod))
+            }
             if (pdfUniversalAccessibility) {
                 part("pdfua", "true")
             } else {

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/client/PdfConversionClient.kt
@@ -39,7 +39,7 @@ class PdfConversionClient(
         document: InputStream,
         fileName: String? = null,
         pdfArchiveMethod: PdfArchiveMethod = PdfArchiveMethod.NONE,
-        pdfArchiveUniversalAccessibility: Boolean = false,
+        pdfUniversalAccessibility: Boolean = false,
     ): InputStream {
 
 
@@ -47,7 +47,7 @@ class PdfConversionClient(
             part("files", InputStreamResource(document)).filename(fileName ?: "file_name_unknown")
             part("exportFormFields", "false")
             part("pdfa", convertPdfArchiveMethodToGotenbergValue(pdfArchiveMethod))
-            if (pdfArchiveUniversalAccessibility) {
+            if (pdfUniversalAccessibility) {
                 part("pdfua", "true")
             } else {
                 part("pdfua", "false")

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/domain/PdfArchiveMethod.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/domain/PdfArchiveMethod.kt
@@ -12,6 +12,6 @@ enum class PdfArchiveMethod {
     @JsonProperty("PDF/A-2b")
     PDFA2B,
 
-    @JsonProperty("PDF/A-2b")
+    @JsonProperty("PDF/A-3b")
     PDFA3B,
 }

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/domain/PdfArchiveMethod.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/domain/PdfArchiveMethod.kt
@@ -1,0 +1,17 @@
+package com.ritense.documentenapipreview.domain
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+enum class PdfArchiveMethod {
+    @JsonProperty("none")
+    NONE,
+
+    @JsonProperty("PDF/A-1b")
+    PDFA1B,
+
+    @JsonProperty("PDF/A-2b")
+    PDFA2B,
+
+    @JsonProperty("PDF/A-2b")
+    PDFA3B,
+}

--- a/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/domain/PdfArchiveMethod.kt
+++ b/backend/zgw/documenten-api-preview/src/main/kotlin/com/ritense/documentenapipreview/domain/PdfArchiveMethod.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.documentenapipreview.domain
 
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPluginTest.kt
+++ b/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPluginTest.kt
@@ -19,6 +19,7 @@ package com.ritense.documentenapipreview
 import com.ritense.documentenapi.DocumentenApiPlugin
 import com.ritense.documentenapi.client.DocumentInformatieObject
 import com.ritense.documentenapipreview.client.PdfConversionClient
+import com.ritense.documentenapipreview.domain.PdfArchiveMethod
 import com.ritense.plugin.service.PluginService
 import com.ritense.zgw.Rsin
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +36,7 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 class DocumentenApiPreviewPluginTest {
+    private val documentenApiConfigurationId: String = "mock_documenten_api_preview_configuration_id"
     private lateinit var documentenApiPreviewPlugin: DocumentenApiPreviewPlugin
     private lateinit var documentenApiPlugin: DocumentenApiPlugin
     private lateinit var pdfConversionClient: PdfConversionClient
@@ -47,13 +49,9 @@ class DocumentenApiPreviewPluginTest {
         pdfConversionClient = mock<PdfConversionClient>()
         pluginService = mock<PluginService>()
 
-        documentenApiPreviewPlugin = DocumentenApiPreviewPlugin(pdfConversionClient, pluginService)
-        documentenApiPreviewPlugin.documentenApiConfigurationId = "mock_documenten_api_configuration_id"
-        documentenApiPreviewPlugin.pdfConversionUrl = URI("http://mock.url")
-
         mockDocumentStream = "TEST_DOCUMENT".byteInputStream()
 
-        whenever(pluginService.createInstance<DocumentenApiPlugin>(documentenApiPreviewPlugin.documentenApiConfigurationId))
+        whenever(pluginService.createInstance<DocumentenApiPlugin>(documentenApiConfigurationId))
             .thenReturn(documentenApiPlugin)
         whenever(documentenApiPlugin.downloadInformatieObject(MOCK_CASE_DOCUMENT_ID, MOCK_DOCUMENT_ID))
             .thenReturn(mockDocumentStream)
@@ -64,6 +62,10 @@ class DocumentenApiPreviewPluginTest {
 
     @Test
     fun `should call download on DocumentenApiPlugin`() {
+        documentenApiPreviewPlugin = DocumentenApiPreviewPlugin(pdfConversionClient, pluginService)
+        documentenApiPreviewPlugin.documentenApiConfigurationId = documentenApiConfigurationId
+        documentenApiPreviewPlugin.pdfConversionUrl = URI("http://mock.url")
+
         documentenApiPreviewPlugin.generatePreview(MOCK_CASE_DOCUMENT_ID, MOCK_DOCUMENT_ID)
 
         verify(documentenApiPlugin).downloadInformatieObject(MOCK_CASE_DOCUMENT_ID, MOCK_DOCUMENT_ID)
@@ -71,19 +73,47 @@ class DocumentenApiPreviewPluginTest {
 
     @Test
     fun `should call getInformatieObject on DocumentenApiPlugin`() {
+        documentenApiPreviewPlugin = DocumentenApiPreviewPlugin(pdfConversionClient, pluginService)
+        documentenApiPreviewPlugin.documentenApiConfigurationId = documentenApiConfigurationId
+        documentenApiPreviewPlugin.pdfConversionUrl = URI("http://mock.url")
+
         documentenApiPreviewPlugin.generatePreview(MOCK_CASE_DOCUMENT_ID, MOCK_DOCUMENT_ID)
 
         verify(documentenApiPlugin).getInformatieObject(MOCK_DOCUMENT_ID, MOCK_CASE_DOCUMENT_ID)
     }
 
     @Test
-    fun `should call generatePreview on PdfConversionClient`() {
+    fun `should call generatePreview on PdfConversionClient with default parameters`() {
+        documentenApiPreviewPlugin = DocumentenApiPreviewPlugin(pdfConversionClient, pluginService)
+        documentenApiPreviewPlugin.documentenApiConfigurationId = documentenApiConfigurationId
+        documentenApiPreviewPlugin.pdfConversionUrl = URI("http://mock.url")
+
         documentenApiPreviewPlugin.generatePreview(MOCK_CASE_DOCUMENT_ID, MOCK_DOCUMENT_ID)
 
         verify(pdfConversionClient).convertDocument(
             documentenApiPreviewPlugin.pdfConversionUrl,
             mockDocumentStream,
-            MOCK_DOCUMENT_INFORMATIE_OBJECT.bestandsnaam)
+            MOCK_DOCUMENT_INFORMATIE_OBJECT.bestandsnaam,
+            PdfArchiveMethod.NONE,
+            false)
+    }
+
+    @Test
+    fun `should call generatePreview on PdfConversionClient with custom parameters`() {
+        documentenApiPreviewPlugin = DocumentenApiPreviewPlugin(pdfConversionClient, pluginService)
+        documentenApiPreviewPlugin.documentenApiConfigurationId = documentenApiConfigurationId
+        documentenApiPreviewPlugin.pdfConversionUrl = URI("http://mock.url")
+        documentenApiPreviewPlugin.pdfArchiveMethod = PdfArchiveMethod.PDFA2B
+        documentenApiPreviewPlugin.pdfUniversalAccessibility = true
+
+        documentenApiPreviewPlugin.generatePreview(MOCK_CASE_DOCUMENT_ID, MOCK_DOCUMENT_ID)
+
+        verify(pdfConversionClient).convertDocument(
+            documentenApiPreviewPlugin.pdfConversionUrl,
+            mockDocumentStream,
+            MOCK_DOCUMENT_INFORMATIE_OBJECT.bestandsnaam,
+            documentenApiPreviewPlugin.pdfArchiveMethod,
+            documentenApiPreviewPlugin.pdfUniversalAccessibility)
     }
 
     companion object {

--- a/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPluginTest.kt
+++ b/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/DocumentenApiPreviewPluginTest.kt
@@ -59,7 +59,7 @@ class DocumentenApiPreviewPluginTest {
             .thenReturn(mockDocumentStream)
         whenever(documentenApiPlugin.getInformatieObject(MOCK_DOCUMENT_ID, MOCK_CASE_DOCUMENT_ID))
             .thenReturn(MOCK_DOCUMENT_INFORMATIE_OBJECT)
-        whenever(pdfConversionClient.convertDocument(any(), any(), any())).thenReturn(mockDocumentStream)
+        whenever(pdfConversionClient.convertDocument(any(), any(), any(), any(), any())).thenReturn(mockDocumentStream)
     }
 
     @Test

--- a/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/client/PdfConversionClientIT.kt
+++ b/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/client/PdfConversionClientIT.kt
@@ -19,6 +19,7 @@ package com.ritense.documentenapipreview.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.documentenapipreview.BaseIntegrationTest
 import com.ritense.documentenapipreview.DocumentenApiPreviewPlugin
+import com.ritense.documentenapipreview.domain.PdfArchiveMethod
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 
@@ -67,7 +68,9 @@ internal class PdfConversionClientIT @Autowired constructor(
         val stream = pdfConversionClient.convertDocument(
             documentenApiPreviewPlugin.pdfConversionUrl,
             "test_document".byteInputStream(),
-            "dummy_file.txt"
+            "dummy_file.txt",
+            PdfArchiveMethod.PDFA2B,
+            true
         )
 
         assertNotNull(stream)

--- a/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/client/PdfConversionClientTest.kt
+++ b/backend/zgw/documenten-api-preview/src/test/kotlin/com/ritense/documentenapipreview/client/PdfConversionClientTest.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.documentenapipreview.client
 
+import com.ritense.documentenapipreview.domain.PdfArchiveMethod
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertNotNull
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 import java.io.ByteArrayInputStream
@@ -33,6 +33,8 @@ import java.util.HashMap
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
 
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -71,7 +73,7 @@ internal class PdfConversionClientTest {
     }
 
     @Test
-    fun `should send request with correct form fields`() {
+    fun `should send request with default conversion parameters`() {
         val restClientBuilder = RestClient.builder()
         val client = PdfConversionClient(restClientBuilder)
 
@@ -82,7 +84,8 @@ internal class PdfConversionClientTest {
         client.convertDocument(
             mockPdfConversionApi.url("/").toUri(),
             "TEST_DOCUMENT".byteInputStream(),
-            "mock_document.txt")
+            "mock_document.txt"
+        )
 
         val recordedRequest = mockPdfConversionApi.takeRequest(5, TimeUnit.SECONDS)
         assertNotNull(recordedRequest)
@@ -92,8 +95,66 @@ internal class PdfConversionClientTest {
         assertTrue(recordedRequest.getHeader("Content-Type")?.startsWith("multipart/form-data") ?: false )
         assertEquals("TEST_DOCUMENT", formFields["files"])
         assertEquals("false",formFields["exportFormFields"])
-        assertEquals("PDF/A-1b", formFields["pdfa"])
+        assertNull(formFields["pdfa"])
+        assertEquals("false",formFields["pdfua"])
+    }
+
+    @Test
+    fun `should send request with PDF A-2b and PDF UA set to true`() {
+        val restClientBuilder = RestClient.builder()
+        val client = PdfConversionClient(restClientBuilder)
+
+        val responseBody = "TEST_PDF_CONTENT"
+
+        mockPdfConversionApi.enqueue(mockResponse(responseBody))
+
+        client.convertDocument(
+            mockPdfConversionApi.url("/").toUri(),
+            "TEST_DOCUMENT".byteInputStream(),
+            "mock_document.txt",
+            PdfArchiveMethod.PDFA2B,
+            true
+        )
+
+        val recordedRequest = mockPdfConversionApi.takeRequest(5, TimeUnit.SECONDS)
+        assertNotNull(recordedRequest)
+
+        val formFields = parseMultipartFormData(recordedRequest)
+
+        assertTrue(recordedRequest.getHeader("Content-Type")?.startsWith("multipart/form-data") ?: false )
+        assertEquals("TEST_DOCUMENT", formFields["files"])
+        assertEquals("false",formFields["exportFormFields"])
+        assertEquals("PDF/A-2b", formFields["pdfa"])
         assertEquals("true", formFields["pdfua"] )
+    }
+
+    @Test
+    fun `should send request with PDF A-3b and PDF UA set to false`() {
+        val restClientBuilder = RestClient.builder()
+        val client = PdfConversionClient(restClientBuilder)
+
+        val responseBody = "TEST_PDF_CONTENT"
+
+        mockPdfConversionApi.enqueue(mockResponse(responseBody))
+
+        client.convertDocument(
+            mockPdfConversionApi.url("/").toUri(),
+            "TEST_DOCUMENT".byteInputStream(),
+            "mock_document.txt",
+            PdfArchiveMethod.PDFA3B,
+            false
+        )
+
+        val recordedRequest = mockPdfConversionApi.takeRequest(5, TimeUnit.SECONDS)
+        assertNotNull(recordedRequest)
+
+        val formFields = parseMultipartFormData(recordedRequest)
+
+        assertTrue(recordedRequest.getHeader("Content-Type")?.startsWith("multipart/form-data") ?: false )
+        assertEquals("TEST_DOCUMENT", formFields["files"])
+        assertEquals("false",formFields["exportFormFields"])
+        assertEquals("PDF/A-3b", formFields["pdfa"])
+        assertEquals("false", formFields["pdfua"] )
     }
 
     private fun mockResponse(body: String): MockResponse {

--- a/documentation/features/plugins/configure-documenten-api-preview-plugin.md
+++ b/documentation/features/plugins/configure-documenten-api-preview-plugin.md
@@ -18,8 +18,7 @@ requires some configuration. A general description on how to configure plugins c
 
 > IMPORTANT:
 > 
-> The [Gotenberg][1] PDF conversion API is provided as a docker container and should be installed separately from the 
-> plugin (see [installation guide](https://gotenberg.dev/docs/getting-started/installation)).  
+> The [Gotenberg][1] PDF conversion API is available as a docker image and should be installed separately (see [installation guide](https://gotenberg.dev/docs/getting-started/installation)).  
 
 To configure this plugin the following properties have to be entered:
 

--- a/documentation/features/plugins/configure-documenten-api-preview-plugin.md
+++ b/documentation/features/plugins/configure-documenten-api-preview-plugin.md
@@ -16,6 +16,11 @@ the original documents to PDF format is done using the open-source project [Gote
 a Docker-based API specifically designed to convert documents to PDF. This means the "Documenten API Preview plugin" 
 requires some configuration. A general description on how to configure plugins can be found in the [plugin configuration guide](./configure-plugin.md).
 
+> IMPORTANT:
+> 
+> The [Gotenberg][1] PDF conversion API is provided as a docker container and should be installed separately from the 
+> plugin (see [installation guide](https://gotenberg.dev/docs/getting-started/installation)).  
+
 To configure this plugin the following properties have to be entered:
 
 * **Configuration ID (`configurationId`).** The plugin will be saved under this ID. The ID must be in the format of a UUID.

--- a/documentation/release-notes/13.x.x/13.26.0/README.md
+++ b/documentation/release-notes/13.x.x/13.26.0/README.md
@@ -6,15 +6,15 @@
 
 ## New Features
 
-* **New feature title**
+* **Support configuration of PDF archive methods**
 
-  New feature explanation.
+  The documenten-api-preview plugin now supports configuration of PDF archive methods. PDF archiving is turned off by default, but administrators can enable PDF archiving via the plugin configuration.
 
 ## Enhancements
 
-* **New enhancement title**
+* **Explanatory loading message**
 
-  New enhancement explanation.
+  The documenten-api-preview plugin will now show an explanatory loading message, above the loading spinner, when converting a document to a preview.
 
 ## Bugfixes
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.html
@@ -88,7 +88,7 @@
       [disabled]="obs.disabled"
       [onText]="'pdfUniversalAccessibility.toggleOn' | pluginTranslate: pluginId | async"
       [offText]="'pdfUniversalAccessibility.toggleOff' | pluginTranslate: pluginId | async"
-      (checkedChange)="onPdfArchiveUniversalAccessibilityChange($event)"
+      (checkedChange)="onPdfUniversalAccessibilityChange($event)"
     ></cds-toggle>
   </div>
 </v-form>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.html
@@ -20,6 +20,7 @@
     disabled: disabled$ | async,
     prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
     documentenApiPluginSelectItems: documentenApiPluginSelectItems$ | async,
+    pdfUniversalAccessibility: pdfUniversalAccessibility$ | async,
   } as obs"
 >
   <v-input
@@ -35,6 +36,7 @@
     placeholder="Documenten API Preview Plugin"
   >
   </v-input>
+
   <v-input
     name="pdfConversionUrl"
     data-test-id="pdfConversionUrl"
@@ -48,6 +50,7 @@
     placeholder="https://gotenberg:3000/"
   >
   </v-input>
+
   <v-select
     [loading]="!obs.documentenApiPluginSelectItems"
     [items]="obs.documentenApiPluginSelectItems"
@@ -60,6 +63,7 @@
     [required]="true"
     [tooltip]="'documentenApiPluginConfigurationTooltip' | pluginTranslate: pluginId | async"
   ></v-select>
+
   <v-select
     [loading]="!pdfArchiveMethods"
     [items]="pdfArchiveMethods"
@@ -71,4 +75,20 @@
     [disabled]="obs.disabled"
     [required]="true"
   ></v-select>
+
+  <div class="input-toggle--small-margin">
+    <v-input-label
+      [title]="'pdfUniversalAccessibility' | pluginTranslate: pluginId | async"
+      [tooltip]="'pdfUniversalAccessibilityTooltip' | pluginTranslate: pluginId | async"
+    >
+    </v-input-label>
+
+    <cds-toggle
+      [checked]="obs.pdfUniversalAccessibility"
+      [disabled]="obs.disabled"
+      [onText]="'pdfUniversalAccessibility.toggleOn' | pluginTranslate: pluginId | async"
+      [offText]="'pdfUniversalAccessibility.toggleOff' | pluginTranslate: pluginId | async"
+      (checkedChange)="onPdfArchiveUniversalAccessibilityChange($event)"
+    ></cds-toggle>
+  </div>
 </v-form>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.html
@@ -19,6 +19,7 @@
   *ngIf="{
     disabled: disabled$ | async,
     prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
+    documentenApiPluginSelectItems: documentenApiPluginSelectItems$ | async,
   } as obs"
 >
   <v-input
@@ -47,22 +48,27 @@
     placeholder="https://gotenberg:3000/"
   >
   </v-input>
-  <ng-container
-    *ngIf="{
-      documentenApiPluginSelectItems: documentenApiPluginSelectItems$ | async,
-    } as documentenApiObs"
-  >
-    <v-select
-      [loading]="!documentenApiObs.documentenApiPluginSelectItems"
-      [items]="documentenApiObs.documentenApiPluginSelectItems"
-      [margin]="true"
-      name="documentenApiConfigurationId"
-      data-test-id="documentenPreviewDocumentenApiPluginConfiguration"
-      [title]="'documentenApiPluginConfiguration' | pluginTranslate: pluginId | async"
-      [disabled]="obs.disabled"
-      [defaultSelectionId]="obs.prefill?.documentenApiConfigurationId"
-      [required]="true"
-      [tooltip]="'documentenApiPluginConfigurationTooltip' | pluginTranslate: pluginId | async"
-    ></v-select>
-  </ng-container>
+  <v-select
+    [loading]="!obs.documentenApiPluginSelectItems"
+    [items]="obs.documentenApiPluginSelectItems"
+    [margin]="true"
+    name="documentenApiConfigurationId"
+    data-test-id="documentenPreviewDocumentenApiPluginConfiguration"
+    [title]="'documentenApiPluginConfiguration' | pluginTranslate: pluginId | async"
+    [disabled]="obs.disabled"
+    [defaultSelectionId]="obs.prefill?.documentenApiConfigurationId"
+    [required]="true"
+    [tooltip]="'documentenApiPluginConfigurationTooltip' | pluginTranslate: pluginId | async"
+  ></v-select>
+  <v-select
+    [loading]="!pdfArchiveMethods"
+    [items]="pdfArchiveMethods"
+    name="pdfArchiveMethod"
+    [title]="'pdfArchiveMethod' | pluginTranslate: pluginId | async"
+    [tooltip]="'pdfArchiveMethodTooltip' | pluginTranslate: pluginId | async"
+    [margin]="true"
+    [defaultSelectionId]="obs.prefill?.pdfArchiveMethod || 'none'"
+    [disabled]="obs.disabled"
+    [required]="true"
+  ></v-select>
 </v-form>

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
@@ -86,8 +86,8 @@ export class DocumentenApiPreviewConfigurationComponent
     this.saveSubscription?.unsubscribe();
   }
 
-  public onPdfArchiveUniversalAccessibilityChange(event: any): void {
-    this.pdfUniversalAccessibility$.next(event);
+  public onPdfUniversalAccessibilityChange(checked: boolean): void {
+    this.pdfUniversalAccessibility$.next(checked);
   }
 
   formValueChange(formValue: DocumentenApiPreviewConfig): void {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
@@ -39,6 +39,7 @@ export class DocumentenApiPreviewConfigurationComponent
     new EventEmitter<DocumentenApiPreviewConfig>();
 
   private saveSubscription!: Subscription;
+  private _pdfUniversalAccessibilitySubscription!: Subscription;
 
   private readonly formValue$ = new BehaviorSubject<DocumentenApiPreviewConfig | null>(null);
   private readonly valid$ = new BehaviorSubject<boolean>(false);
@@ -49,6 +50,8 @@ export class DocumentenApiPreviewConfigurationComponent
     {id: 'PDF/A-2b', text: 'PDF/A-2b', translationKey: 'pdfArchiveMethodPDFA2b'},
     {id: 'PDF/A-3b', text: 'PDF/A-3b', translationKey: 'pdfArchiveMethodPDFA3b'},
   ];
+
+  public readonly pdfUniversalAccessibility$ = new BehaviorSubject<boolean>(false);
 
   public readonly documentenApiPluginSelectItems$: Observable<Array<{id: string; text: string}>> =
     combineLatest([
@@ -73,16 +76,39 @@ export class DocumentenApiPreviewConfigurationComponent
   ) {}
 
   ngOnInit(): void {
+    this.initPdfUniversalAccessibilityEnabled();
+    this.openPdfUniversalAccessibilitySubscription();
     this.openSaveSubscription();
   }
 
   ngOnDestroy() {
+    this._pdfUniversalAccessibilitySubscription.unsubscribe();
     this.saveSubscription?.unsubscribe();
   }
 
+  public onPdfArchiveUniversalAccessibilityChange(event: any): void {
+    this.pdfUniversalAccessibility$.next(event);
+  }
+
   formValueChange(formValue: DocumentenApiPreviewConfig): void {
-    this.formValue$.next(formValue);
-    this.handleValid(formValue);
+    const formValueIncludingToggle = {
+      ...formValue,
+      pdfUniversalAccessibility: this.pdfUniversalAccessibility$.getValue(),
+    };
+    this.formValue$.next(formValueIncludingToggle);
+    this.handleValid(formValueIncludingToggle);
+  }
+
+  private initPdfUniversalAccessibilityEnabled(): void {
+    this.prefillConfiguration$.pipe(take(1)).subscribe(configuration => {
+      this.pdfUniversalAccessibility$.next(configuration.pdfArchiveUniversalAccessibility);
+    });
+  }
+
+  private openPdfUniversalAccessibilitySubscription(): void {
+    this._pdfUniversalAccessibilitySubscription = this.pdfUniversalAccessibility$.subscribe(value => {
+      this.formValueChange(this.formValue$.getValue())
+    });
   }
 
   private handleValid(formValue: DocumentenApiPreviewConfig): void {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
@@ -20,6 +20,7 @@ import {BehaviorSubject, combineLatest, map, Observable, Subscription, take} fro
 import {DocumentenApiPreviewConfig} from '../../models';
 import {PluginManagementService, PluginTranslationService} from '../../../../services';
 import {TranslateService} from '@ngx-translate/core';
+import {SelectItem} from '@valtimo/components';
 
 @Component({
   selector: 'valtimo-documenten-api-preview-configuration',
@@ -42,7 +43,14 @@ export class DocumentenApiPreviewConfigurationComponent
   private readonly formValue$ = new BehaviorSubject<DocumentenApiPreviewConfig | null>(null);
   private readonly valid$ = new BehaviorSubject<boolean>(false);
 
-  readonly documentenApiPluginSelectItems$: Observable<Array<{id: string; text: string}>> =
+  public readonly pdfArchiveMethods: SelectItem[] = [
+    {id: 'none', text: 'None', translationKey: 'pdfArchiveMethodNone'},
+    {id: 'PDF/A-1b', text: 'PDF/A-1b', translationKey: 'pdfArchiveMethodPDFA1b'},
+    {id: 'PDF/A-2b', text: 'PDF/A-2b', translationKey: 'pdfArchiveMethodPDFA2b'},
+    {id: 'PDF/A-3b', text: 'PDF/A-3b', translationKey: 'pdfArchiveMethodPDFA3b'},
+  ];
+
+  public readonly documentenApiPluginSelectItems$: Observable<Array<{id: string; text: string}>> =
     combineLatest([
       this.pluginManagementService.getPluginConfigurationsByPluginDefinitionKey('documentenapi'),
       this.translateService.stream('key'),

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
@@ -16,7 +16,7 @@
 
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {PluginConfigurationComponent} from '../../../../models';
-import {BehaviorSubject, combineLatest, map, Observable, Subscription, take} from 'rxjs';
+import {BehaviorSubject, combineLatest, map, Observable, skip, Subscription, take} from 'rxjs';
 import {DocumentenApiPreviewConfig} from '../../models';
 import {PluginManagementService, PluginTranslationService} from '../../../../services';
 import {TranslateService} from '@ngx-translate/core';
@@ -46,9 +46,9 @@ export class DocumentenApiPreviewConfigurationComponent
 
   public readonly pdfArchiveMethods: SelectItem[] = [
     {id: 'none', text: 'None', translationKey: 'pdfArchiveMethodNone'},
-    {id: 'PDF/A-1b', text: 'PDF/A-1b', translationKey: 'pdfArchiveMethodPDFA1b'},
-    {id: 'PDF/A-2b', text: 'PDF/A-2b', translationKey: 'pdfArchiveMethodPDFA2b'},
-    {id: 'PDF/A-3b', text: 'PDF/A-3b', translationKey: 'pdfArchiveMethodPDFA3b'},
+    {id: 'PDF/A-1b', text: 'PDF/A-1b', translationKey: 'pdfArchiveMethodPdfA1b'},
+    {id: 'PDF/A-2b', text: 'PDF/A-2b', translationKey: 'pdfArchiveMethodPdfA2b'},
+    {id: 'PDF/A-3b', text: 'PDF/A-3b', translationKey: 'pdfArchiveMethodPdfA3b'},
   ];
 
   public readonly pdfUniversalAccessibility$ = new BehaviorSubject<boolean>(false);
@@ -100,15 +100,20 @@ export class DocumentenApiPreviewConfigurationComponent
   }
 
   private initPdfUniversalAccessibilityEnabled(): void {
-    this.prefillConfiguration$.pipe(take(1)).subscribe(configuration => {
-      this.pdfUniversalAccessibility$.next(configuration.pdfArchiveUniversalAccessibility);
+    this.prefillConfiguration$?.pipe(take(1)).subscribe(configuration => {
+      this.pdfUniversalAccessibility$.next(!!configuration?.pdfUniversalAccessibility);
     });
   }
 
   private openPdfUniversalAccessibilitySubscription(): void {
-    this._pdfUniversalAccessibilitySubscription = this.pdfUniversalAccessibility$.subscribe(value => {
-      this.formValueChange(this.formValue$.getValue())
-    });
+    this._pdfUniversalAccessibilitySubscription = this.pdfUniversalAccessibility$
+      .pipe(skip(1))
+      .subscribe(() => {
+        const currentFormValue = this.formValue$.getValue();
+        if (currentFormValue) {
+          this.formValueChange(currentFormValue);
+        }
+      });
   }
 
   private handleValid(formValue: DocumentenApiPreviewConfig): void {

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/components/documenten-api-preview-configuration/documenten-api-preview-configuration.component.ts
@@ -82,7 +82,7 @@ export class DocumentenApiPreviewConfigurationComponent
   }
 
   ngOnDestroy() {
-    this._pdfUniversalAccessibilitySubscription.unsubscribe();
+    this._pdfUniversalAccessibilitySubscription?.unsubscribe();
     this.saveSubscription?.unsubscribe();
   }
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.module.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.module.ts
@@ -18,7 +18,8 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {DocumentenApiPreviewConfigurationComponent} from './components/documenten-api-preview-configuration/documenten-api-preview-configuration.component';
 import {PluginTranslatePipeModule} from '../../pipes';
-import {FormModule, InputModule, ParagraphModule, SelectModule} from '@valtimo/components';
+import {FormModule, InputLabelModule, InputModule, ParagraphModule, SelectModule} from '@valtimo/components';
+import {ToggleModule} from 'carbon-components-angular';
 
 @NgModule({
   declarations: [DocumentenApiPreviewConfigurationComponent],
@@ -28,6 +29,8 @@ import {FormModule, InputModule, ParagraphModule, SelectModule} from '@valtimo/c
     FormModule,
     InputModule,
     SelectModule,
+    InputLabelModule,
+    ToggleModule,
   ],
   exports: [DocumentenApiPreviewConfigurationComponent],
 })

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.module.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.module.ts
@@ -28,7 +28,6 @@ import {FormModule, InputModule, ParagraphModule, SelectModule} from '@valtimo/c
     FormModule,
     InputModule,
     SelectModule,
-    ParagraphModule,
   ],
   exports: [DocumentenApiPreviewConfigurationComponent],
 })

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.specification.ts
@@ -29,12 +29,19 @@ const documentenApiPreviewPluginSpecification: PluginSpecification = {
       configurationTitle: 'Configuratienaam',
       configurationTitleTooltip:
         'Hier kun je een eigen naam verzinnen. Onder deze naam zal de plugin te herkennen zijn in de rest van de applicatie',
-      pdfConversionUrl: 'PDF Conversie URL',
+      pdfConversionUrl: 'PDF conversie URL',
       pdfConversionUrlTooltip:
         'In dit veld moet de verwijzing komen naar de locatie van de PDF conversie server (Project Gotenberg).',
+      pdfArchiveMethod: 'PDF archivering methode',
+      pdfArchiveMethodTooltip:
+        'Selecteer de methode die gebruikt wordt om PDF documenten te archiveren. Het archiveren van PDF documenten kan lang duren en extra resources vereisen, selecteer de optie "Geen" voor de meest optimale prestaties.',
       documentenApiPluginConfiguration: 'Documenten API configuratie',
       documentenApiPluginConfigurationTooltip:
         'Selecteer de plugin die gebruikt wordt voor het ontsluiten van documenten. Deze plugin zal worden gebruikt om de originele documenten te ontsluiten zodat deze geconverteerd kunnen worden naar PDF voor weergave in de browser.',
+      pdfArchiveMethodNone: 'Geen',
+      pdfArchiveMethodPdfA1b: 'PDF/A-1b',
+      pdfArchiveMethodPdfA2b: 'PDF/A-2b',
+      pdfArchiveMethodPdfA3b: 'PDF/A-3b',
     },
     en: {
       title: 'Documenten API Preview',
@@ -42,11 +49,18 @@ const documentenApiPreviewPluginSpecification: PluginSpecification = {
       configurationTitle: 'Configuration name',
       configurationTitleTooltip:
         'Here you can enter a name for the plugin. This name will be used to recognize the plugin throughout the rest of the application',
-      pdfConversionUrl: 'PDF Conversion URL',
+      pdfConversionUrl: 'PDF conversion URL',
       pdfConversionUrlTooltip: 'This field must contain the URL to the PDF conversion server.',
+      pdfArchiveMethod: 'PDF archive method',
+      pdfArchiveMethodTooltip:
+        'Select the method that should be used to archive PDF documents. Important: generating a PDF archive can take a long time and may require additional resources, select the option "None" for the optimal performance.',
       documentenApiPluginConfiguration: 'Document API configuration',
       documentenApiPluginConfigurationTooltip:
         'Select the plugin that can access the documents. This plugin will be used to access the original document so it can be converted to PDF and previewed in the browser.',
+      pdfArchiveMethodNone: 'None',
+      pdfArchiveMethodPdfA1b: 'PDF/A-1b',
+      pdfArchiveMethodPdfA2b: 'PDF/A-2b',
+      pdfArchiveMethodPdfA3b: 'PDF/A-3b',
     },
   },
 };

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/documenten-api-preview-plugin.specification.ts
@@ -42,6 +42,11 @@ const documentenApiPreviewPluginSpecification: PluginSpecification = {
       pdfArchiveMethodPdfA1b: 'PDF/A-1b',
       pdfArchiveMethodPdfA2b: 'PDF/A-2b',
       pdfArchiveMethodPdfA3b: 'PDF/A-3b',
+      pdfUniversalAccessibility: 'Universele toegankelijkheid',
+      pdfUniversalAccessibilityTooltip:
+        'Schakel deze optie aan om het PDF document geschikt te maken voor ondersteunende technologieën zoals screen readers.',
+      'pdfUniversalAccessibility.toggleOn': 'Geactiveerd',
+      'pdfUniversalAccessibility.toggleOff': 'Gedeactiveerd',
     },
     en: {
       title: 'Documenten API Preview',
@@ -61,6 +66,11 @@ const documentenApiPreviewPluginSpecification: PluginSpecification = {
       pdfArchiveMethodPdfA1b: 'PDF/A-1b',
       pdfArchiveMethodPdfA2b: 'PDF/A-2b',
       pdfArchiveMethodPdfA3b: 'PDF/A-3b',
+      pdfUniversalAccessibility: 'Universal accessibility',
+      pdfUniversalAccessibilityTooltip:
+        'Enable this option to make the PDF document suitable for assistive technologies such as screen readers.',
+      'pdfUniversalAccessibility.toggleOn': 'Enabled',
+      'pdfUniversalAccessibility.toggleOff': 'Disabled',
     },
   },
 };

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/models/config.ts
@@ -19,6 +19,8 @@ import {PluginConfigurationData} from '../../../models';
 interface DocumentenApiPreviewConfig extends PluginConfigurationData {
   pdfConversionUrl: string;
   documentenApiConfigurationId: string;
+  pdfArchiveMethod: string;
+  pdfArchiveUniversalAccessibility: boolean;
 }
 
 export {DocumentenApiPreviewConfig};

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/models/config.ts
@@ -16,10 +16,12 @@
 
 import {PluginConfigurationData} from '../../../models';
 
+type PdfArchiveMethod = 'none' | 'PDF/A-1b' | 'PDF/A-2b' | 'PDF/A-3b';
+
 interface DocumentenApiPreviewConfig extends PluginConfigurationData {
   pdfConversionUrl: string;
   documentenApiConfigurationId: string;
-  pdfArchiveMethod: string;
+  pdfArchiveMethod: PdfArchiveMethod;
   pdfUniversalAccessibility: boolean;
 }
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api-preview/models/config.ts
@@ -20,7 +20,7 @@ interface DocumentenApiPreviewConfig extends PluginConfigurationData {
   pdfConversionUrl: string;
   documentenApiConfigurationId: string;
   pdfArchiveMethod: string;
-  pdfArchiveUniversalAccessibility: boolean;
+  pdfUniversalAccessibility: boolean;
 }
 
 export {DocumentenApiPreviewConfig};

--- a/frontend/projects/valtimo/shared/assets/core/en.json
+++ b/frontend/projects/valtimo/shared/assets/core/en.json
@@ -1179,7 +1179,8 @@
         "modal": {
           "header": "Document preview"
         },
-        "pdfViewerNotSupported": "Your browser does not support PDF viewing."
+        "pdfViewerNotSupported": "Your browser does not support PDF viewing.",
+        "loading": "A preview version of the document is being generated. This may take a moment."
       }
     },
     "notifications": {

--- a/frontend/projects/valtimo/shared/assets/core/nl.json
+++ b/frontend/projects/valtimo/shared/assets/core/nl.json
@@ -1213,7 +1213,8 @@
         "modal": {
           "header": "Document weergave"
         },
-        "pdfViewerNotSupported": "Uw browser biedt geen ondersteuning voor het weergeven van PDF bestanden."
+        "pdfViewerNotSupported": "Uw browser biedt geen ondersteuning voor het weergeven van PDF bestanden.",
+        "loading": "Het document wordt geconverteerd voor weergave. Dit kan even duren."
       }
     },
     "notifications": {

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-preview-modal/documenten-api-preview-modal.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-preview-modal/documenten-api-preview-modal.component.html
@@ -43,7 +43,10 @@
 </cds-modal>
 
 <ng-template #loading>
-  <div class="loading-container pb-2">
+  <div class="loading-container">
+    <span class="cds--inline-notification__title">
+      {{ 'zgw.documents.preview.loading' | translate }}
+    </span>
     <cds-loading size="normal"></cds-loading>
   </div>
 </ng-template>

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-preview-modal/documenten-api-preview-modal.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-preview-modal/documenten-api-preview-modal.component.html
@@ -43,8 +43,8 @@
 </cds-modal>
 
 <ng-template #loading>
-  <div class="loading-container">
-    <span class="cds--inline-notification__title">
+  <div class="loading-container" role="status" aria-live="polite">
+    <span class="cds--type-heading-compact-01">
       {{ 'zgw.documents.preview.loading' | translate }}
     </span>
     <cds-loading size="normal"></cds-loading>

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-preview-modal/documenten-api-preview-modal.component.scss
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-preview-modal/documenten-api-preview-modal.component.scss
@@ -24,9 +24,10 @@
 }
 
 .loading-container {
-  display: flex;
   justify-content: center;
+  flex-direction: column;
   align-items: center;
   height: 88vh;
+  gap: 50px;
   width: 100%;
 }


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

This pull-request adds the following improvements to the documenten-api-preview plugin:

1. The current version of the plugin converts document using the `PDF/A-1b` archiving method. This method is specifically designed to generate PDF files for content that should be archived and can have a big performance impact. Since the preview version of a document is a futile, using the `PDF/A-1b` method is overkill. This PR contains an update that will disable archiving support by default, but allows administrators to enable it using the plugin configuration settings.
2. End-users provided some feedback to add a description to the loading screen while documents are converted to a PDF. The reasoning would be that users are more likely to wait for the process to finish when they are aware of what is happening instead of only seeing a spinner. This PR adds an explanatory message to the loading screen, asking users to wait for the document to be converted for preview.
3. This PR also adds additional documentation indicating that the documenten-api-preview plugin relies on the Gotenberg API and that companies / municipalities are responsible for adding the Gotenberg API to their infrastructure.

Specify the code branch location: https://github.com/baseflow/valtimo/tree/document_api_preview_frontend

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps

Configuring the additional options for the preview generation:
- [ ] Step 1 - Log into Valtimo as administrator and go to "Admin" -> "Plugins".
- [ ] Step 2 - Edit the configuration for the "Documenten API Preview" plugin.
- [ ] Step 3 - Notice the two additional fields "PDF Archive method" and "Universal accessibility".
- [ ] Step 3.1 - The field "PDF Archive method" should allow selecting on of the following options: "None" (default), "PDF/A-1b", "PDF/A-2b" and "PDF/A-3b".
- [ ] Step 3.2 - The field "Universal accessibility" is a boolean (default "false") and should be rendered as a switch.

Showing the additional explanation while loading:
- [ ] Step 1 - Create a new case (e.g. "Bezwaar")
- [ ] Step 2 - Open the case, goto "Documenten" and upload a Microsoft Office document (Word, Excel or PowerPoint).
- [ ] Step 3 - From the list of documents click on the Microsoft Office Document to create the preview. 
- [ ] Step 4 - While loading the following text should be displayed above the spinner:
  - English: A preview version of the document is being generated. This may take a moment. 
  - Dutch: Het document wordt geconverteerd voor weergave. Dit kan even duren.


### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
