### PR TITLE
docker: fix profile of iko-redis

### DIFF
--- a/backend/app/gzac/docker-compose.yaml
+++ b/backend/app/gzac/docker-compose.yaml
@@ -582,6 +582,8 @@ services:
         ports:
             - "6379:6379"
         container_name: iko-redis
+        profiles:
+            - iko
         healthcheck:
             test: [ "CMD", "redis-cli", "ping" ]
             interval: 10s


### PR DESCRIPTION
### Describe the changes

IKO was unable to connect to iko-redis due to missing profile in docker compose

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
