### PR TITLE
GH-447: Dependency upgrades

### DIFF
--- a/backend/app/gzac/build.gradle
+++ b/backend/app/gzac/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation group: 'org.postgresql', name: 'postgresql', version: postgresqlDriverVersion
 
     if (System.getProperty("os.arch") == "aarch64") {
-        runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.105.Final:osx-aarch_64")
+        runtimeOnly("io.netty:netty-resolver-dns-native-macos::osx-aarch_64")
     }
 
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -102,6 +102,7 @@ allprojects {
                 mavenBom "software.amazon.awssdk:bom:${awssdkVersion}"
                 mavenBom "com.fasterxml.jackson:jackson-bom:${jacksonVersion}"
                 mavenBom "org.junit:junit-bom:${junitVersion}"
+                // Temporary override, remove on next upgrade of spring
                 mavenBom "io.netty:netty-bom:4.1.133.Final"
             }
             dependencies {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -102,6 +102,7 @@ allprojects {
                 mavenBom "software.amazon.awssdk:bom:${awssdkVersion}"
                 mavenBom "com.fasterxml.jackson:jackson-bom:${jacksonVersion}"
                 mavenBom "org.junit:junit-bom:${junitVersion}"
+                mavenBom "io.netty:netty-bom:4.1.133.Final"
             }
             dependencies {
                 dependency "org.hibernate.orm:hibernate-core:${hibernateCoreVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -99,7 +99,7 @@ slf4jVersion=2.0.13
 
 # version overrides
 
-nettyCodecVersionOverride=4.1.132.Final
+nettyCodecVersionOverride=4.1.133.Final
 snakeYamlVersionOverride=2.2
 commonsBeanutilsVersion=1.11.0
 commonsFileuploadVersion=1.6.0


### PR DESCRIPTION
Forced Netty to a specific version. Spring hasn't updated yet, so this has to do for now.

Fixes https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/447