### PR TITLE
GH-710: Actuator security refactor (V12)

### DIFF
--- a/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/HttpSecurityAutoConfiguration.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/autoconfigure/HttpSecurityAutoConfiguration.java
@@ -20,6 +20,7 @@ import com.ritense.valtimo.contract.hardening.service.HardeningService;
 import com.ritense.valtimo.contract.security.config.HttpSecurityConfigurer;
 import com.ritense.valtimo.contract.security.config.oauth2.NoOAuth2ClientsConfiguredCondition;
 import com.ritense.valtimo.contract.web.rest.error.ExceptionTranslator;
+import com.ritense.valtimo.security.ActuatorRoleHealthEndpointGroups;
 import com.ritense.valtimo.security.ActuatorSecurityFilterChainFactory;
 import com.ritense.valtimo.security.CoreSecurityFactory;
 import com.ritense.valtimo.security.Http401UnauthorizedEntryPoint;
@@ -52,8 +53,10 @@ import java.util.List;
 import java.util.Optional;
 import org.camunda.bpm.engine.IdentityService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointProperties;
+import org.springframework.boot.actuate.health.HealthEndpointGroups;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -300,6 +303,25 @@ public class HttpSecurityAutoConfiguration {
             username,
             password
         );
+    }
+
+    // Wraps the auto-configured HealthEndpointGroups so /actuator/health responses only include
+    // components/details when the caller is authenticated and holds ROLE_ACTUATOR. This is a
+    // code-level override of management.endpoint.health.{show-details,roles} and per-group
+    // equivalents — application.yml cannot relax it. Defense-in-depth alongside the conditional
+    // permitAll in ActuatorSecurityFilterChainFactory.
+    @Bean
+    public static BeanPostProcessor actuatorRoleHealthEndpointGroupsPostProcessor() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) {
+                if (bean instanceof HealthEndpointGroups groups
+                        && !(bean instanceof ActuatorRoleHealthEndpointGroups)) {
+                    return new ActuatorRoleHealthEndpointGroups(groups);
+                }
+                return bean;
+            }
+        };
     }
 
     @Order(100)

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorRoleHealthEndpointGroups.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorRoleHealthEndpointGroups.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.security
+
+import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.ACTUATOR
+import org.springframework.boot.actuate.endpoint.SecurityContext
+import org.springframework.boot.actuate.health.HealthEndpointGroup
+import org.springframework.boot.actuate.health.HealthEndpointGroups
+
+// Code-override of management.endpoint.health.{show-details,roles} and per-group equivalents:
+// regardless of what application.yml configures, /actuator/health responses only include
+// components/details when the caller is authenticated and holds ROLE_ACTUATOR. Mirrors the
+// safety invariant in ActuatorSecurityFilterChainFactory.healthDetailsAreSafeForAnonymous.
+internal class ActuatorRoleHealthEndpointGroup(
+    private val delegate: HealthEndpointGroup
+) : HealthEndpointGroup by delegate {
+
+    override fun showDetails(securityContext: SecurityContext): Boolean =
+        isActuator(securityContext) && delegate.showDetails(securityContext)
+
+    override fun showComponents(securityContext: SecurityContext): Boolean =
+        isActuator(securityContext) && delegate.showComponents(securityContext)
+
+    private fun isActuator(context: SecurityContext): Boolean =
+        context.principal != null && context.isUserInRole(ACTUATOR)
+}
+
+// Wraps every HealthEndpointGroup returned by the delegate. getPrimary() covers the top-level
+// /actuator/health (uses HealthEndpointProperties.showDetails); get(name) covers each named
+// group at /actuator/health/<name> (uses props.group.<name>.show-details with inheritance).
+class ActuatorRoleHealthEndpointGroups(
+    private val delegate: HealthEndpointGroups
+) : HealthEndpointGroups {
+
+    override fun getPrimary(): HealthEndpointGroup = ActuatorRoleHealthEndpointGroup(delegate.primary)
+
+    override fun getNames(): Set<String> = delegate.names
+
+    override fun get(name: String): HealthEndpointGroup? =
+        delegate.get(name)?.let { ActuatorRoleHealthEndpointGroup(it) }
+}

--- a/backend/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorSecurityFilterChainFactory.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorSecurityFilterChainFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,8 @@ package com.ritense.valtimo.security
 import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.ACTUATOR
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties
 import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointProperties
-import org.springframework.boot.actuate.endpoint.Show
-import org.springframework.http.HttpMethod.GET
-import org.springframework.http.HttpMethod.POST
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest
+import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.ProviderManager
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
@@ -32,8 +31,8 @@ import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.provisioning.InMemoryUserDetailsManager
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher
-import org.springframework.security.web.util.matcher.OrRequestMatcher
+import org.springframework.security.web.util.matcher.AndRequestMatcher
+import org.springframework.security.web.util.matcher.RequestMatcher
 
 class ActuatorSecurityFilterChainFactory {
 
@@ -48,6 +47,7 @@ class ActuatorSecurityFilterChainFactory {
         return createFilterChain(http, webEndpointProperties, null, passwordEncoder, username, password)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun createFilterChain(
         http: HttpSecurity,
         webEndpointProperties: WebEndpointProperties,
@@ -56,26 +56,24 @@ class ActuatorSecurityFilterChainFactory {
         username: String,
         password: String
     ): SecurityFilterChain {
-        val matchers = getActuatorMatchers(webEndpointProperties.basePath)
         http
-            .securityMatcher(OrRequestMatcher(*matchers))
+            .securityMatcher(EndpointRequest.toAnyEndpoint())
             .authorizeHttpRequests {
-                if (healthEndpointProperties != null && (
-                        //Allow access to this endpoint only if the details are not shown to anonymous users or users without ROLE_ACTUATOR
-                        healthEndpointProperties.showDetails == Show.NEVER || (
-                            healthEndpointProperties.showDetails == Show.WHEN_AUTHORIZED &&
-                            healthEndpointProperties.roles.contains(ACTUATOR)
-                        )
-                )) {
-                    it.requestMatchers(*getPublicMatchers(webEndpointProperties.basePath)).permitAll()
-                }
-                it.requestMatchers(*matchers).hasAuthority(ACTUATOR)
+                // /health and /actuator (links) are always publicly readable; components and
+                // details are stripped for non-actuator callers by ActuatorRoleHealthEndpointGroups.
+                it.requestMatchers(EndpointRequest.to("health").withHttpMethod(HttpMethod.GET)).permitAll()
+                // toLinks() has no withHttpMethod; AndRequestMatcher restricts it to GET.
+                it.requestMatchers(AndRequestMatcher(getOnly, EndpointRequest.toLinks())).permitAll()
+                // Only runtime mutation we expose: POST /loggers/{name}.
+                it.requestMatchers(EndpointRequest.to("loggers").withHttpMethod(HttpMethod.POST)).hasAuthority(ACTUATOR)
+                it.requestMatchers(EndpointRequest.toAnyEndpoint().withHttpMethod(HttpMethod.GET)).hasAuthority(ACTUATOR)
+                // Defense in depth: any other write (POST /env, DELETE /caches, ...) lands here.
+                it.anyRequest().denyAll()
             }
             .authenticationManager(actuatorAuthenticationManager(passwordEncoder, username, password))
             .httpBasic { it.realmName(ACTUATOR_REALM) }
-            .csrf {
-                csrfConfigurer -> csrfConfigurer.ignoringRequestMatchers("${webEndpointProperties.basePath}/loggers/**")
-            }
+            // CSRF off only for /loggers so automation can POST without first fetching a token.
+            .csrf { it.ignoringRequestMatchers(EndpointRequest.to("loggers")) }
 
         return http.build()
     }
@@ -86,9 +84,8 @@ class ActuatorSecurityFilterChainFactory {
         password: String
     ): AuthenticationManager {
         val userDetailsService: UserDetailsService = userDetailsService(passwordEncoder, username, password)
-        val authenticationProvider = DaoAuthenticationProvider()
+        val authenticationProvider = DaoAuthenticationProvider(userDetailsService)
         authenticationProvider.setPasswordEncoder(passwordEncoder)
-        authenticationProvider.setUserDetailsService(userDetailsService)
 
         return ProviderManager(authenticationProvider)
     }
@@ -107,28 +104,9 @@ class ActuatorSecurityFilterChainFactory {
         return InMemoryUserDetailsManager(actuatorUser)
     }
 
-    private fun getActuatorMatchers(actuatorPath: String) = arrayOf(
-        antMatcher(GET, actuatorPath),
-        antMatcher(GET, "${actuatorPath}/configprops"),
-        antMatcher(GET, "${actuatorPath}/env"),
-        *getPublicMatchers(actuatorPath),
-        antMatcher(GET, "${actuatorPath}/health/liveness"),
-        antMatcher(GET, "${actuatorPath}/health/readiness"),
-        antMatcher(GET, "${actuatorPath}/mappings"),
-        antMatcher(GET, "${actuatorPath}/logfile"),
-        antMatcher(GET, "${actuatorPath}/loggers"),
-        antMatcher(POST, "${actuatorPath}/loggers/**"),
-        antMatcher(GET, "${actuatorPath}/info"),
-    )
-
-    private fun getPublicMatchers(actuatorPath: String) = arrayOf(
-        antMatcher(GET, actuatorPath),
-        antMatcher(GET, "${actuatorPath}/health"),
-        antMatcher(GET, "${actuatorPath}/health/liveness"),
-        antMatcher(GET, "${actuatorPath}/health/readiness"),
-    )
-
     companion object {
         const val ACTUATOR_REALM = "Actuator realm"
+
+        private val getOnly = RequestMatcher { request -> request.method == "GET" }
     }
 }

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/security/ActuatorRoleHealthEndpointGroupTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/security/ActuatorRoleHealthEndpointGroupTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.security
+
+import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.ACTUATOR
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.actuate.endpoint.SecurityContext
+import org.springframework.boot.actuate.health.HealthEndpointGroup
+import java.security.Principal
+
+class ActuatorRoleHealthEndpointGroupTest {
+
+    private val delegate: HealthEndpointGroup = mock()
+    private val wrapper = ActuatorRoleHealthEndpointGroup(delegate)
+
+    @Test
+    fun `anonymous caller never sees details, even when delegate would allow`() {
+        val context = anonymousContext()
+        whenever(delegate.showDetails(context)).thenReturn(true)
+
+        assertThat(wrapper.showDetails(context)).isFalse
+    }
+
+    @Test
+    fun `authenticated non-actuator caller never sees details, even when delegate would allow`() {
+        val context = authenticatedContext(hasActuatorRole = false)
+        whenever(delegate.showDetails(context)).thenReturn(true)
+
+        assertThat(wrapper.showDetails(context)).isFalse
+    }
+
+    @Test
+    fun `actuator caller sees details when delegate allows`() {
+        val context = authenticatedContext(hasActuatorRole = true)
+        whenever(delegate.showDetails(context)).thenReturn(true)
+
+        assertThat(wrapper.showDetails(context)).isTrue
+    }
+
+    @Test
+    fun `actuator caller does not see details when delegate denies (e g show-details=NEVER)`() {
+        val context = authenticatedContext(hasActuatorRole = true)
+        whenever(delegate.showDetails(context)).thenReturn(false)
+
+        assertThat(wrapper.showDetails(context)).isFalse
+    }
+
+    @Test
+    fun `showComponents follows the same role rule`() {
+        val anonymous = anonymousContext()
+        whenever(delegate.showComponents(anonymous)).thenReturn(true)
+        assertThat(wrapper.showComponents(anonymous)).isFalse
+
+        val actuator = authenticatedContext(hasActuatorRole = true)
+        whenever(delegate.showComponents(actuator)).thenReturn(true)
+        assertThat(wrapper.showComponents(actuator)).isTrue
+    }
+
+    private fun anonymousContext(): SecurityContext {
+        val context = mock<SecurityContext>()
+        whenever(context.principal).thenReturn(null)
+        whenever(context.isUserInRole(ACTUATOR)).thenReturn(false)
+        return context
+    }
+
+    private fun authenticatedContext(hasActuatorRole: Boolean): SecurityContext {
+        val context = mock<SecurityContext>()
+        whenever(context.principal).thenReturn(mock<Principal>())
+        whenever(context.isUserInRole(ACTUATOR)).thenReturn(hasActuatorRole)
+        return context
+    }
+}

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityHealthShowDetailsIntTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityHealthShowDetailsIntTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.web.rest.actuator
+
+import com.jayway.jsonpath.JsonPath.read
+import com.jayway.jsonpath.PathNotFoundException
+import com.ritense.valtimo.web.rest.SecuritySpecificEndpointIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import java.util.Base64
+
+@Tag("security")
+class ActuatorSecurityHealthShowDetailsIntTest {
+
+    @Nested
+    @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+    @TestPropertySource(properties = [
+        "management.port=0",
+        "management.endpoint.health.show-details=never"
+    ])
+    inner class Never : SecuritySpecificEndpointIntegrationTest() {
+
+        @Test
+        fun `unauthenticated user should have access to health endpoint without details`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health").init()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+
+        @Test
+        fun `actuator user should have access to health endpoint without details`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health")
+                .init()
+                .withBasicTestUser()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+
+        @Test
+        fun `unauthenticated user should have access to actuator discovery endpoint`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator").init()
+            assertHttpStatus(request, HttpStatus.OK)
+        }
+    }
+
+    @Nested
+    @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+    @TestPropertySource(properties = [
+        "management.port=0",
+        "management.endpoint.health.show-details=always"
+    ])
+    inner class Always : SecuritySpecificEndpointIntegrationTest() {
+
+        @Test
+        fun `unauthenticated user can read health endpoint, components stripped despite show-details=ALWAYS`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health").init()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            // Wrapper forces no-details for non-actuator callers regardless of show-details=ALWAYS.
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+
+        @Test
+        fun `actuator user should have access to health endpoint with details`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health")
+                .init()
+                .withBasicTestUser()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+
+            val pingStatus = read<Any>(response.contentAsString, "$.components.ping.status")
+            assertThat(pingStatus).isEqualTo("UP")
+        }
+
+        @Test
+        fun `unauthenticated user can read actuator discovery endpoint`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator").init()
+            assertHttpStatus(request, HttpStatus.OK)
+        }
+    }
+
+    @Nested
+    @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+    @TestPropertySource(properties = [
+        "management.port=0",
+        "management.endpoint.health.show-details=when-authorized",
+        "management.endpoint.health.roles[0]=ROLE_OTHER"
+    ])
+    inner class WhenAuthorizedOtherRole : SecuritySpecificEndpointIntegrationTest() {
+
+        @Test
+        fun `unauthenticated user can read health endpoint without components when details are gated to non-actuator role`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health").init()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+
+        @Test
+        fun `actuator user should have access to health endpoint without details when details are gated to non-actuator role`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health")
+                .init()
+                .withBasicTestUser()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+
+        @Test
+        fun `unauthenticated user can read actuator discovery endpoint`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator").init()
+            assertHttpStatus(request, HttpStatus.OK)
+        }
+    }
+
+    @Nested
+    @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+    @TestPropertySource(properties = [
+        "management.port=0",
+        "management.endpoint.health.show-details=never",
+        "management.endpoint.health.group.leaky.show-details=always",
+        "management.endpoint.health.group.leaky.include=ping"
+    ])
+    inner class GroupOverride : SecuritySpecificEndpointIntegrationTest() {
+
+        @Test
+        fun `unauthenticated user can read health group but never sees components despite group override`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health/leaky").init()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            // Group config says show-details=ALWAYS; the ActuatorRoleHealthEndpointGroups wrapper
+            // strips components for non-actuator callers regardless.
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+
+        @Test
+        fun `unauthenticated user can read top-level health without components`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health").init()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+
+        @Test
+        fun `actuator user should have access to health group with details`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health/leaky")
+                .init()
+                .withBasicTestUser()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+
+            val pingStatus = read<Any>(response.contentAsString, "$.components.ping.status")
+            assertThat(pingStatus).isEqualTo("UP")
+        }
+
+        @Test
+        fun `actuator user should have access to top-level health without details`() {
+            val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/health")
+                .init()
+                .withBasicTestUser()
+
+            val response = mockMvc.perform(request).andReturn().response
+            assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+            assertThrows<PathNotFoundException> {
+                read<Map<String, Any>>(response.contentAsString, "$.components")
+            }
+        }
+    }
+}
+
+private fun MockHttpServletRequestBuilder.init() =
+    this.accept(MediaType.APPLICATION_JSON)
+        .with { r: MockHttpServletRequest ->
+            r.remoteAddr = "8.8.8.8"
+            r
+        }
+
+private fun MockHttpServletRequestBuilder.withBasicTestUser(): MockHttpServletRequestBuilder {
+    val credentials = Base64.getEncoder().encodeToString("test:test".toByteArray())
+    return this.header("Authorization", "Basic $credentials")
+}

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityIntTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityIntTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.ritense.valtimo.web.rest
+package com.ritense.valtimo.web.rest.actuator
 
 import com.jayway.jsonpath.JsonPath.read
 import com.jayway.jsonpath.PathNotFoundException
 import com.ritense.valtimo.contract.authentication.AuthoritiesConstants
+import com.ritense.valtimo.web.rest.SecuritySpecificEndpointIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -34,7 +35,11 @@ import java.util.Base64
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
-@TestPropertySource(properties = ["management.port=0"])
+@TestPropertySource(properties = [
+    "management.port=0",
+    "management.endpoints.web.exposure.include=health,configprops,env,info,mappings,loggers,logfile",
+    "logging.file.name=build/test-actuator.log"
+])
 class ActuatorSecurityIntTest : SecuritySpecificEndpointIntegrationTest() {
 
     @Test
@@ -147,6 +152,92 @@ class ActuatorSecurityIntTest : SecuritySpecificEndpointIntegrationTest() {
         val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/configprops")
             .init()
         assertHttpStatus(request, HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `unauthenticated user should get 401 on protected actuator endpoint`() {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/configprops")
+            .init()
+        assertHttpStatus(request, HttpStatus.UNAUTHORIZED)
+    }
+
+    @Test
+    fun `unauthenticated request should include actuator realm in WWW-Authenticate header`() {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/configprops")
+            .init()
+
+        val response = mockMvc.perform(request).andReturn().response
+        assertThat(response.status).isEqualTo(HttpStatus.UNAUTHORIZED.value())
+        assertThat(response.getHeader("WWW-Authenticate"))
+            .isNotNull()
+            .contains("realm=\"Actuator realm\"")
+    }
+
+    @Test
+    fun `request with wrong basic auth credentials should return 401`() {
+        val wrongCredentials = Base64.getEncoder().encodeToString("test:wrong-password".toByteArray())
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/configprops")
+            .init()
+            .header("Authorization", "Basic $wrongCredentials")
+
+        assertHttpStatus(request, HttpStatus.UNAUTHORIZED)
+    }
+
+    @Test
+    fun `actuator user should have access to actuator discovery endpoint`() {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator")
+            .init()
+            .withBasicTestUser()
+        assertHttpStatus(request, HttpStatus.OK)
+    }
+
+    @Test
+    fun `unauthenticated user should have access to actuator discovery endpoint when health details are gated to actuator role`() {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator")
+            .init()
+        assertHttpStatus(request, HttpStatus.OK)
+    }
+
+    @ParameterizedTest
+    @CsvSource("/actuator/env", "/actuator/info", "/actuator/mappings", "/actuator/loggers")
+    fun `actuator user should have access to protected actuator endpoint`(path: String) {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, path)
+            .init()
+            .withBasicTestUser()
+        assertHttpStatus(request, HttpStatus.OK)
+    }
+
+    @ParameterizedTest
+    @CsvSource("/actuator/env", "/actuator/info", "/actuator/mappings", "/actuator/loggers", "/actuator/logfile")
+    @WithMockUser(authorities = [AuthoritiesConstants.USER])
+    fun `non-actuator authenticated user should get 403 on protected actuator endpoint`(path: String) {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, path)
+            .init()
+        assertHttpStatus(request, HttpStatus.FORBIDDEN)
+    }
+
+    @ParameterizedTest
+    @CsvSource("/actuator/env", "/actuator/info", "/actuator/mappings", "/actuator/loggers", "/actuator/logfile")
+    fun `unauthenticated user should get 401 on protected actuator endpoint`(path: String) {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, path)
+            .init()
+        assertHttpStatus(request, HttpStatus.UNAUTHORIZED)
+    }
+
+    @Test
+    fun `actuator user can POST to loggers without CSRF token`() {
+        val request = MockMvcRequestBuilders.request(HttpMethod.POST, "/actuator/loggers/com.ritense.valtimo")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{}")
+            .with { r: MockHttpServletRequest ->
+                r.remoteAddr = "8.8.8.8"
+                r
+            }
+            .withBasicTestUser()
+
+        val response = mockMvc.perform(request).andReturn().response
+        assertThat(response.status).isEqualTo(HttpStatus.NO_CONTENT.value())
     }
 
     fun MockHttpServletRequestBuilder.init() =

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityRealTomcatIntTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityRealTomcatIntTest.kt
@@ -17,7 +17,6 @@
 package com.ritense.valtimo.web.rest.actuator
 
 import com.ritense.valtimo.contract.authentication.UserManagementService
-import com.ritense.valtimo.service.ProcessDefinitionCaseDefinitionLinker
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -54,8 +53,7 @@ import java.util.Base64
 )
 class ActuatorSecurityRealTomcatIntTest @Autowired constructor(
     @LocalServerPort private val serverPort: Int,
-    @MockitoBean private val userManagementService: UserManagementService,
-    @MockitoBean private val processDefinitionCaseDefinitionLinker: ProcessDefinitionCaseDefinitionLinker
+    @MockitoBean private val userManagementService: UserManagementService
 ) {
 
     @Test

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityRealTomcatIntTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityRealTomcatIntTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.web.rest.actuator
+
+import com.ritense.valtimo.contract.authentication.UserManagementService
+import com.ritense.valtimo.service.ProcessDefinitionCaseDefinitionLinker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.exchange
+import java.util.Base64
+
+@ExtendWith(SpringExtension::class)
+@Tag("security")
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = [
+        "management.endpoints.web.base-path=/management",
+        "management.endpoints.web.exposure.include=health,info",
+        "management.endpoint.health.show-details=when_authorized",
+        "management.endpoint.health.roles=ROLE_ACTUATOR",
+        "management.endpoint.health.probes.enabled=true",
+        "management.endpoint.health.group.liveness.include=livenessState",
+        "management.endpoint.health.group.liveness.show-details=ALWAYS",
+        "management.endpoint.health.group.readiness.include=readinessState",
+        "management.endpoint.health.group.readiness.show-details=ALWAYS",
+        "valtimo.security.whitelist.hosts=localhost"
+    ]
+)
+class ActuatorSecurityRealTomcatIntTest @Autowired constructor(
+    @LocalServerPort private val serverPort: Int,
+    @MockitoBean private val userManagementService: UserManagementService,
+    @MockitoBean private val processDefinitionCaseDefinitionLinker: ProcessDefinitionCaseDefinitionLinker
+) {
+
+    @Test
+    fun `anonymous can read management health on real tomcat without exposing details`() {
+        val restTemplate = RestTemplate()
+
+        val response = restTemplate.exchange<String>(
+            url = "http://localhost:$serverPort/management/health",
+            method = HttpMethod.GET,
+            requestEntity = HttpEntity<Any>(HttpHeaders())
+        )
+
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        // Even though liveness/readiness groups have show-details=ALWAYS, the wrapper strips
+        // components for non-actuator callers.
+        assertThat(response.body).doesNotContain("components")
+    }
+
+    @Test
+    fun `actuator user can access management health on real tomcat`() {
+        val restTemplate = RestTemplate()
+        val headers = HttpHeaders().apply {
+            val credentials = Base64.getEncoder().encodeToString("test:test".toByteArray())
+            set("Authorization", "Basic $credentials")
+        }
+
+        val response = restTemplate.exchange<String>(
+            url = "http://localhost:$serverPort/management/health",
+            method = HttpMethod.GET,
+            requestEntity = HttpEntity<Any>(headers)
+        )
+
+        assertThat(response.statusCode.value()).isEqualTo(200)
+    }
+}

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityWriteBlockedIntTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/web/rest/actuator/ActuatorSecurityWriteBlockedIntTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.web.rest.actuator
+
+import com.ritense.valtimo.web.rest.SecuritySpecificEndpointIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import java.util.Base64
+import java.util.stream.Stream
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestPropertySource(properties = [
+    "management.port=0",
+    "management.endpoints.web.exposure.include=*",
+    "management.endpoints.access.default=unrestricted",
+    "management.endpoint.shutdown.enabled=true",
+    "management.endpoint.env.post.enabled=true"
+])
+class ActuatorSecurityWriteBlockedIntTest : SecuritySpecificEndpointIntegrationTest() {
+
+    @Test
+    fun `actuator user can read loggers (positive baseline)`() {
+        val request = MockMvcRequestBuilders.request(HttpMethod.GET, "/actuator/loggers")
+            .init()
+            .withBasicTestUser()
+
+        val response = mockMvc.perform(request).andReturn().response
+        assertThat(response.status).isEqualTo(HttpStatus.OK.value())
+    }
+
+    @Test
+    fun `actuator user can write loggers (positive baseline)`() {
+        val request = MockMvcRequestBuilders.request(HttpMethod.POST, "/actuator/loggers/com.ritense.valtimo")
+            .init()
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{}")
+            .withBasicTestUser()
+
+        val response = mockMvc.perform(request).andReturn().response
+        assertThat(response.status).isEqualTo(HttpStatus.NO_CONTENT.value())
+    }
+
+    @ParameterizedTest(name = "{0} {1}")
+    @MethodSource("nonLoggersWriteOperations")
+    fun `actuator user cannot mutate non-loggers actuator endpoints even when access is unrestricted`(
+        method: HttpMethod,
+        path: String
+    ) {
+        val request = MockMvcRequestBuilders.request(method, path)
+            .init()
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{}")
+            .withBasicTestUser()
+
+        val response = mockMvc.perform(request).andReturn().response
+        val status = HttpStatus.valueOf(response.status)
+        assertThat(status.is2xxSuccessful)
+            .describedAs("$method $path returned ${response.status}; expected non-2xx")
+            .isFalse
+    }
+
+    @ParameterizedTest(name = "{0} {1}")
+    @MethodSource("nonLoggersWriteOperationsAtRegisteredEndpoints")
+    fun `denyAll blocks non-loggers mutations even when CSRF is satisfied`(
+        method: HttpMethod,
+        path: String
+    ) {
+        val request = MockMvcRequestBuilders.request(method, path)
+            .init()
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{}")
+            .with(csrf())
+            .withBasicTestUser()
+
+        assertHttpStatus(request, HttpStatus.FORBIDDEN)
+    }
+
+    fun MockHttpServletRequestBuilder.init() =
+        this.accept(MediaType.APPLICATION_JSON)
+            .with { r: MockHttpServletRequest ->
+                r.remoteAddr = "8.8.8.8"
+                r
+            }
+
+    fun MockHttpServletRequestBuilder.withBasicTestUser(): MockHttpServletRequestBuilder {
+        val credentials = Base64.getEncoder().encodeToString("test:test".toByteArray())
+        return this.header("Authorization", "Basic $credentials")
+    }
+
+    companion object {
+        @JvmStatic
+        fun nonLoggersWriteOperations(): Stream<Arguments> = Stream.of(
+            Arguments.of(HttpMethod.POST, "/actuator/env"),
+            Arguments.of(HttpMethod.POST, "/actuator/env/some.property"),
+            Arguments.of(HttpMethod.POST, "/actuator/shutdown"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/caches"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/caches/anyCache"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/sessions/abc123"),
+            Arguments.of(HttpMethod.POST, "/actuator/loggers"),
+            Arguments.of(HttpMethod.POST, "/actuator/configprops"),
+            Arguments.of(HttpMethod.POST, "/actuator/info"),
+            Arguments.of(HttpMethod.POST, "/actuator/mappings"),
+            Arguments.of(HttpMethod.POST, "/actuator/health"),
+            Arguments.of(HttpMethod.PUT, "/actuator/loggers/com.ritense.valtimo"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/loggers/com.ritense.valtimo")
+        )
+
+        // Subset of write operations that target endpoints we know are registered in the test app.
+        // Used to assert exact 403 from the security chain's denyAll, distinct from MVC's 405 or
+        // fall-through 401/404 for unregistered endpoints.
+        @JvmStatic
+        fun nonLoggersWriteOperationsAtRegisteredEndpoints(): Stream<Arguments> = Stream.of(
+            Arguments.of(HttpMethod.POST, "/actuator/env"),
+            Arguments.of(HttpMethod.POST, "/actuator/env/some.property"),
+            Arguments.of(HttpMethod.POST, "/actuator/shutdown"),
+            Arguments.of(HttpMethod.POST, "/actuator/configprops"),
+            Arguments.of(HttpMethod.POST, "/actuator/info"),
+            Arguments.of(HttpMethod.POST, "/actuator/mappings"),
+            Arguments.of(HttpMethod.POST, "/actuator/health"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/env"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/configprops"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/info"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/mappings"),
+            Arguments.of(HttpMethod.PUT, "/actuator/env"),
+            Arguments.of(HttpMethod.PUT, "/actuator/configprops"),
+            Arguments.of(HttpMethod.PATCH, "/actuator/env"),
+            Arguments.of(HttpMethod.PUT, "/actuator/loggers/com.ritense.valtimo"),
+            Arguments.of(HttpMethod.DELETE, "/actuator/loggers/com.ritense.valtimo"),
+            Arguments.of(HttpMethod.PATCH, "/actuator/loggers/com.ritense.valtimo")
+        )
+    }
+}

--- a/documentation/release-notes/12.x.x/12.35.0/README.md
+++ b/documentation/release-notes/12.x.x/12.35.0/README.md
@@ -8,9 +8,23 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Improved actuator endpoint security**
 
-  New enhancement explanation.
+  Endpoints added to `management.endpoints.web.exposure.include` are now
+  automatically protected — no filter chain override needed.
+
+* **Hardened anonymous health responses**
+
+  Anonymous calls to `/actuator/health` only return the overall status;
+  component details require the actuator role. Kubernetes probes and load
+  balancers are unaffected.
+
+  {% hint style="warning" %}
+  Health groups (e.g. `liveness`, `readiness`) configured with
+  `show-details: ALWAYS` previously exposed component details to anonymous
+  callers. They are now also reduced to status-only for unauthenticated
+  requests. Authenticate with the actuator role to keep seeing details.
+  {% endhint %}
 
 ## Bugfixes
 

--- a/documentation/release-notes/12.x.x/12.36.0/README.md
+++ b/documentation/release-notes/12.x.x/12.36.0/README.md
@@ -8,9 +8,23 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Improved actuator endpoint security**
 
-  New enhancement explanation.
+  Endpoints added to `management.endpoints.web.exposure.include` are now
+  automatically protected — no filter chain override needed.
+
+* **Hardened anonymous health responses**
+
+  Anonymous calls to `/actuator/health` only return the overall status;
+  component details require the actuator role. Kubernetes probes and load
+  balancers are unaffected.
+
+  {% hint style="warning" %}
+  Health groups (e.g. `liveness`, `readiness`) configured with
+  `show-details: ALWAYS` previously exposed component details to anonymous
+  callers. They are now also reduced to status-only for unauthenticated
+  requests. Authenticate with the actuator role to keep seeing details.
+  {% endhint %}
 
 ## Bugfixes
 


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/710

Created a separate V12 ticket: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/433

Specify the code branch location: backend/core

> V12 backport of #641.

**Relevant comments:**
> Refactors `ActuatorSecurityFilterChainFactory` to use Spring Boot's `EndpointRequest` matchers instead of a hardcoded path list. Adding a new actuator endpoint to `management.endpoints.web.exposure.include` is now sufficient — overriding the filter chain in your application is no longer needed.
>
> Adds an `ActuatorRoleHealthEndpointGroups` wrapper that forces health responses to omit components/details for non-actuator callers, regardless of `management.endpoint.health.show-details` (top-level or per-group). Anonymous probes (Kubernetes liveness/readiness, load balancers) still receive the overall status.

### Breaking changes
- [ ] The contribution only contains changes that are not breaking.

> Anonymous callers reading component-level fields from `/actuator/health` (or its groups, e.g. `liveness`/`readiness`) now receive only the overall status. Documented in the 12.35.0 release notes with a warning hint.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes

### Tests
Unit tests have been added that cover these changes
- [x] Yes (`ActuatorRoleHealthEndpointGroupTest`)

Integration tests have been added that cover these changes
- [x] Yes (extended `ActuatorSecurityIntTest`, new `ActuatorSecurityHealthShowDetailsIntTest` with @Nested variants, `ActuatorSecurityWriteBlockedIntTest`, `ActuatorSecurityRealTomcatIntTest`)

Describe the testing steps
- [ ] `./gradlew :backend:core:securityTesting` is green (79 tests)
- [ ] Manual: anonymous `GET /management/health` returns 200 without components
- [ ] Manual: authenticated `GET /management/health` with actuator credentials returns 200 with components
- [ ] Manual: anonymous `POST /management/env` returns non-2xx (denyAll)

### Security
- [x] Yes
- [x] Not applicable (no new REST API endpoints)
- [x] Not applicable (no Valtimo access control changes)

### Dependencies
- [x] Not applicable (no dependency changes)