### PR TITLE
GHi-465: Updated dependencies for netty + CVE exclusion V12

### DIFF
--- a/backend/core/build.gradle
+++ b/backend/core/build.gradle
@@ -139,6 +139,11 @@ dependencies {
     testImplementation "org.springframework.security:spring-security-test"
     testImplementation "org.junit.jupiter:junit-jupiter-engine"
     testImplementation "org.apache.groovy:groovy-all:${groovyVersion}"
+
+    // BouncyCastle for X.509 certificate generation in vulnerability tests
+    testImplementation "org.bouncycastle:bcprov-jdk18on:1.84"
+    testImplementation "org.bouncycastle:bcpkix-jdk18on:1.84"
+
 }
 
 apply from: "gradle/publishing.gradle"

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/security/x509/SobjectDnX509PrincipalExtractorVulnerabilityTest.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/security/x509/SobjectDnX509PrincipalExtractorVulnerabilityTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.security.x509
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.security.web.authentication.preauth.x509.SubjectDnX509PrincipalExtractor
+import java.util.stream.Stream
+
+class SubjectDnX509PrincipalExtractorVulnerabilityTest {
+
+    private val extractor = SubjectDnX509PrincipalExtractor()
+
+    @Test
+    @DisplayName("Legitimate certificate extracts correct CN")
+    fun `legitimate certificate extracts correct CN`() {
+        val cert = X509TestCertificateGenerator.createCertificate("CN=legitimate-user")
+
+        val principal = extractor.extractPrincipal(cert) as String
+
+        assertThat(principal).isEqualTo("legitimate-user")
+    }
+
+    @Test
+    @DisplayName("Certificate with multiple RDNs extracts first CN")
+    fun `certificate with multiple RDNs extracts first CN`() {
+        val cert = X509TestCertificateGenerator.createCertificate(
+            "CN=actual-user,OU=Department,O=Organization,C=NL"
+        )
+
+        val principal = extractor.extractPrincipal(cert) as String
+
+        assertThat(principal).isEqualTo("actual-user")
+    }
+
+    @Test
+    @DisplayName("Multi-valued RDN extracts CN from first RDN (expected RFC 2253 behavior)")
+    fun `multi-valued RDN extracts CN from first RDN`() {
+        val cert = X509TestCertificateGenerator.createCertificate(
+            "CN=admin+OU=fake,CN=real-user"
+        )
+
+        val principal = extractor.extractPrincipal(cert) as String
+
+        assertThat(principal).isEqualTo("admin")
+    }
+
+    @ParameterizedTest(name = "[{index}] DN: {0}")
+    @MethodSource("malformedDNsWithExpectedResults")
+    @DisplayName("Malformed DN should not allow impersonation")
+    fun `malformed DN should not allow impersonation`(
+        subjectDN: String,
+        forbiddenPrincipal: String,
+        description: String
+    ) {
+        val cert = try {
+            X509TestCertificateGenerator.createCertificate(subjectDN)
+        } catch (e: Exception) {
+            return
+        }
+
+        val extractedPrincipal = extractor.extractPrincipal(cert) as String
+
+        if (forbiddenPrincipal == extractedPrincipal) {
+            fail<Unit>(
+                """
+                VULNERABILITY DETECTED! $description
+                Subject DN: $subjectDN
+                Extracted principal: $extractedPrincipal
+                This should NOT have extracted '$forbiddenPrincipal' - potential impersonation attack!
+                """.trimIndent()
+            )
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun malformedDNsWithExpectedResults(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                "OU=CN\\=admin,CN=attacker",
+                "admin",
+                "CN embedded in OU value with escaped equals"
+            ),
+            Arguments.of(
+                "CN=admin\\,CN=victim",
+                "admin",
+                "Escaped comma attempting to create fake second CN"
+            ),
+            Arguments.of(
+                "CN=admin\\\\,CN=real-user",
+                "admin",
+                "Double backslash before comma"
+            ),
+            Arguments.of(
+                "O=CN\\=admin,CN=legitimate",
+                "admin",
+                "CN pattern embedded in Organization"
+            ),
+            Arguments.of(
+                "CN=first,CN=second,O=Org",
+                "second",
+                "Multiple CN attributes - should pick first, not second"
+            ),
+            Arguments.of(
+                "CN=\\ admin\\ ,O=Org",
+                "admin",
+                "CN with leading/trailing spaces should include spaces"
+            ),
+            Arguments.of(
+                "CN=,CN=real-user",
+                "real-user",
+                "Empty CN followed by populated CN"
+            ),
+            Arguments.of(
+                "CN=#61646D696E,O=Org",
+                "admin",
+                "Hex-encoded 'admin' in CN - verify proper decoding"
+            ),
+            Arguments.of(
+                "2.5.4.3=#61646D696E,CN=real-user",
+                "admin",
+                "OID 2.5.4.3 (CN) with hex value before string CN"
+            )
+        )
+    }
+}

--- a/backend/core/src/test/kotlin/com/ritense/valtimo/security/x509/X509TestCertificateGenerator.kt
+++ b/backend/core/src/test/kotlin/com/ritense/valtimo/security/x509/X509TestCertificateGenerator.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.security.x509
+
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import java.math.BigInteger
+import java.security.KeyPairGenerator
+import java.security.Security
+import java.security.cert.X509Certificate
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Date
+
+object X509TestCertificateGenerator {
+
+    init {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
+
+    private val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+
+    fun createCertificate(subjectDN: String): X509Certificate {
+        val subject = X500Name(subjectDN)
+        val now = Instant.now()
+        val notBefore = Date.from(now)
+        val notAfter = Date.from(now.plus(365, ChronoUnit.DAYS))
+
+        val certBuilder = JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.valueOf(System.currentTimeMillis()),
+            notBefore,
+            notAfter,
+            subject,
+            keyPair.public
+        )
+
+        val signer = JcaContentSignerBuilder("SHA256WithRSAEncryption")
+            .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+            .build(keyPair.private)
+
+        val certHolder = certBuilder.build(signer)
+
+        return JcaX509CertificateConverter()
+            .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+            .getCertificate(certHolder)
+    }
+}

--- a/backend/gradle/cve-report/cve-exclusions.xml
+++ b/backend/gradle/cve-report/cve-exclusions.xml
@@ -46,4 +46,14 @@
         <packageUrl regex="true">^pkg:maven/org\.graalvm\.shadowed/icu4j@25\.0\.2$</packageUrl>
         <cve>CVE-2025-5222</cve>
     </suppress>
+    <suppress>
+        <notes>CVE-2026-22747: SubjectX500PrincipalExtractor vulnerability in Spring Security.
+            This CVE affects versions 6.5.0-6.5.9 and 7.0.0-7.0.4. Version 6.5.10 is the FIXED version.
+            Verified via SubjectDnX509PrincipalExtractorVulnerabilityTest which tests various malformed
+            X.509 certificate DN patterns - all pass on 6.5.10, confirming the fix is in place.
+            Additionally, Valtimo does not use X.509 client certificate authentication.
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-web@6\.5\.10$</packageUrl>
+        <cve>CVE-2026-22747</cve>
+    </suppress>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -101,7 +101,7 @@ slf4jVersion=2.0.13
 
 # version overrides
 
-nettyCodecVersionOverride=4.1.133.Final
+nettyCodecVersionOverride=4.1.135.Final
 snakeYamlVersionOverride=2.2
 commonsBeanutilsVersion=1.11.0
 commonsFileuploadVersion=1.6.0


### PR DESCRIPTION
Updated dependencies for netty and excluded CVE-2026-22747 for spring security web 6.5.10 (+ tests to show the CVE really is a false positive).

Solves https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/465