### PR TITLE
GH-446: Dependency upgrades

### DIFF
--- a/backend/app/gzac/build.gradle
+++ b/backend/app/gzac/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation "com.mysql:mysql-connector-j:$mysqlDriverVersion"
 
     if (System.getProperty("os.arch") == "aarch64") {
-        runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.105.Final:osx-aarch_64")
+        runtimeOnly("io.netty:netty-resolver-dns-native-macos::osx-aarch_64")
     }
 
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -151,6 +151,7 @@ allprojects {
                 mavenBom "software.amazon.awssdk:bom:${awssdkVersion}"
                 mavenBom "com.fasterxml.jackson:jackson-bom:${jacksonVersion}"
                 mavenBom "org.junit:junit-bom:${junitVersion}"
+                mavenBom "io.netty:netty-bom:4.1.133.Final"
             }
             dependencies {
                 dependency "org.hibernate.orm:hibernate-core:${hibernateCoreVersion}"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -151,6 +151,7 @@ allprojects {
                 mavenBom "software.amazon.awssdk:bom:${awssdkVersion}"
                 mavenBom "com.fasterxml.jackson:jackson-bom:${jacksonVersion}"
                 mavenBom "org.junit:junit-bom:${junitVersion}"
+                // Temporary override, remove on next upgrade of spring
                 mavenBom "io.netty:netty-bom:4.1.133.Final"
             }
             dependencies {


### PR DESCRIPTION
Forced Netty to a specific version. Spring hasn't updated yet, so this has to do for now.

Fixes https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/446