### PR TITLE
Fix OutOfMemoryError when running tests

### DIFF
--- a/backend/gradle/test.gradle
+++ b/backend/gradle/test.gradle
@@ -100,6 +100,7 @@ tasks.register("integrationTestingMysql", Test) {
 tasks.register("securityTesting", Test) {
     group = 'verification'
     systemProperty("spring.profiles.include", "inttest,postgresql")
+    maxHeapSize = "2g"
     testLogging {
         events("passed", "skipped", "failed", "standardError")
     }


### PR DESCRIPTION
https://github.com/valtimo-platform/valtimo/actions/runs/25789891913

Root cause: `java.lang.OutOfMemoryError`: Java heap space during ClassGraph scan in WidgetAnnotatedClassResolver.
  
Fix:
```
maxHeapSize = "2g"
```