### PR TITLE
Refactor: Value resolver options are now collected by everit schema walker

### DIFF
--- a/backend/case/src/main/java/com/ritense/document/service/DocumentDefinitionService.java
+++ b/backend/case/src/main/java/com/ritense/document/service/DocumentDefinitionService.java
@@ -56,8 +56,6 @@ public interface DocumentDefinitionService {
         CaseDefinitionId caseDefinitionId
     );
 
-    List<String> getPropertyNames(DocumentDefinition definition);
-
     List<CaseDefinitionId> findVersionsByName(String documentDefinitionName);
 
     DeployDocumentDefinitionResult deploy(String schema, CaseDefinitionId caseDefinitionId);

--- a/backend/case/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentDefinitionService.java
+++ b/backend/case/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentDefinitionService.java
@@ -57,13 +57,11 @@ import com.ritense.document.service.result.DeployDocumentDefinitionResultSucceed
 import com.ritense.document.service.result.error.DocumentDefinitionError;
 import com.ritense.logging.LoggableResource;
 import com.ritense.valtimo.contract.BlueprintId;
-import com.ritense.valtimo.contract.buildingblock.BuildingBlockDefinitionId;
 import com.ritense.valtimo.contract.case_.CaseDefinitionChecker;
 import com.ritense.valtimo.contract.case_.CaseDefinitionId;
 import jakarta.validation.ValidationException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -263,17 +261,6 @@ public class JsonSchemaDocumentDefinitionService implements DocumentDefinitionSe
         ));
 
         return optionalDefinition;
-    }
-
-    @Override
-    public List<String> getPropertyNames(DocumentDefinition definition) {
-        return withLoggingContext(JsonSchemaDocumentDefinition.class, definition.id(), () -> {
-            JsonSchemaDocumentDefinition jsonSchemaDocumentDefinition = (JsonSchemaDocumentDefinition) definition;
-            ObjectNode propertiesObjectNode = (ObjectNode) jsonSchemaDocumentDefinition.getSchema()
-                .asJson()
-                .get("properties");
-            return getPropertyNamesFromObjectNode(jsonSchemaDocumentDefinition, propertiesObjectNode, "/");
-        });
     }
 
     @Override
@@ -520,48 +507,6 @@ public class JsonSchemaDocumentDefinitionService implements DocumentDefinitionSe
 
     private Resource[] loadResources() throws IOException {
         return ResourcePatternUtils.getResourcePatternResolver(resourceLoader).getResources(PATH);
-    }
-
-    private List<String> getPropertyNamesFromObjectNode(
-        JsonSchemaDocumentDefinition definition,
-        ObjectNode node,
-        String parent
-    ) {
-        List<String> propertyNames = new ArrayList<>();
-        if (node != null) {
-            node.fields().forEachRemaining((jsonNode -> {
-                if (jsonNode.getValue().has("type")) {
-                    String propertyType = jsonNode.getValue().get("type").asText();
-                    if (isSimpleObject(propertyType)) {
-                        propertyNames.add(parent + jsonNode.getKey());
-                    } else if (propertyType.equals("object")) {
-                        ObjectNode objectNode = (ObjectNode) jsonNode.getValue();
-                        propertyNames.addAll(getPropertyNamesFromObjectNode(
-                            definition,
-                            (ObjectNode) objectNode.get("properties"),
-                            parent.concat(jsonNode.getKey() + "/")
-                        ));
-                    }
-                } else if (jsonNode.getValue().has("$ref")) {
-                    String internalDefinition = jsonNode.getValue().get("$ref").asText().substring(1);
-                    if (internalDefinition.startsWith("/")) {
-                        ObjectNode jsonNode1 = (ObjectNode) definition.schema().at(internalDefinition).get("properties");
-                        propertyNames.addAll(getPropertyNamesFromObjectNode(
-                            definition,
-                            jsonNode1,
-                            parent.concat(jsonNode.getKey() + "/")
-                        ));
-                    }
-                }
-            }));
-        }
-
-        return propertyNames;
-    }
-
-    private boolean isSimpleObject(String propertyType) {
-        List<String> simpleTypes = List.of("string", "boolean", "integer", "number");
-        return simpleTypes.contains(propertyType);
     }
 
     private JsonSchema applyKeyOverride(JsonSchema jsonSchema, String key) {

--- a/backend/case/src/main/kotlin/com/ritense/document/domain/EveritSchemaResolvableOptions.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/domain/EveritSchemaResolvableOptions.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.document.domain
+
+import com.ritense.valueresolver.ValueResolverOption
+import com.ritense.valueresolver.ValueResolverOptionType.COLLECTION
+import com.ritense.valueresolver.ValueResolverOptionType.FIELD
+import org.everit.json.schema.ArraySchema
+import org.everit.json.schema.BooleanSchema
+import org.everit.json.schema.CombinedSchema
+import org.everit.json.schema.ConstSchema
+import org.everit.json.schema.EnumSchema
+import org.everit.json.schema.NumberSchema
+import org.everit.json.schema.ObjectSchema
+import org.everit.json.schema.ReferenceSchema
+import org.everit.json.schema.Schema
+import org.everit.json.schema.StringSchema
+
+/**
+ * Walks the typed everit [Schema] tree and produces the list of resolvable options.
+ */
+@JvmOverloads
+fun Schema.collectResolvableOptions(prefix: String = ""): List<ValueResolverOption> =
+    walkResolvableOptions(prefix, "")
+
+private fun Schema.walkResolvableOptions(prefix: String, path: String): List<ValueResolverOption> {
+    return when (this) {
+        is ObjectSchema ->
+            propertySchemas.flatMap { (key, sub) -> sub.walkResolvableOptions(prefix, "$path/$key") }
+
+        is ArraySchema ->
+            listOf(ValueResolverOption("$prefix$path", COLLECTION, allItemSchema?.collectResolvableOptions().orEmpty()))
+
+        is ReferenceSchema ->
+            referredSchema?.walkResolvableOptions(prefix, path).orEmpty()
+
+        is CombinedSchema ->
+            subschemas.flatMap { it.walkResolvableOptions(prefix, path) }.distinctBy { it.path }
+
+        is StringSchema, is NumberSchema, is BooleanSchema, is EnumSchema, is ConstSchema ->
+            listOf(ValueResolverOption("$prefix$path", FIELD))
+
+        else -> emptyList()
+    }
+}

--- a/backend/case/src/main/kotlin/com/ritense/document/domain/EveritSchemaResolvableOptions.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/domain/EveritSchemaResolvableOptions.kt
@@ -34,22 +34,23 @@ import org.everit.json.schema.StringSchema
  * Walks the typed everit [Schema] tree and produces the list of resolvable options.
  */
 @JvmOverloads
-fun Schema.collectResolvableOptions(prefix: String = ""): List<ValueResolverOption> =
-    walkResolvableOptions(prefix, "")
+fun Schema.collectValueResolverOptions(prefix: String = ""): List<ValueResolverOption> =
+    walkValueResolverOptions(prefix, "")
 
-private fun Schema.walkResolvableOptions(prefix: String, path: String): List<ValueResolverOption> {
+private fun Schema.walkValueResolverOptions(prefix: String, path: String): List<ValueResolverOption> {
     return when (this) {
         is ObjectSchema ->
-            propertySchemas.flatMap { (key, sub) -> sub.walkResolvableOptions(prefix, "$path/$key") }
+            propertySchemas.flatMap { (key, sub) -> sub.walkValueResolverOptions(prefix, "$path/$key") }
 
-        is ArraySchema ->
-            listOf(ValueResolverOption("$prefix$path", COLLECTION, allItemSchema?.collectResolvableOptions().orEmpty()))
+        is ArraySchema -> listOf(
+            ValueResolverOption("$prefix$path", COLLECTION, allItemSchema?.collectValueResolverOptions().orEmpty())
+        )
 
         is ReferenceSchema ->
-            referredSchema?.walkResolvableOptions(prefix, path).orEmpty()
+            referredSchema?.walkValueResolverOptions(prefix, path).orEmpty()
 
         is CombinedSchema ->
-            subschemas.flatMap { it.walkResolvableOptions(prefix, path) }.distinctBy { it.path }
+            subschemas.flatMap { it.walkValueResolverOptions(prefix, path) }.distinctBy { it.path }
 
         is StringSchema, is NumberSchema, is BooleanSchema, is EnumSchema, is ConstSchema ->
             listOf(ValueResolverOption("$prefix$path", FIELD))

--- a/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentDefinitionServiceTest.java
+++ b/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentDefinitionServiceTest.java
@@ -262,25 +262,6 @@ class JsonSchemaDocumentDefinitionServiceTest extends BaseTest {
         );
     }
 
-    @Test
-    void shouldGetPropertyNamesFromReferencedNestedObject() {
-        var definitionName = "combined-schema-additional-property-example";
-        var definition = mockDefinition(definitionName);
-
-        var names = documentDefinitionService.getPropertyNames(definition);
-
-        Collections.sort(names);
-        assertArrayEquals(
-            names.toArray(), new String[]{
-                "/address/city",
-                "/address/country",
-                "/address/number",
-                "/address/province",
-                "/address/streetName"
-            }
-        );
-    }
-
     public JsonSchemaDocumentDefinition mockDefinition(String definitionName) {
         var definition = definitionOfForUnitTests(definitionName);
         when(jsonSchemaDocumentDefinitionRepository.findOne(any(Specification.class)))

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/resolver/CaseDocumentJsonValueResolverFactory.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/resolver/CaseDocumentJsonValueResolverFactory.kt
@@ -27,6 +27,7 @@ import com.jayway.jsonpath.internal.path.PathCompiler
 import com.ritense.authorization.AuthorizationContext
 import com.ritense.document.config.DocumentProperties
 import com.ritense.document.domain.Document
+import com.ritense.document.domain.collectResolvableOptions
 import com.ritense.document.domain.impl.JsonDocumentContent
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.domain.impl.JsonSchemaDocumentDefinition
@@ -43,7 +44,6 @@ import com.ritense.valtimo.contract.case_.CaseDefinitionId
 import com.ritense.valtimo.contract.json.patch.JsonPatchBuilder
 import com.ritense.valueresolver.ValueResolverFactory
 import com.ritense.valueresolver.ValueResolverOption
-import com.ritense.valueresolver.ValueResolverOptionType
 import com.ritense.valueresolver.exception.ValueResolverValidationException
 import org.operaton.bpm.engine.delegate.VariableScope
 import org.springframework.dao.OptimisticLockingFailureException
@@ -235,24 +235,17 @@ class CaseDocumentJsonValueResolverFactory(
 
     override fun getResolvableKeyOptions(caseDefinitionId: CaseDefinitionId): List<ValueResolverOption> {
         val documentDefinition = documentDefinitionService.findByBlueprintId(caseDefinitionId).orElseThrow()
-        val schemaAsNode = documentDefinition.schema
-            .asJson() as ObjectNode
-        return getPropertyNamesFromObjectNode(documentDefinition, schemaAsNode, "$PREFIX:")
+        return documentDefinition.schema.schema.collectResolvableOptions("$PREFIX:")
     }
 
     override fun getResolvableKeyOptions(caseDefinitionKey: String): List<ValueResolverOption> {
-        val documentDefinitionName = caseDefinitionKey
-        val documentDefinition = documentDefinitionService.findActiveByName(documentDefinitionName).orElseThrow()
-        val schemaAsNode = documentDefinition.schema
-            .asJson() as ObjectNode
-        return getPropertyNamesFromObjectNode(documentDefinition, schemaAsNode, "$PREFIX:")
+        val documentDefinition = documentDefinitionService.findActiveByName(caseDefinitionKey).orElseThrow()
+        return documentDefinition.schema.schema.collectResolvableOptions("$PREFIX:")
     }
 
     override fun getResolvableKeyOptions(blueprintId: BlueprintId): List<ValueResolverOption> {
         val documentDefinition = documentDefinitionService.findByBlueprintId(blueprintId).orElseThrow()
-        val schemaAsNode = documentDefinition.schema
-            .asJson() as ObjectNode
-        return getPropertyNamesFromObjectNode(documentDefinition, schemaAsNode, "$PREFIX:")
+        return documentDefinition.schema.schema.collectResolvableOptions("$PREFIX:")
     }
 
     private fun buildJsonPatch(jsonNode: JsonNode, values: Map<String, Any?>) {
@@ -331,64 +324,6 @@ class CaseDocumentJsonValueResolverFactory(
 
     private fun toValueNode(value: Any?): JsonNode {
         return objectMapper.valueToTree(value)
-    }
-
-    private fun getPropertyNamesFromObjectNode(
-        definition: JsonSchemaDocumentDefinition,
-        node: ObjectNode,
-        path: String
-    ): List<ValueResolverOption> {
-        val options: MutableList<ValueResolverOption> = mutableListOf()
-        if (node.has("type")) {
-            val typeNode = node["type"]
-            val propertyType = if (typeNode.isArray && typeNode.size() == 2 && typeNode.any { it.asText() == "null" }) {
-                typeNode.firstOrNull { it.asText() != "null" }?.asText() ?: ""
-            } else if (typeNode.isArray) {
-                ""
-            } else {
-                typeNode.asText()
-            }
-            if (isSimpleObject(propertyType)) {
-                options += ValueResolverOption(path, ValueResolverOptionType.FIELD)
-            } else if (propertyType == "object") {
-                node["properties"]?.fields()?.forEach { jsonNode ->
-                    options += getPropertyNamesFromObjectNode(
-                        definition,
-                        jsonNode.value as ObjectNode,
-                        "$path/${jsonNode.key}"
-                    )
-                }
-            } else if (propertyType == "array") {
-                options += ValueResolverOption(
-                    path,
-                    ValueResolverOptionType.COLLECTION,
-                    node["items"]?.let { getPropertyNamesFromObjectNode(definition, it as ObjectNode, "") }
-                )
-            }
-        } else if (node.has("oneOf") || node.has("anyOf")) {
-            val schemas = (node["oneOf"] ?: node["anyOf"])!!
-            val nonNullSchema = schemas.firstOrNull { it.has("type") && it["type"].asText() != "null" }
-            if (schemas.size() == 2 && schemas.any { it.has("type") && it["type"].asText() == "null" } && nonNullSchema != null) {
-                options += getPropertyNamesFromObjectNode(definition, nonNullSchema as ObjectNode, path)
-            }
-        } else if (node.has("\$ref")) {
-            val internalDefinition = node["\$ref"].asText().substring(1)
-            if (internalDefinition.startsWith("/")) {
-                val referencedNode = definition.schema().at(internalDefinition) as ObjectNode
-                options += getPropertyNamesFromObjectNode(
-                    definition,
-                    referencedNode,
-                    path
-                )
-            }
-        }
-
-        return options
-    }
-
-    private fun isSimpleObject(propertyType: String): Boolean {
-        val simpleTypes = listOf("string", "boolean", "integer", "number")
-        return simpleTypes.contains(propertyType)
     }
 
     companion object {

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/resolver/CaseDocumentJsonValueResolverFactory.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/resolver/CaseDocumentJsonValueResolverFactory.kt
@@ -27,7 +27,7 @@ import com.jayway.jsonpath.internal.path.PathCompiler
 import com.ritense.authorization.AuthorizationContext
 import com.ritense.document.config.DocumentProperties
 import com.ritense.document.domain.Document
-import com.ritense.document.domain.collectResolvableOptions
+import com.ritense.document.domain.collectValueResolverOptions
 import com.ritense.document.domain.impl.JsonDocumentContent
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.domain.impl.JsonSchemaDocumentDefinition
@@ -235,17 +235,17 @@ class CaseDocumentJsonValueResolverFactory(
 
     override fun getResolvableKeyOptions(caseDefinitionId: CaseDefinitionId): List<ValueResolverOption> {
         val documentDefinition = documentDefinitionService.findByBlueprintId(caseDefinitionId).orElseThrow()
-        return documentDefinition.schema.schema.collectResolvableOptions("$PREFIX:")
+        return documentDefinition.schema.schema.collectValueResolverOptions("$PREFIX:")
     }
 
     override fun getResolvableKeyOptions(caseDefinitionKey: String): List<ValueResolverOption> {
         val documentDefinition = documentDefinitionService.findActiveByName(caseDefinitionKey).orElseThrow()
-        return documentDefinition.schema.schema.collectResolvableOptions("$PREFIX:")
+        return documentDefinition.schema.schema.collectValueResolverOptions("$PREFIX:")
     }
 
     override fun getResolvableKeyOptions(blueprintId: BlueprintId): List<ValueResolverOption> {
         val documentDefinition = documentDefinitionService.findByBlueprintId(blueprintId).orElseThrow()
-        return documentDefinition.schema.schema.collectResolvableOptions("$PREFIX:")
+        return documentDefinition.schema.schema.collectValueResolverOptions("$PREFIX:")
     }
 
     private fun buildJsonPatch(jsonNode: JsonNode, values: Map<String, Any?>) {

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/resolver/DocumentJsonValueResolverTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/resolver/DocumentJsonValueResolverTest.kt
@@ -575,21 +575,21 @@ internal class DocumentJsonValueResolverTest {
     }
 
     @Test
-    fun `should not include oneOf field with more than two schemas as FIELD option`() {
+    fun `should include oneOf field with multiple primitive type schemas as FIELD option`() {
         mockDefinition("test")
 
         val options = documentValueResolver.getResolvableKeyOptions("test")
 
-        assertThat(options).noneMatch { it.path == "doc:/string5" }
+        assertThat(options).anyMatch { it.path == "doc:/string5" && it.type == ValueResolverOptionType.FIELD }
     }
 
     @Test
-    fun `should not include union type field without null as FIELD option`() {
+    fun `should include union type field without null as FIELD option`() {
         mockDefinition("test")
 
         val options = documentValueResolver.getResolvableKeyOptions("test")
 
-        assertThat(options).noneMatch { it.path == "doc:/string6" }
+        assertThat(options).anyMatch { it.path == "doc:/string6" && it.type == ValueResolverOptionType.FIELD }
     }
 
     private fun mockDefinition(definitionName: String): JsonSchemaDocumentDefinition {


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/466

Solves:
```
java.lang.ClassCastException: class com.fasterxml.jackson.databind.node.BooleanNode cannot be cast to class com.fasterxml.jackson.databind.node.ObjectNode (com.fasterxml.jackson.databind.node.BooleanNode and com.fasterxml.jackson.databind.node.ObjectNode are in unnamed module of loader org.springframework.boot.loader.launch.LaunchedClassLoader @568db2f2)
    at com.ritense.processdocument.resolver.CaseDocumentJsonValueResolverFactory.getPropertyNamesFromObjectNode(CaseDocumentJsonValueResolverFactory.kt:350)
    at com.ritense.processdocument.resolver.CaseDocumentJsonValueResolverFactory.getResolvableKeyOptions(CaseDocumentJsonValueResolverFactory.kt:240)
    at com.ritense.valueresolver.ValueResolverServiceImpl.getResolvableKeys(ValueResolverServiceImpl.kt:73)
```

Changes:
- Value resolver options are now collected by everit schema walker. More robust
- Also Remove unused code