### PR TITLE
GHi-436: Harden Liquibase migration runner against stale changelog locks (V12 backport)

### DIFF
--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
@@ -51,6 +51,7 @@ public class LiquibaseRunner {
     private final Contexts context;
     private final DataSource datasource;
     private final int staleLockThresholdMinutes;
+    private volatile boolean aborting = false;
 
     public LiquibaseRunner(
         final List<LiquibaseMasterChangeLogLocation> liquibaseMasterChangeLogLocations,
@@ -91,6 +92,11 @@ public class LiquibaseRunner {
     void executeMigrations(Database database, LockService lockService) throws LiquibaseException {
         try {
             for (LiquibaseMasterChangeLogLocation changeLogLocation : liquibaseMasterChangeLogLocations) {
+                if (aborting) {
+                    throw new LiquibaseException(
+                        "Liquibase migration aborted by JVM shutdown signal before: "
+                            + changeLogLocation.getFilePath());
+                }
                 disableFastCheckCaching();
                 runChangeLog(database, changeLogLocation.getFilePath());
             }
@@ -122,6 +128,9 @@ public class LiquibaseRunner {
      */
     Thread newShutdownHook(LockService originalLockService) {
         return new Thread(() -> {
+            // Set unconditionally so the iteration loop in executeMigrations() skips remaining
+            // master changelogs even if the lock has already been released between iterations.
+            aborting = true;
             if (!originalLockService.hasChangeLogLock()) {
                 return;
             }

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
@@ -175,6 +175,12 @@ public class LiquibaseRunner {
         liquibase.update(context);
     }
 
+    /**
+     * Liquibase's fast-check optimization caches "already executed" state on pipeline objects
+     * that live on the Liquibase Scope and are shared across {@link Liquibase#update} calls.
+     * We run multiple master changelogs in sequence, so the cache from one update leaks into the
+     * next and can incorrectly skip newly-added changesets. Disable it before every update.
+     */
     private void disableFastCheckCaching() {
         CommandFactory commandFactory = Scope.getCurrentScope().getSingleton(CommandFactory.class);
         Stream.of(UpdateSqlCommandStep.COMMAND_NAME, UpdateCommandStep.COMMAND_NAME)

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
@@ -125,7 +125,10 @@ public class LiquibaseRunner {
      * next startup.
      */
     Thread newShutdownHook() {
-        return new Thread(() -> aborting = true, "liquibase-shutdown-hook");
+        return new Thread(() -> {
+            logger.warn("JVM shutdown signal received; Liquibase migration will abort at the next changelog boundary");
+            aborting = true;
+        }, "liquibase-shutdown-hook");
     }
 
     private void deregisterShutdownHook(Thread hook) {

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
@@ -70,14 +70,25 @@ public class LiquibaseRunner {
         JdbcConnection jdbcConnection = new JdbcConnection(connection);
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcConnection);
         LockService lockService = LockServiceFactory.getInstance().getLockService(database);
-        Thread shutdownHook = newShutdownHook(lockService);
+        Thread shutdownHook = newShutdownHook();
         try {
             forceReleaseStaleLock(lockService);
             Runtime.getRuntime().addShutdownHook(shutdownHook);
-            executeMigrations(database, lockService);
+            for (LiquibaseMasterChangeLogLocation changeLogLocation : liquibaseMasterChangeLogLocations) {
+                if (aborting) {
+                    logger.warn("Liquibase migration aborted by JVM shutdown signal before: {}",
+                        changeLogLocation.getFilePath());
+                    break;
+                }
+                disableFastCheckCaching();
+                runChangeLog(database, changeLogLocation.getFilePath());
+            }
         } catch (LiquibaseException liquibaseException) {
             throw new DatabaseException(liquibaseException);
         } finally {
+            // liquibase.update() releases on its own happy path; this covers an iteration-time
+            // exception or a shutdown-triggered break before the next changelog runs.
+            releaseLockQuietly(lockService);
             deregisterShutdownHook(shutdownHook);
             try {
                 connection.rollback();
@@ -87,23 +98,6 @@ public class LiquibaseRunner {
             }
         }
         logger.info("Finished running liquibase");
-    }
-
-    void executeMigrations(Database database, LockService lockService) throws LiquibaseException {
-        try {
-            for (LiquibaseMasterChangeLogLocation changeLogLocation : liquibaseMasterChangeLogLocations) {
-                if (aborting) {
-                    throw new LiquibaseException(
-                        "Liquibase migration aborted by JVM shutdown signal before: "
-                            + changeLogLocation.getFilePath());
-                }
-                disableFastCheckCaching();
-                runChangeLog(database, changeLogLocation.getFilePath());
-            }
-        } finally {
-            // liquibase.update() releases on its own happy path; this catches an iteration-time exception.
-            releaseLockQuietly(lockService);
-        }
     }
 
     /** Recovers from a stale lock left by a previous JVM that died (SIGKILL/OOM) without releasing it. */
@@ -122,38 +116,25 @@ public class LiquibaseRunner {
     }
 
     /**
-     * Releases the lock on graceful SIGTERM if the migration is still in flight. Hard kills bypass
-     * shutdown hooks — {@link #forceReleaseStaleLock} covers those. Uses a fresh connection because
-     * the original is closed by the outer finally before this fires.
+     * Signals an in-flight migration to abort at the next iteration boundary. The hook intentionally
+     * does no DB I/O: releasing the lock here would let another pod acquire it and start its own DDL
+     * while this pod's in-flight {@link Liquibase#update} is still executing against the same
+     * database. Lock release is deferred to the main thread, which breaks out of the iteration loop
+     * once the current changeset finishes and releases the lock in {@link #run()}'s {@code finally}.
+     * Hard kills bypass shutdown hooks entirely — {@link #forceReleaseStaleLock} covers those on the
+     * next startup.
      */
-    Thread newShutdownHook(LockService originalLockService) {
-        return new Thread(() -> {
-            // Set unconditionally so the iteration loop in executeMigrations() skips remaining
-            // master changelogs even if the lock has already been released between iterations.
-            aborting = true;
-            if (!originalLockService.hasChangeLogLock()) {
-                return;
-            }
-            try (Connection conn = datasource.getConnection()) {
-                JdbcConnection jdbc = new JdbcConnection(conn);
-                Database db = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbc);
-                LockServiceFactory.getInstance().getLockService(db).forceReleaseLock();
-                conn.commit();
-                logger.warn("JVM shutdown: force-released Liquibase changelog lock");
-            } catch (Exception e) {
-                logger.warn("JVM shutdown: failed to release Liquibase changelog lock", e);
-            }
-        }, "liquibase-shutdown-hook");
+    Thread newShutdownHook() {
+        return new Thread(() -> aborting = true, "liquibase-shutdown-hook");
     }
 
     private void deregisterShutdownHook(Thread hook) {
         try {
             Runtime.getRuntime().removeShutdownHook(hook);
         } catch (IllegalStateException ignored) {
-            // JVM is already shutting down; the hook will fire (or has fired) and no-op via its hasChangeLogLock guard.
+            // JVM is already shutting down; the hook has fired (or is firing) and the abort flag is set.
         } catch (RuntimeException e) {
-            // Best-effort: must not abort the outer finally. Worst case the hook stays registered
-            // and no-ops on JVM exit via its hasChangeLogLock guard.
+            // Best-effort: must not abort the outer finally.
             logger.warn("Failed to deregister Liquibase shutdown hook", e);
         }
     }

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.ritense.valtimo.contract.config;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
@@ -33,6 +35,10 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
+import liquibase.exception.LockException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+import liquibase.lockservice.LockService;
+import liquibase.lockservice.LockServiceFactory;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,29 +50,34 @@ public class LiquibaseRunner {
     private final List<LiquibaseMasterChangeLogLocation> liquibaseMasterChangeLogLocations;
     private final Contexts context;
     private final DataSource datasource;
+    private final int staleLockThresholdMinutes;
 
     public LiquibaseRunner(
         final List<LiquibaseMasterChangeLogLocation> liquibaseMasterChangeLogLocations,
         final LiquibaseProperties liquibaseProperties,
-        final DataSource datasource
+        final DataSource datasource,
+        final int staleLockThresholdMinutes
     ) {
         this.liquibaseMasterChangeLogLocations = liquibaseMasterChangeLogLocations;
         this.datasource = datasource;
         this.context = new Contexts(liquibaseProperties.getContexts());
+        this.staleLockThresholdMinutes = staleLockThresholdMinutes;
     }
 
     public void run() throws SQLException, DatabaseException {
         Connection connection = datasource.getConnection();
         JdbcConnection jdbcConnection = new JdbcConnection(connection);
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcConnection);
+        LockService lockService = LockServiceFactory.getInstance().getLockService(database);
+        Thread shutdownHook = newShutdownHook(lockService);
         try {
-            for (LiquibaseMasterChangeLogLocation changeLogLocation : liquibaseMasterChangeLogLocations) {
-                disableFastCheckCaching();
-                runChangeLog(database, changeLogLocation.getFilePath());
-            }
+            forceReleaseStaleLock(lockService);
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+            executeMigrations(database, lockService);
         } catch (LiquibaseException liquibaseException) {
             throw new DatabaseException(liquibaseException);
         } finally {
+            deregisterShutdownHook(shutdownHook);
             try {
                 connection.rollback();
                 connection.close();
@@ -77,8 +88,79 @@ public class LiquibaseRunner {
         logger.info("Finished running liquibase");
     }
 
+    void executeMigrations(Database database, LockService lockService) throws LiquibaseException {
+        try {
+            for (LiquibaseMasterChangeLogLocation changeLogLocation : liquibaseMasterChangeLogLocations) {
+                disableFastCheckCaching();
+                runChangeLog(database, changeLogLocation.getFilePath());
+            }
+        } finally {
+            // liquibase.update() releases on its own happy path; this catches an iteration-time exception.
+            releaseLockQuietly(lockService);
+        }
+    }
+
+    /** Recovers from a stale lock left by a previous JVM that died (SIGKILL/OOM) without releasing it. */
+    void forceReleaseStaleLock(LockService lockService) throws LockException, DatabaseException {
+        DatabaseChangeLogLock[] locks = lockService.listLocks();
+        for (DatabaseChangeLogLock lock : locks) {
+            long heldForMinutes = Duration.between(lock.getLockGranted().toInstant(), Instant.now()).toMinutes();
+            if (heldForMinutes >= staleLockThresholdMinutes) {
+                logger.warn(
+                    "Force-releasing stale Liquibase changelog lock held by '{}' since {} ({} minutes ago, threshold {} min)",
+                    lock.getLockedBy(), lock.getLockGranted(), heldForMinutes, staleLockThresholdMinutes
+                );
+                lockService.forceReleaseLock();
+            }
+        }
+    }
+
+    /**
+     * Releases the lock on graceful SIGTERM if the migration is still in flight. Hard kills bypass
+     * shutdown hooks — {@link #forceReleaseStaleLock} covers those. Uses a fresh connection because
+     * the original is closed by the outer finally before this fires.
+     */
+    Thread newShutdownHook(LockService originalLockService) {
+        return new Thread(() -> {
+            if (!originalLockService.hasChangeLogLock()) {
+                return;
+            }
+            try (Connection conn = datasource.getConnection()) {
+                JdbcConnection jdbc = new JdbcConnection(conn);
+                Database db = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbc);
+                LockServiceFactory.getInstance().getLockService(db).forceReleaseLock();
+                conn.commit();
+                logger.warn("JVM shutdown: force-released Liquibase changelog lock");
+            } catch (Exception e) {
+                logger.warn("JVM shutdown: failed to release Liquibase changelog lock", e);
+            }
+        }, "liquibase-shutdown-hook");
+    }
+
+    private void deregisterShutdownHook(Thread hook) {
+        try {
+            Runtime.getRuntime().removeShutdownHook(hook);
+        } catch (IllegalStateException ignored) {
+            // JVM is already shutting down; the hook will fire (or has fired) and no-op via its hasChangeLogLock guard.
+        } catch (RuntimeException e) {
+            // Best-effort: must not abort the outer finally. Worst case the hook stays registered
+            // and no-ops on JVM exit via its hasChangeLogLock guard.
+            logger.warn("Failed to deregister Liquibase shutdown hook", e);
+        }
+    }
+
+    private void releaseLockQuietly(LockService lockService) {
+        try {
+            lockService.releaseLock();
+        } catch (LockException | RuntimeException e) {
+            // "Quietly": a throw here would mask the real migration exception. RuntimeException
+            // covers cases where Liquibase internals leak past the declared LockException.
+            logger.warn("Failed to release Liquibase changelog lock", e);
+        }
+    }
+
     @SuppressWarnings({"squid:S2095", "java:S2095"}) // Liquibase connection is closed elsewhere
-    private void runChangeLog(Database database, String filePath) throws LiquibaseException {
+    void runChangeLog(Database database, String filePath) throws LiquibaseException {
         Liquibase liquibase = new Liquibase(filePath, new ClassLoaderResourceAccessor(), database);
         logger.info("Running liquibase master changelog: {}", liquibase.getChangeLogFile());
         liquibase.update(context);

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfiguration.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfiguration.java
@@ -21,7 +21,6 @@ import javax.sql.DataSource;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
@@ -38,14 +37,8 @@ import org.springframework.context.annotation.Bean;
 @EnableConfigurationProperties({LiquibaseProperties.class, ValtimoProperties.class})
 public class LiquibaseRunnerAutoConfiguration {
 
-    /**
-     * Uses {@code valtimo.liquibase.enabled} (not {@code spring.liquibase.enabled}) — the latter
-     * is already used by consumers to disable Spring Boot's SpringLiquibase, which would otherwise
-     * race with this runner.
-     */
     @Bean
     @ConditionalOnMissingBean(LiquibaseRunner.class)
-    @ConditionalOnProperty(name = "valtimo.liquibase.enabled", havingValue = "true", matchIfMissing = true)
     public LiquibaseRunner liquibaseRunner(
         final List<LiquibaseMasterChangeLogLocation> liquibaseMasterChangeLogLocations,
         final LiquibaseProperties liquibaseProperties,

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfiguration.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import javax.sql.DataSource;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
@@ -34,16 +35,28 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration
 @AutoConfigureAfter({DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
-@EnableConfigurationProperties(LiquibaseProperties.class)
+@EnableConfigurationProperties({LiquibaseProperties.class, ValtimoProperties.class})
 public class LiquibaseRunnerAutoConfiguration {
 
+    /**
+     * Uses {@code valtimo.liquibase.enabled} (not {@code spring.liquibase.enabled}) — the latter
+     * is already used by consumers to disable Spring Boot's SpringLiquibase, which would otherwise
+     * race with this runner.
+     */
     @Bean
     @ConditionalOnMissingBean(LiquibaseRunner.class)
+    @ConditionalOnProperty(name = "valtimo.liquibase.enabled", havingValue = "true", matchIfMissing = true)
     public LiquibaseRunner liquibaseRunner(
         final List<LiquibaseMasterChangeLogLocation> liquibaseMasterChangeLogLocations,
         final LiquibaseProperties liquibaseProperties,
-        final DataSource datasource
+        final DataSource datasource,
+        final ValtimoProperties valtimoProperties
     ) {
-        return new LiquibaseRunner(liquibaseMasterChangeLogLocations, liquibaseProperties, datasource);
+        return new LiquibaseRunner(
+            liquibaseMasterChangeLogLocations,
+            liquibaseProperties,
+            datasource,
+            valtimoProperties.getLiquibase().getStaleLockThresholdMinutes()
+        );
     }
 }

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,19 +35,23 @@ public class ValtimoProperties {
 
     private final Process process;
 
+    private final Liquibase liquibase;
+
     @ConstructorBinding
     public ValtimoProperties(
         App app,
         Mandrill mandrill,
         Oauth oauth,
         Portal portal,
-        Process process
+        Process process,
+        Liquibase liquibase
     ) {
         this.app = app != null ? app : new App();
         this.mandrill = mandrill != null ? mandrill : new Mandrill();
         this.oauth = oauth != null ? oauth : new Oauth();
         this.portal = portal != null ? portal : new Portal();
         this.process = process != null ? process : new Process();
+        this.liquibase = liquibase != null ? liquibase : new Liquibase();
         new OauthConfigHolder(this.oauth);
     }
 
@@ -69,6 +73,10 @@ public class ValtimoProperties {
 
     public Process getProcess() {
         return process;
+    }
+
+    public Liquibase getLiquibase() {
+        return liquibase;
     }
 
     public static class App {
@@ -239,4 +247,24 @@ public class ValtimoProperties {
         }
     }
 
+    public static class Liquibase {
+        private boolean enabled = true;
+        private int staleLockThresholdMinutes = 30;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getStaleLockThresholdMinutes() {
+            return staleLockThresholdMinutes;
+        }
+
+        public void setStaleLockThresholdMinutes(int staleLockThresholdMinutes) {
+            this.staleLockThresholdMinutes = staleLockThresholdMinutes;
+        }
+    }
 }

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
@@ -255,6 +255,11 @@ public class ValtimoProperties {
         }
 
         public void setStaleLockThresholdMinutes(int staleLockThresholdMinutes) {
+            if (staleLockThresholdMinutes <= 0) {
+                throw new IllegalArgumentException(
+                    "valtimo.liquibase.stale-lock-threshold-minutes must be > 0, was: " + staleLockThresholdMinutes
+                );
+            }
             this.staleLockThresholdMinutes = staleLockThresholdMinutes;
         }
     }

--- a/backend/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
+++ b/backend/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
@@ -248,16 +248,7 @@ public class ValtimoProperties {
     }
 
     public static class Liquibase {
-        private boolean enabled = true;
         private int staleLockThresholdMinutes = 30;
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public void setEnabled(boolean enabled) {
-            this.enabled = enabled;
-        }
 
         public int getStaleLockThresholdMinutes() {
             return staleLockThresholdMinutes;

--- a/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfigurationTest.java
+++ b/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.contract.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class LiquibaseRunnerAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(LiquibaseRunnerAutoConfiguration.class))
+        .withBean(DataSource.class, () -> mock(DataSource.class));
+
+    @Test
+    void liquibaseRunnerIsCreatedByDefault() {
+        contextRunner.run(context -> assertThat(context).hasSingleBean(LiquibaseRunner.class));
+    }
+
+    @Test
+    void liquibaseRunnerIsCreatedWhenExplicitlyEnabled() {
+        contextRunner
+            .withPropertyValues("valtimo.liquibase.enabled=true")
+            .run(context -> assertThat(context).hasSingleBean(LiquibaseRunner.class));
+    }
+
+    @Test
+    void liquibaseRunnerIsNotCreatedWhenDisabled() {
+        contextRunner
+            .withPropertyValues("valtimo.liquibase.enabled=false")
+            .run(context -> assertThat(context).doesNotHaveBean(LiquibaseRunner.class));
+    }
+
+    @Test
+    void staleLockThresholdDefaultsToThirtyMinutes() {
+        contextRunner.run(context -> {
+            ValtimoProperties properties = context.getBean(ValtimoProperties.class);
+            assertThat(properties.getLiquibase().getStaleLockThresholdMinutes()).isEqualTo(30);
+            assertThat(properties.getLiquibase().isEnabled()).isTrue();
+        });
+    }
+
+    @Test
+    void staleLockThresholdIsConfigurable() {
+        contextRunner
+            .withPropertyValues("valtimo.liquibase.stale-lock-threshold-minutes=5")
+            .run(context -> {
+                ValtimoProperties properties = context.getBean(ValtimoProperties.class);
+                assertThat(properties.getLiquibase().getStaleLockThresholdMinutes()).isEqualTo(5);
+            });
+    }
+}

--- a/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfigurationTest.java
+++ b/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfigurationTest.java
@@ -36,25 +36,10 @@ class LiquibaseRunnerAutoConfigurationTest {
     }
 
     @Test
-    void liquibaseRunnerIsCreatedWhenExplicitlyEnabled() {
-        contextRunner
-            .withPropertyValues("valtimo.liquibase.enabled=true")
-            .run(context -> assertThat(context).hasSingleBean(LiquibaseRunner.class));
-    }
-
-    @Test
-    void liquibaseRunnerIsNotCreatedWhenDisabled() {
-        contextRunner
-            .withPropertyValues("valtimo.liquibase.enabled=false")
-            .run(context -> assertThat(context).doesNotHaveBean(LiquibaseRunner.class));
-    }
-
-    @Test
     void staleLockThresholdDefaultsToThirtyMinutes() {
         contextRunner.run(context -> {
             ValtimoProperties properties = context.getBean(ValtimoProperties.class);
             assertThat(properties.getLiquibase().getStaleLockThresholdMinutes()).isEqualTo(30);
-            assertThat(properties.getLiquibase().isEnabled()).isTrue();
         });
     }
 

--- a/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfigurationTest.java
+++ b/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerAutoConfigurationTest.java
@@ -52,4 +52,11 @@ class LiquibaseRunnerAutoConfigurationTest {
                 assertThat(properties.getLiquibase().getStaleLockThresholdMinutes()).isEqualTo(5);
             });
     }
+
+    @Test
+    void staleLockThresholdRejectsNonPositiveValues() {
+        contextRunner
+            .withPropertyValues("valtimo.liquibase.stale-lock-threshold-minutes=0")
+            .run(context -> assertThat(context).hasFailed());
+    }
 }

--- a/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerTest.java
+++ b/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerTest.java
@@ -16,7 +16,6 @@
 
 package com.ritense.valtimo.contract.config;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -26,10 +25,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import javax.sql.DataSource;
-import liquibase.database.Database;
-import liquibase.exception.LiquibaseException;
 import liquibase.lockservice.DatabaseChangeLogLock;
 import liquibase.lockservice.LockService;
 import org.junit.jupiter.api.Test;
@@ -87,36 +83,8 @@ class LiquibaseRunnerTest {
     }
 
     @Test
-    void releasesLockEvenWhenIterationThrows() throws Exception {
-        LockService lockService = mock(LockService.class);
-        Database database = mock(Database.class);
-        LiquibaseMasterChangeLogLocation location = mock(LiquibaseMasterChangeLogLocation.class);
-        when(location.getFilePath()).thenReturn("changelog.xml");
-
-        LiquibaseRunner failingRunner = new LiquibaseRunner(
-            List.of(location),
-            new LiquibaseProperties(),
-            mock(DataSource.class),
-            THRESHOLD_MINUTES
-        ) {
-            @Override
-            void runChangeLog(Database db, String filePath) throws LiquibaseException {
-                throw new LiquibaseException("boom");
-            }
-        };
-
-        assertThatThrownBy(() -> failingRunner.executeMigrations(database, lockService))
-            .isInstanceOf(LiquibaseException.class)
-            .hasMessage("boom");
-
-        verify(lockService).releaseLock();
-    }
-
-    @Test
-    void shutdownHookIsNoOpWhenLockNotHeld() throws Exception {
+    void shutdownHookSignalsAbortWithoutTouchingDatasource() throws Exception {
         DataSource datasource = mock(DataSource.class);
-        LockService lockService = mock(LockService.class);
-        when(lockService.hasChangeLogLock()).thenReturn(false);
 
         LiquibaseRunner hookRunner = new LiquibaseRunner(
             Collections.emptyList(),
@@ -125,45 +93,10 @@ class LiquibaseRunnerTest {
             THRESHOLD_MINUTES
         );
 
-        Thread hook = hookRunner.newShutdownHook(lockService);
+        Thread hook = hookRunner.newShutdownHook();
         hook.start();
         hook.join();
 
-        verify(lockService).hasChangeLogLock();
         verify(datasource, never()).getConnection();
-    }
-
-    @Test
-    void executeMigrationsBreaksWhenAbortFlagSet() throws Exception {
-        LockService hookLockService = mock(LockService.class);
-        when(hookLockService.hasChangeLogLock()).thenReturn(false);
-        LockService loopLockService = mock(LockService.class);
-        Database database = mock(Database.class);
-        LiquibaseMasterChangeLogLocation first = mock(LiquibaseMasterChangeLogLocation.class);
-        when(first.getFilePath()).thenReturn("first-master.xml");
-        LiquibaseMasterChangeLogLocation second = mock(LiquibaseMasterChangeLogLocation.class);
-
-        LiquibaseRunner abortingRunner = new LiquibaseRunner(
-            List.of(first, second),
-            new LiquibaseProperties(),
-            mock(DataSource.class),
-            THRESHOLD_MINUTES
-        ) {
-            @Override
-            void runChangeLog(Database db, String filePath) {
-                throw new AssertionError("runChangeLog must not be called once aborting=true");
-            }
-        };
-
-        Thread hook = abortingRunner.newShutdownHook(hookLockService);
-        hook.start();
-        hook.join();
-
-        assertThatThrownBy(() -> abortingRunner.executeMigrations(database, loopLockService))
-            .isInstanceOf(LiquibaseException.class)
-            .hasMessageContaining("aborted by JVM shutdown signal")
-            .hasMessageContaining("first-master.xml");
-
-        verify(loopLockService).releaseLock();
     }
 }

--- a/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerTest.java
+++ b/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.contract.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import javax.sql.DataSource;
+import liquibase.database.Database;
+import liquibase.exception.LiquibaseException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+import liquibase.lockservice.LockService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;
+
+class LiquibaseRunnerTest {
+
+    private static final int THRESHOLD_MINUTES = 30;
+
+    private final LiquibaseRunner runner = new LiquibaseRunner(
+        Collections.emptyList(),
+        new LiquibaseProperties(),
+        mock(DataSource.class),
+        THRESHOLD_MINUTES
+    );
+
+    @Test
+    void forceReleasesStaleLock() throws Exception {
+        LockService lockService = mock(LockService.class);
+        DatabaseChangeLogLock staleLock = new DatabaseChangeLogLock(
+            1,
+            Date.from(Instant.now().minusSeconds((THRESHOLD_MINUTES + 5) * 60L)),
+            "previous-pod (10.0.0.1)"
+        );
+        when(lockService.listLocks()).thenReturn(new DatabaseChangeLogLock[]{staleLock});
+
+        runner.forceReleaseStaleLock(lockService);
+
+        verify(lockService, times(1)).forceReleaseLock();
+    }
+
+    @Test
+    void leavesFreshLockAlone() throws Exception {
+        LockService lockService = mock(LockService.class);
+        DatabaseChangeLogLock freshLock = new DatabaseChangeLogLock(
+            1,
+            Date.from(Instant.now().minusSeconds(60L)),
+            "current-pod (10.0.0.2)"
+        );
+        when(lockService.listLocks()).thenReturn(new DatabaseChangeLogLock[]{freshLock});
+
+        runner.forceReleaseStaleLock(lockService);
+
+        verify(lockService, never()).forceReleaseLock();
+    }
+
+    @Test
+    void noOpWhenNoLockHeld() throws Exception {
+        LockService lockService = mock(LockService.class);
+        when(lockService.listLocks()).thenReturn(new DatabaseChangeLogLock[]{});
+
+        runner.forceReleaseStaleLock(lockService);
+
+        verify(lockService, never()).forceReleaseLock();
+    }
+
+    @Test
+    void releasesLockEvenWhenIterationThrows() throws Exception {
+        LockService lockService = mock(LockService.class);
+        Database database = mock(Database.class);
+        LiquibaseMasterChangeLogLocation location = mock(LiquibaseMasterChangeLogLocation.class);
+        when(location.getFilePath()).thenReturn("changelog.xml");
+
+        LiquibaseRunner failingRunner = new LiquibaseRunner(
+            List.of(location),
+            new LiquibaseProperties(),
+            mock(DataSource.class),
+            THRESHOLD_MINUTES
+        ) {
+            @Override
+            void runChangeLog(Database db, String filePath) throws LiquibaseException {
+                throw new LiquibaseException("boom");
+            }
+        };
+
+        assertThatThrownBy(() -> failingRunner.executeMigrations(database, lockService))
+            .isInstanceOf(LiquibaseException.class)
+            .hasMessage("boom");
+
+        verify(lockService).releaseLock();
+    }
+
+    @Test
+    void shutdownHookIsNoOpWhenLockNotHeld() throws Exception {
+        DataSource datasource = mock(DataSource.class);
+        LockService lockService = mock(LockService.class);
+        when(lockService.hasChangeLogLock()).thenReturn(false);
+
+        LiquibaseRunner hookRunner = new LiquibaseRunner(
+            Collections.emptyList(),
+            new LiquibaseProperties(),
+            datasource,
+            THRESHOLD_MINUTES
+        );
+
+        Thread hook = hookRunner.newShutdownHook(lockService);
+        hook.start();
+        hook.join();
+
+        verify(lockService).hasChangeLogLock();
+        verify(datasource, never()).getConnection();
+    }
+}

--- a/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerTest.java
+++ b/backend/contract/src/test/java/com/ritense/valtimo/contract/config/LiquibaseRunnerTest.java
@@ -132,4 +132,38 @@ class LiquibaseRunnerTest {
         verify(lockService).hasChangeLogLock();
         verify(datasource, never()).getConnection();
     }
+
+    @Test
+    void executeMigrationsBreaksWhenAbortFlagSet() throws Exception {
+        LockService hookLockService = mock(LockService.class);
+        when(hookLockService.hasChangeLogLock()).thenReturn(false);
+        LockService loopLockService = mock(LockService.class);
+        Database database = mock(Database.class);
+        LiquibaseMasterChangeLogLocation first = mock(LiquibaseMasterChangeLogLocation.class);
+        when(first.getFilePath()).thenReturn("first-master.xml");
+        LiquibaseMasterChangeLogLocation second = mock(LiquibaseMasterChangeLogLocation.class);
+
+        LiquibaseRunner abortingRunner = new LiquibaseRunner(
+            List.of(first, second),
+            new LiquibaseProperties(),
+            mock(DataSource.class),
+            THRESHOLD_MINUTES
+        ) {
+            @Override
+            void runChangeLog(Database db, String filePath) {
+                throw new AssertionError("runChangeLog must not be called once aborting=true");
+            }
+        };
+
+        Thread hook = abortingRunner.newShutdownHook(hookLockService);
+        hook.start();
+        hook.join();
+
+        assertThatThrownBy(() -> abortingRunner.executeMigrations(database, loopLockService))
+            .isInstanceOf(LiquibaseException.class)
+            .hasMessageContaining("aborted by JVM shutdown signal")
+            .hasMessageContaining("first-master.xml");
+
+        verify(loopLockService).releaseLock();
+    }
 }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,27 @@ package com.ritense.outbox
 
 import liquibase.Contexts
 import liquibase.Liquibase
+import liquibase.database.Database
 import liquibase.database.DatabaseFactory
 import liquibase.database.jvm.JdbcConnection
 import liquibase.exception.DatabaseException
 import liquibase.exception.LiquibaseException
+import liquibase.exception.LockException
+import liquibase.lockservice.LockService
+import liquibase.lockservice.LockServiceFactory
 import liquibase.resource.ClassLoaderResourceAccessor
 import mu.KotlinLogging
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties
 import java.sql.SQLException
+import java.time.Duration
+import java.time.Instant
 import javax.sql.DataSource
 
-class OutboxLiquibaseRunner(
+open class OutboxLiquibaseRunner(
     liquibaseProperties: LiquibaseProperties,
     private val datasource: DataSource,
+    private val staleLockThresholdMinutes: Int,
 ) : InitializingBean {
     private val context: Contexts = Contexts(liquibaseProperties.contexts)
 
@@ -40,19 +47,99 @@ class OutboxLiquibaseRunner(
         val connection = datasource.connection
         val jdbcConnection = JdbcConnection(connection)
         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcConnection)
+        val lockService = LockServiceFactory.getInstance().getLockService(database)
+        val shutdownHook = newShutdownHook(lockService)
         try {
-            val liquibase = Liquibase(LIQUIBASE_CHANGE_LOG_LOCATION, ClassLoaderResourceAccessor(), database)
-            logger.info { "Running liquibase master changelog: ${liquibase.changeLogFile}" }
-            liquibase.update(context)
+            forceReleaseStaleLock(lockService)
+            Runtime.getRuntime().addShutdownHook(shutdownHook)
+            executeMigration(database, lockService)
         } catch (liquibaseException: LiquibaseException) {
             throw DatabaseException(liquibaseException)
         } finally {
+            deregisterShutdownHook(shutdownHook)
             try {
                 connection.rollback()
                 connection.close()
             } catch (sqlException: SQLException) {
                 logger.error(sqlException) { "Error closing connection" }
             }
+        }
+    }
+
+    internal open fun executeMigration(database: Database, lockService: LockService) {
+        try {
+            applyChangeLog(database)
+        } finally {
+            // liquibase.update() releases on its own happy path; this catches an exception escaping the call.
+            releaseLockQuietly(lockService)
+        }
+    }
+
+    internal open fun applyChangeLog(database: Database) {
+        val liquibase = Liquibase(LIQUIBASE_CHANGE_LOG_LOCATION, ClassLoaderResourceAccessor(), database)
+        logger.info { "Running liquibase master changelog: ${liquibase.changeLogFile}" }
+        liquibase.update(context)
+    }
+
+    /** Recovers from a stale lock left by a previous JVM that died (SIGKILL/OOM) without releasing it. */
+    internal fun forceReleaseStaleLock(lockService: LockService) {
+        lockService.listLocks().forEach { lock ->
+            val heldForMinutes = Duration.between(lock.lockGranted.toInstant(), Instant.now()).toMinutes()
+            if (heldForMinutes >= staleLockThresholdMinutes) {
+                logger.warn {
+                    "Force-releasing stale Outbox Liquibase changelog lock held by '${lock.lockedBy}' " +
+                        "since ${lock.lockGranted} ($heldForMinutes minutes ago, threshold $staleLockThresholdMinutes min)"
+                }
+                lockService.forceReleaseLock()
+            }
+        }
+    }
+
+    /**
+     * Releases the lock on graceful SIGTERM if the migration is still in flight. Hard kills bypass
+     * shutdown hooks — [forceReleaseStaleLock] covers those. Uses a fresh connection because the
+     * original is closed by the outer finally before this fires.
+     */
+    internal fun newShutdownHook(originalLockService: LockService): Thread {
+        return Thread({
+            if (!originalLockService.hasChangeLogLock()) {
+                return@Thread
+            }
+            try {
+                datasource.connection.use { conn ->
+                    val jdbc = JdbcConnection(conn)
+                    val db = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbc)
+                    LockServiceFactory.getInstance().getLockService(db).forceReleaseLock()
+                    conn.commit()
+                    logger.warn { "JVM shutdown: force-released Outbox Liquibase changelog lock" }
+                }
+            } catch (e: Exception) {
+                logger.warn(e) { "JVM shutdown: failed to release Outbox Liquibase changelog lock" }
+            }
+        }, "outbox-liquibase-shutdown-hook")
+    }
+
+    private fun deregisterShutdownHook(hook: Thread) {
+        try {
+            Runtime.getRuntime().removeShutdownHook(hook)
+        } catch (ignored: IllegalStateException) {
+            // JVM is already shutting down; the hook will fire (or has fired) and no-op via its hasChangeLogLock guard.
+        } catch (e: RuntimeException) {
+            // Best-effort: must not abort the outer finally. Worst case the hook stays registered
+            // and no-ops on JVM exit via its hasChangeLogLock guard.
+            logger.warn(e) { "Failed to deregister Outbox Liquibase shutdown hook" }
+        }
+    }
+
+    private fun releaseLockQuietly(lockService: LockService) {
+        try {
+            lockService.releaseLock()
+        } catch (e: LockException) {
+            logger.warn(e) { "Failed to release Outbox Liquibase changelog lock" }
+        } catch (e: RuntimeException) {
+            // "Quietly": a throw here would mask the real migration exception. RuntimeException
+            // covers cases where Liquibase internals leak past the declared LockException.
+            logger.warn(e) { "Failed to release Outbox Liquibase changelog lock" }
         }
     }
 

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
@@ -51,14 +51,23 @@ open class OutboxLiquibaseRunner(
         val jdbcConnection = JdbcConnection(connection)
         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcConnection)
         val lockService = LockServiceFactory.getInstance().getLockService(database)
-        val shutdownHook = newShutdownHook(lockService)
+        val shutdownHook = newShutdownHook()
         try {
             forceReleaseStaleLock(lockService)
             Runtime.getRuntime().addShutdownHook(shutdownHook)
-            executeMigration(database, lockService)
+            if (aborting) {
+                logger.warn {
+                    "Outbox Liquibase migration aborted by JVM shutdown signal before: $LIQUIBASE_CHANGE_LOG_LOCATION"
+                }
+            } else {
+                applyChangeLog(database)
+            }
         } catch (liquibaseException: LiquibaseException) {
             throw DatabaseException(liquibaseException)
         } finally {
+            // liquibase.update() releases on its own happy path; this covers an exception escaping
+            // the call or a shutdown-triggered skip.
+            releaseLockQuietly(lockService)
             deregisterShutdownHook(shutdownHook)
             try {
                 connection.rollback()
@@ -66,20 +75,6 @@ open class OutboxLiquibaseRunner(
             } catch (sqlException: SQLException) {
                 logger.error(sqlException) { "Error closing connection" }
             }
-        }
-    }
-
-    internal open fun executeMigration(database: Database, lockService: LockService) {
-        try {
-            if (aborting) {
-                throw LiquibaseException(
-                    "Outbox Liquibase migration aborted by JVM shutdown signal before: $LIQUIBASE_CHANGE_LOG_LOCATION",
-                )
-            }
-            applyChangeLog(database)
-        } finally {
-            // liquibase.update() releases on its own happy path; this catches an exception escaping the call.
-            releaseLockQuietly(lockService)
         }
     }
 
@@ -104,40 +99,25 @@ open class OutboxLiquibaseRunner(
     }
 
     /**
-     * Releases the lock on graceful SIGTERM if the migration is still in flight. Hard kills bypass
-     * shutdown hooks — [forceReleaseStaleLock] covers those. Uses a fresh connection because the
-     * original is closed by the outer finally before this fires.
+     * Signals an in-flight migration to abort at the next phase boundary. The hook intentionally
+     * does no DB I/O: releasing the lock here would let another pod acquire it and start its own
+     * DDL while this pod's in-flight [Liquibase.update] is still executing against the same
+     * database. Lock release is deferred to the main thread, which skips [applyChangeLog] once
+     * the current changeset finishes and releases the lock in [afterPropertiesSet]'s `finally`.
+     * Hard kills bypass shutdown hooks entirely — [forceReleaseStaleLock] covers those on the
+     * next startup.
      */
-    internal fun newShutdownHook(originalLockService: LockService): Thread {
-        return Thread({
-            // Set unconditionally so executeMigration() skips applyChangeLog if invoked after this point,
-            // even if the lock has already been released between phases.
-            aborting = true
-            if (!originalLockService.hasChangeLogLock()) {
-                return@Thread
-            }
-            try {
-                datasource.connection.use { conn ->
-                    val jdbc = JdbcConnection(conn)
-                    val db = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbc)
-                    LockServiceFactory.getInstance().getLockService(db).forceReleaseLock()
-                    conn.commit()
-                    logger.warn { "JVM shutdown: force-released Outbox Liquibase changelog lock" }
-                }
-            } catch (e: Exception) {
-                logger.warn(e) { "JVM shutdown: failed to release Outbox Liquibase changelog lock" }
-            }
-        }, "outbox-liquibase-shutdown-hook")
+    internal fun newShutdownHook(): Thread {
+        return Thread({ aborting = true }, "outbox-liquibase-shutdown-hook")
     }
 
     private fun deregisterShutdownHook(hook: Thread) {
         try {
             Runtime.getRuntime().removeShutdownHook(hook)
         } catch (ignored: IllegalStateException) {
-            // JVM is already shutting down; the hook will fire (or has fired) and no-op via its hasChangeLogLock guard.
+            // JVM is already shutting down; the hook has fired (or is firing) and the abort flag is set.
         } catch (e: RuntimeException) {
-            // Best-effort: must not abort the outer finally. Worst case the hook stays registered
-            // and no-ops on JVM exit via its hasChangeLogLock guard.
+            // Best-effort: must not abort the outer finally.
             logger.warn(e) { "Failed to deregister Outbox Liquibase shutdown hook" }
         }
     }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
@@ -42,6 +42,9 @@ open class OutboxLiquibaseRunner(
 ) : InitializingBean {
     private val context: Contexts = Contexts(liquibaseProperties.contexts)
 
+    @Volatile
+    private var aborting = false
+
     @Throws(SQLException::class, DatabaseException::class)
     override fun afterPropertiesSet() {
         val connection = datasource.connection
@@ -68,6 +71,11 @@ open class OutboxLiquibaseRunner(
 
     internal open fun executeMigration(database: Database, lockService: LockService) {
         try {
+            if (aborting) {
+                throw LiquibaseException(
+                    "Outbox Liquibase migration aborted by JVM shutdown signal before: $LIQUIBASE_CHANGE_LOG_LOCATION",
+                )
+            }
             applyChangeLog(database)
         } finally {
             // liquibase.update() releases on its own happy path; this catches an exception escaping the call.
@@ -102,6 +110,9 @@ open class OutboxLiquibaseRunner(
      */
     internal fun newShutdownHook(originalLockService: LockService): Thread {
         return Thread({
+            // Set unconditionally so executeMigration() skips applyChangeLog if invoked after this point,
+            // even if the lock has already been released between phases.
+            aborting = true
             if (!originalLockService.hasChangeLogLock()) {
                 return@Thread
             }

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/OutboxLiquibaseRunner.kt
@@ -108,7 +108,10 @@ open class OutboxLiquibaseRunner(
      * next startup.
      */
     internal fun newShutdownHook(): Thread {
-        return Thread({ aborting = true }, "outbox-liquibase-shutdown-hook")
+        return Thread({
+            logger.warn { "JVM shutdown signal received; Outbox Liquibase migration will abort before the changelog runs" }
+            aborting = true
+        }, "outbox-liquibase-shutdown-hook")
     }
 
     private fun deregisterShutdownHook(hook: Thread) {

--- a/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
+++ b/backend/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
@@ -63,9 +63,12 @@ class OutboxAutoConfiguration {
     @ConditionalOnMissingBean(OutboxLiquibaseRunner::class)
     fun outboxLiquibaseRunner(
         liquibaseProperties: LiquibaseProperties,
-        datasource: DataSource
+        datasource: DataSource,
+        // @Value, not ValtimoProperties: outbox is forbidden from depending on other Valtimo modules.
+        // Property is shared with the contract runner so operators have one knob.
+        @Value("\${valtimo.liquibase.stale-lock-threshold-minutes:30}") staleLockThresholdMinutes: Int,
     ): OutboxLiquibaseRunner {
-        return OutboxLiquibaseRunner(liquibaseProperties, datasource)
+        return OutboxLiquibaseRunner(liquibaseProperties, datasource, staleLockThresholdMinutes)
     }
 
     @Bean

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxLiquibaseRunnerTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxLiquibaseRunnerTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox
+
+import liquibase.database.Database
+import liquibase.exception.LiquibaseException
+import liquibase.lockservice.DatabaseChangeLogLock
+import liquibase.lockservice.LockService
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties
+import java.time.Instant
+import java.util.Date
+import javax.sql.DataSource
+
+class OutboxLiquibaseRunnerTest {
+
+    private val thresholdMinutes = 30
+    private val runner = OutboxLiquibaseRunner(
+        LiquibaseProperties(),
+        mock<DataSource>(),
+        thresholdMinutes,
+    )
+
+    @Test
+    fun `force-releases stale outbox lock`() {
+        val lockService = mock<LockService>()
+        val staleLock = DatabaseChangeLogLock(
+            1,
+            Date.from(Instant.now().minusSeconds((thresholdMinutes + 5) * 60L)),
+            "previous-pod (10.0.0.1)",
+        )
+        whenever(lockService.listLocks()).thenReturn(arrayOf(staleLock))
+
+        runner.forceReleaseStaleLock(lockService)
+
+        verify(lockService, times(1)).forceReleaseLock()
+    }
+
+    @Test
+    fun `leaves fresh outbox lock alone`() {
+        val lockService = mock<LockService>()
+        val freshLock = DatabaseChangeLogLock(
+            1,
+            Date.from(Instant.now().minusSeconds(60L)),
+            "current-pod (10.0.0.2)",
+        )
+        whenever(lockService.listLocks()).thenReturn(arrayOf(freshLock))
+
+        runner.forceReleaseStaleLock(lockService)
+
+        verify(lockService, never()).forceReleaseLock()
+    }
+
+    @Test
+    fun `no-op when no outbox lock held`() {
+        val lockService = mock<LockService>()
+        whenever(lockService.listLocks()).thenReturn(emptyArray())
+
+        runner.forceReleaseStaleLock(lockService)
+
+        verify(lockService, never()).forceReleaseLock()
+    }
+
+    @Test
+    fun `releases lock even when migration throws`() {
+        val lockService = mock<LockService>()
+        val database = mock<Database>()
+        val failingRunner = object : OutboxLiquibaseRunner(LiquibaseProperties(), mock<DataSource>(), thresholdMinutes) {
+            override fun applyChangeLog(database: Database) {
+                throw LiquibaseException("boom")
+            }
+        }
+
+        assertThatThrownBy { failingRunner.executeMigration(database, lockService) }
+            .isInstanceOf(LiquibaseException::class.java)
+            .hasMessage("boom")
+
+        verify(lockService).releaseLock()
+    }
+
+    @Test
+    fun `shutdown hook is no-op when lock not held`() {
+        val datasource = mock<DataSource>()
+        val lockService = mock<LockService>()
+        whenever(lockService.hasChangeLogLock()).thenReturn(false)
+
+        val hookRunner = OutboxLiquibaseRunner(LiquibaseProperties(), datasource, thresholdMinutes)
+
+        val hook = hookRunner.newShutdownHook(lockService)
+        hook.start()
+        hook.join()
+
+        verify(lockService).hasChangeLogLock()
+        verify(datasource, never()).connection
+    }
+}

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxLiquibaseRunnerTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxLiquibaseRunnerTest.kt
@@ -113,4 +113,29 @@ class OutboxLiquibaseRunnerTest {
         verify(lockService).hasChangeLogLock()
         verify(datasource, never()).connection
     }
+
+    @Test
+    fun `executeMigration throws and skips applyChangeLog when abort flag set`() {
+        val hookLockService = mock<LockService>()
+        whenever(hookLockService.hasChangeLogLock()).thenReturn(false)
+        val loopLockService = mock<LockService>()
+        val database = mock<Database>()
+
+        val abortingRunner = object : OutboxLiquibaseRunner(LiquibaseProperties(), mock<DataSource>(), thresholdMinutes) {
+            override fun applyChangeLog(database: Database) {
+                throw AssertionError("applyChangeLog must not be called once aborting=true")
+            }
+        }
+
+        val hook = abortingRunner.newShutdownHook(hookLockService)
+        hook.start()
+        hook.join()
+
+        assertThatThrownBy { abortingRunner.executeMigration(database, loopLockService) }
+            .isInstanceOf(LiquibaseException::class.java)
+            .hasMessageContaining("aborted by JVM shutdown signal")
+            .hasMessageContaining("outbox-master.xml")
+
+        verify(loopLockService).releaseLock()
+    }
 }

--- a/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxLiquibaseRunnerTest.kt
+++ b/backend/outbox/src/test/kotlin/com/ritense/outbox/OutboxLiquibaseRunnerTest.kt
@@ -16,11 +16,8 @@
 
 package com.ritense.outbox
 
-import liquibase.database.Database
-import liquibase.exception.LiquibaseException
 import liquibase.lockservice.DatabaseChangeLogLock
 import liquibase.lockservice.LockService
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -82,60 +79,15 @@ class OutboxLiquibaseRunnerTest {
     }
 
     @Test
-    fun `releases lock even when migration throws`() {
-        val lockService = mock<LockService>()
-        val database = mock<Database>()
-        val failingRunner = object : OutboxLiquibaseRunner(LiquibaseProperties(), mock<DataSource>(), thresholdMinutes) {
-            override fun applyChangeLog(database: Database) {
-                throw LiquibaseException("boom")
-            }
-        }
-
-        assertThatThrownBy { failingRunner.executeMigration(database, lockService) }
-            .isInstanceOf(LiquibaseException::class.java)
-            .hasMessage("boom")
-
-        verify(lockService).releaseLock()
-    }
-
-    @Test
-    fun `shutdown hook is no-op when lock not held`() {
+    fun `shutdown hook signals abort without touching datasource`() {
         val datasource = mock<DataSource>()
-        val lockService = mock<LockService>()
-        whenever(lockService.hasChangeLogLock()).thenReturn(false)
 
         val hookRunner = OutboxLiquibaseRunner(LiquibaseProperties(), datasource, thresholdMinutes)
 
-        val hook = hookRunner.newShutdownHook(lockService)
+        val hook = hookRunner.newShutdownHook()
         hook.start()
         hook.join()
 
-        verify(lockService).hasChangeLogLock()
         verify(datasource, never()).connection
-    }
-
-    @Test
-    fun `executeMigration throws and skips applyChangeLog when abort flag set`() {
-        val hookLockService = mock<LockService>()
-        whenever(hookLockService.hasChangeLogLock()).thenReturn(false)
-        val loopLockService = mock<LockService>()
-        val database = mock<Database>()
-
-        val abortingRunner = object : OutboxLiquibaseRunner(LiquibaseProperties(), mock<DataSource>(), thresholdMinutes) {
-            override fun applyChangeLog(database: Database) {
-                throw AssertionError("applyChangeLog must not be called once aborting=true")
-            }
-        }
-
-        val hook = abortingRunner.newShutdownHook(hookLockService)
-        hook.start()
-        hook.join()
-
-        assertThatThrownBy { abortingRunner.executeMigration(database, loopLockService) }
-            .isInstanceOf(LiquibaseException::class.java)
-            .hasMessageContaining("aborted by JVM shutdown signal")
-            .hasMessageContaining("outbox-master.xml")
-
-        verify(loopLockService).releaseLock()
     }
 }

--- a/documentation/release-notes/12.x.x/12.34.0/README.md
+++ b/documentation/release-notes/12.x.x/12.34.0/README.md
@@ -12,7 +12,3 @@
 * **Task list columns**
 
   Task list columns can now also display the tags display type.
-
-## Bugfixes
-
-* New bugfix.

--- a/documentation/release-notes/12.x.x/12.34.0/README.md
+++ b/documentation/release-notes/12.x.x/12.34.0/README.md
@@ -16,6 +16,15 @@
 
   Task list columns can now also display the tags display type.
 
+* **Skip Valtimo's database migrations**
+
+  A new setting lets you disable Valtimo's built-in database migrations, so they can be run from
+  a separate job instead.
+
 ## Bugfixes
 
-* New bugfix.
+* **Recover from stuck migration locks**
+
+  If an application instance was killed mid-migration, the migration lock could stay held and
+  prevent other instances from starting. Valtimo now releases such stale locks automatically on
+  startup and on graceful shutdown.

--- a/documentation/release-notes/12.x.x/12.34.0/README.md
+++ b/documentation/release-notes/12.x.x/12.34.0/README.md
@@ -15,8 +15,4 @@
 
 ## Bugfixes
 
-* **Recover from stuck migration locks**
-
-  If an application instance was killed mid-migration, the migration lock could stay held and
-  prevent other instances from starting. Valtimo now releases such stale locks automatically on
-  startup and on graceful shutdown.
+* New bugfix.

--- a/documentation/release-notes/12.x.x/12.34.0/README.md
+++ b/documentation/release-notes/12.x.x/12.34.0/README.md
@@ -16,11 +16,6 @@
 
   Task list columns can now also display the tags display type.
 
-* **Skip Valtimo's database migrations**
-
-  A new setting lets you disable Valtimo's built-in database migrations, so they can be run from
-  a separate job instead.
-
 ## Bugfixes
 
 * **Recover from stuck migration locks**

--- a/documentation/release-notes/12.x.x/12.35.0/README.md
+++ b/documentation/release-notes/12.x.x/12.35.0/README.md
@@ -14,4 +14,8 @@
 
 ## Bugfixes
 
-* New bugfix.
+* **Recover from stuck migration locks**
+
+  If an application instance was killed mid-migration, the migration lock could stay held and
+  prevent other instances from starting. Valtimo now releases such stale locks automatically on
+  startup and on graceful shutdown.


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/436

V12 backport of #628 (V13 / `next-minor`). Code is byte-identical apart from two V12-specific differences resolved during the cherry-pick:
- Kept the `IdentifierField` enum and its `JsonCreator`/`Nonnull` imports in `ValtimoProperties` (removed in `next-minor`, still present on V12).
- Skipped the operaton-package `CallDepthExecutionListenerTest.kt` (added on `next-minor` only).

A hard-killed migrating JVM (SIGKILL, OOMKill, host eviction, terminationGrace expiry) currently leaves `DATABASECHANGELOGLOCK.LOCKED=true` indefinitely, blocking every subsequent instance on `LiquibaseRunner.run()` for the full lock-wait timeout. A real incident on Valtimo 12.32.0 held the lock for ~17 hours before manual recovery.

This PR adds three protections to both `LiquibaseRunner` (contract module) and `OutboxLiquibaseRunner` (outbox module):

- **Stale-lock detection** — before `liquibase.update()`, force-release the lock if `lockgranted` is older than `valtimo.liquibase.stale-lock-threshold-minutes` (default 30). Logs a WARN naming the previous `LOCKEDBY`. This is the only protection against `SIGKILL` / OOM paths.
- **Explicit `try { update() } finally { releaseLock() }`** around the iteration — so an exception escaping mid-iteration cannot leave the lock held.
- **JVM shutdown hook** scoped to the `run()` invocation — force-releases the lock on graceful `SIGTERM` if this JVM is still the holder, then deregisters itself in the outer `finally`.

> **Note on scope:** an earlier revision of this PR also added a `valtimo.liquibase.enabled` opt-out so consumers could skip in-pod migrations. That toggle has been split off into a separate, broader bootstrap-toggle initiative; this PR is now strictly the stale-lock hardening.

Specify the code branch location: `bugfix/706-liquibase-stale-lock-hardening-v12` → `rc/12.34.0`.

**Relevant comments:**
> The original analysis proposed adding `EntityManagerFactory @DependsOn("liquibaseRunner")` to fence Hibernate's connection borrowing during migration, but in Valtimo's setup migrations run inside Operaton's `ProcessEngine` init via `ValtimoSchemaOperationsCommand`, not from the bean's `afterPropertiesSet`. So `@DependsOn` would only fence around bean construction (microseconds), not the migration window. The misleading "Apparent connection leak detected" warning is a downstream symptom of stale-lock parking and is resolved indirectly by the stale-lock detection.
>
> The shutdown hook is registered just before migrations start and deregistered in the outer `finally` so it doesn't accumulate across `run()` invocations. `releaseLockQuietly` and `deregisterShutdownHook` swallow `RuntimeException` to preserve the contract that best-effort cleanup in a `finally` cannot mask the real migration exception.

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Run `./gradlew :backend:contract:test :backend:outbox:test` — new unit tests pass on each side (stale-lock-released, leaves-fresh-alone, no-op-empty, releases-on-iteration-exception, shutdown-hook-no-op-when-no-lock).
- [ ] Run `./gradlew :backend:contract:integrationTestingPostgresql :backend:outbox:integrationTestingPostgresql` — existing integration suites still pass.
- [ ] Smoke: in a running gzac instance, simulate a stale lock with `UPDATE databasechangeloglock SET locked=true, lockgranted = NOW() - INTERVAL '1 hour'` and restart the app. Expect a WARN log naming the previous `LOCKEDBY` and a successful startup.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
