### PR TITLE
GH-429: Added tags as display type for task list columns (v12)

### DIFF
--- a/documentation/release-notes/12.x.x/12.34.0/README.md
+++ b/documentation/release-notes/12.x.x/12.34.0/README.md
@@ -8,9 +8,9 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Task list columns**
 
-  New enhancement explanation.
+  Task list columns can now also display the tags display type.
 
 ## Bugfixes
 

--- a/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.ts
+++ b/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.ts
@@ -134,6 +134,7 @@ export class TaskManagementColumnModalComponent {
     ViewType.BOOLEAN,
     ViewType.ENUM,
     ViewType.ARRAY_COUNT,
+    ViewType.TAGS,
     ViewType.UNDERSCORES_TO_SPACES,
   ];
 


### PR DESCRIPTION
Solves https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/429

Raised a new ticket to track the release milestone: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/431