### PR TITLE
Building block plugin resolve fix

### DIFF
--- a/backend/building-block/src/main/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolver.kt
+++ b/backend/building-block/src/main/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolver.kt
@@ -24,10 +24,10 @@ import com.ritense.document.service.DocumentService
 import com.ritense.plugin.service.BuildingBlockPluginConfigurationResolver
 import com.ritense.processlink.service.ProcessLinkService
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
-import java.util.UUID
 import org.operaton.bpm.engine.delegate.DelegateExecution
 import org.operaton.bpm.engine.delegate.DelegateTask
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 @Component
 @SkipComponentScan
@@ -39,8 +39,7 @@ class DefaultBuildingBlockPluginConfigurationResolver(
 ) : BuildingBlockPluginConfigurationResolver {
 
     override fun resolve(execution: DelegateExecution, pluginDefinitionKey: String): UUID? {
-        val instance = buildingBlockInstanceService.getByProcessInstanceId(execution.processInstanceId)
-            ?: return null
+        val instance = findInstance(execution) ?: return null
         val root = findRootInstance(instance)
 
         return findCallActivityMapping(root, pluginDefinitionKey)
@@ -49,6 +48,28 @@ class DefaultBuildingBlockPluginConfigurationResolver(
 
     override fun resolve(task: DelegateTask, pluginDefinitionKey: String): UUID? {
         return resolve(task.execution, pluginDefinitionKey)
+    }
+
+    /**
+     * Prefer the BB document id (Valtimo convention: business key == document id, propagated through
+     * `<camunda:in businessKey="..."/>` on call activities). This makes the resolver work from any
+     * process started by the BB — including sub-processes called via plain `<callActivity>` from
+     * the BB main process, which have their own [DelegateExecution.getProcessInstanceId] and no BB
+     * instance row. Falls back to processInstanceId for legacy paths where the business key isn't set.
+     */
+    private fun findInstance(execution: DelegateExecution): BuildingBlockInstance? {
+        execution.processBusinessKey
+            ?.toUuidOrNull()
+            ?.let { buildingBlockInstanceService.getByDocumentId(it) }
+            ?.let { return it }
+
+        return buildingBlockInstanceService.getByProcessInstanceId(execution.processInstanceId)
+    }
+
+    private fun String.toUuidOrNull(): UUID? = try {
+        UUID.fromString(this)
+    } catch (_: IllegalArgumentException) {
+        null
     }
 
     private fun findRootInstance(instance: BuildingBlockInstance): BuildingBlockInstance {

--- a/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolverTest.kt
+++ b/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolverTest.kt
@@ -26,8 +26,10 @@ import com.ritense.valtimo.contract.buildingblock.BuildingBlockDefinitionId
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.operaton.bpm.engine.delegate.DelegateExecution
@@ -154,8 +156,7 @@ class DefaultBuildingBlockPluginConfigurationResolverTest {
             definition = definition
         )
 
-        // The sub-process has no row of its own; only the BB main process does.
-        whenever(buildingBlockInstanceService.getByProcessInstanceId(subProcessInstanceId)).thenReturn(null)
+        // Only the BB main process has a row; the sub-process does not.
         whenever(buildingBlockInstanceService.getByDocumentId(buildingBlockDocumentId)).thenReturn(bbInstance)
 
         whenever(processLinkService.getProcessLinks(callerProcessDefinitionId, activityId)).thenReturn(
@@ -175,6 +176,9 @@ class DefaultBuildingBlockPluginConfigurationResolverTest {
         val resolved = resolver.resolve(execution, "plugin-definition")
 
         assertThat(resolved).isEqualTo(pluginConfigurationId)
+        // Document-id path resolves the instance; processInstanceId fallback must not be consulted.
+        verify(buildingBlockInstanceService).getByDocumentId(buildingBlockDocumentId)
+        verify(buildingBlockInstanceService, never()).getByProcessInstanceId(any())
     }
 
     @Test

--- a/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolverTest.kt
+++ b/backend/building-block/src/test/kotlin/com/ritense/buildingblock/processlink/service/DefaultBuildingBlockPluginConfigurationResolverTest.kt
@@ -123,6 +123,61 @@ class DefaultBuildingBlockPluginConfigurationResolverTest {
     }
 
     @Test
+    fun `should resolve plugin via business key when called from sub-process inside a building block`() {
+        // Scenario: BB main process started ad-hoc -> plain callActivity to a sub-process that has
+        // a plugin process link. The sub-process has its own processInstanceId and no BB instance
+        // row of its own; resolution must succeed via the business key (= BB document id) which the
+        // call activity propagates per Valtimo convention.
+        val subProcessInstanceId = "sub-process-instance"
+        val buildingBlockDocumentId = UUID.randomUUID()
+        val callerProcessDefinitionId = "case-process-def"
+        val activityId = "callBB"
+        val pluginConfigurationId = UUID.randomUUID()
+
+        val execution = mock<DelegateExecution> {
+            on { processInstanceId } doReturn subProcessInstanceId
+            on { processBusinessKey } doReturn buildingBlockDocumentId.toString()
+        }
+
+        val buildingBlockDefinitionId = BuildingBlockDefinitionId.of("bb-key", "1.0.0")
+        val definition = BuildingBlockDefinition(
+            buildingBlockDefinitionId, "Test block", "desc", "tester",
+            LocalDateTime.now(), null, false
+        )
+
+        val bbInstance = BuildingBlockInstance(
+            documentId = buildingBlockDocumentId,
+            caseDocumentId = UUID.randomUUID(),
+            processInstanceId = "bb-main-process-instance",
+            activityId = activityId,
+            callerProcessDefinitionId = callerProcessDefinitionId,
+            definition = definition
+        )
+
+        // The sub-process has no row of its own; only the BB main process does.
+        whenever(buildingBlockInstanceService.getByProcessInstanceId(subProcessInstanceId)).thenReturn(null)
+        whenever(buildingBlockInstanceService.getByDocumentId(buildingBlockDocumentId)).thenReturn(bbInstance)
+
+        whenever(processLinkService.getProcessLinks(callerProcessDefinitionId, activityId)).thenReturn(
+            listOf(
+                BuildingBlockProcessLink(
+                    id = UUID.randomUUID(),
+                    processDefinitionId = callerProcessDefinitionId,
+                    activityId = activityId,
+                    activityType = ActivityTypeWithEventName.CALL_ACTIVITY_START,
+                    buildingBlockDefinitionId = buildingBlockDefinitionId,
+                    pluginConfigurationMappings = mapOf("plugin-definition" to pluginConfigurationId),
+                    inputMappings = emptyList()
+                )
+            )
+        )
+
+        val resolved = resolver.resolve(execution, "plugin-definition")
+
+        assertThat(resolved).isEqualTo(pluginConfigurationId)
+    }
+
+    @Test
     fun `should resolve from case link when no call activity mapping exists`() {
         val bbProcessInstanceId = "bb-process-instance"
         val caseDocumentId = UUID.randomUUID()

--- a/documentation/release-notes/13.x.x/13.30.0/README.md
+++ b/documentation/release-notes/13.x.x/13.30.0/README.md
@@ -18,4 +18,8 @@
 
 ## Bugfixes
 
-* New bugfix.
+* **Plugins in building block sub-processes now resolve correctly**
+
+  When a building block's main process called another process inside the same building block via a call activity, plugins
+  in that called process could fail to find their configured plugin instance. The plugin configuration is now resolved
+  reliably in this scenario.


### PR DESCRIPTION
Fixes: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/719

There was an issue with finding the plugin configuration when running a process link when:

- The building block was started as a supporting process through the start menu in the case.
- The building block main process has a call activity to another process.
- The other process uses plugins for process links.