### PR TITLE
 Support variables for create besluit date fields + UI fixes

### DIFF
--- a/documentation/release-notes/13.x.x/13.33.0/README.md
+++ b/documentation/release-notes/13.x.x/13.33.0/README.md
@@ -12,9 +12,11 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Value resolver support for Besluiten API plugin date fields**
 
-  New enhancement explanation.
+  In the Besluiten API plugin, the *create besluit* action can now resolve the publication date, shipment date and
+  response deadline from a value resolver expression (e.g. `pv:publicatiedatum` or `doc:/besluit/publicatiedatum`)
+  instead of only a fixed date, selectable per field via an input-type toggle.
 
 ## Bugfixes
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/besluiten-api-plugin.specification.ts
@@ -66,11 +66,14 @@ const besluitenApiPluginSpecification: PluginSpecification = {
       ingetrokken_overheid: 'Ingetrokken door overheid',
       ingetrokken_belanghebbende: 'Ingetrokken door belanghebbende',
       publicatiedatum: 'Publicatiedatum',
-      publicatiedatumTooltip: 'Datum waarop het besluit gepubliceerd wordt.',
+      publicatiedatumTooltip:
+        'Datum waarop het besluit gepubliceerd wordt. Ondersteunt de value resolver, bijv: pv:publicatiedatum of doc:/besluit/publicatiedatum. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       verzenddatum: 'Verzenddatum',
-      verzenddatumTooltip: 'Datum waarop het besluit verzonden is.',
+      verzenddatumTooltip:
+        'Datum waarop het besluit verzonden is. Ondersteunt de value resolver, bijv: pv:verzenddatum of doc:/besluit/verzenddatum. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       uiterlijkeReactieDatum: 'Uiterlijke reactie datum',
-      uiterlijkeReactieDatumTooltip: 'De datum tot wanneer verweer tegen het besluit mogelijk is.',
+      uiterlijkeReactieDatumTooltip:
+        'De datum tot wanneer verweer tegen het besluit mogelijk is. Ondersteunt de value resolver, bijv: pv:uiterlijkeReactieDatum of doc:/besluit/uiterlijkeReactieDatum. Ondersteunende datum voorbeelden: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       besluitUrlProcessVariable: 'Naam procesvariabele met besluit URL',
       besluitUrlProcessVariableTooltip:
         'Hier moet de naam van de procesvariabele ingevuld worden waarin de besluit URL lokaal staat opgeslagen',
@@ -84,6 +87,9 @@ const besluitenApiPluginSpecification: PluginSpecification = {
       inputTypeBesluitToggle: 'Invoertype Besluit-URL',
       inputTypeStartingDateToggle: 'Invoertype Begindatum',
       inputTypeExpirationDateToggle: 'Invoertype vervaldatum',
+      inputTypePublicationDateToggle: 'Invoertype publicatiedatum',
+      inputTypeSendDateToggle: 'Invoertype verzenddatum',
+      inputTypeResponseDeadlineToggle: 'Invoertype uiterlijke reactie datum',
       text: 'Tekst',
       selection: 'Selectie',
       caseDefinition: 'Dossierdefinitie',
@@ -135,12 +141,14 @@ const besluitenApiPluginSpecification: PluginSpecification = {
       ingetrokken_overheid: 'Withdrawn by government',
       ingetrokken_belanghebbende: 'Withdrawn by interested party',
       publicatiedatum: 'Publication date',
-      publicatiedatumTooltip: 'Date on which the besluit is published.',
+      publicatiedatumTooltip:
+        'Date on which the besluit is published. Supports the value resolver eg: pv:publicatiedatum or doc:/besluit/publicatiedatum. Supporting date format examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       verzenddatum: 'Shipment date',
-      verzenddatumTooltip: 'Date on which the besluit was sent.',
+      verzenddatumTooltip:
+        'Date on which the besluit was sent. Supports the value resolver eg: pv:verzenddatum or doc:/besluit/verzenddatum. Supporting date format examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       uiterlijkeReactieDatum: 'Response deadline',
       uiterlijkeReactieDatumTooltip:
-        'The date until which a defense against the decision is possible.',
+        'The date until which a defense against the decision is possible. Supports the value resolver eg: pv:uiterlijkeReactieDatum or doc:/besluit/uiterlijkeReactieDatum. Supporting date format examples: 2024-04-01, 2024-04-01T12:10:00, 2024-04-01T12:10:06.069Z.',
       besluitUrlProcessVariable: 'Process variable name with besluit URL',
       besluitUrlProcessVariableTooltip:
         'Here must be entered the name of the process variable in which the besluit URL is stored locally',
@@ -154,6 +162,9 @@ const besluitenApiPluginSpecification: PluginSpecification = {
       inputTypeBesluitToggle: 'Input type Besluit-URL',
       inputTypeStartingDateToggle: 'Input type start date',
       inputTypeExpirationDateToggle: 'Input type expiration date',
+      inputTypePublicationDateToggle: 'Input type publication date',
+      inputTypeSendDateToggle: 'Input type shipment date',
+      inputTypeResponseDeadlineToggle: 'Input type response deadline',
       text: 'Text',
       selection: 'Selection',
       caseDefinition: 'Case definition',

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/create-zaak-besluit/create-zaak-besluit-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/create-zaak-besluit/create-zaak-besluit-configuration.component.html
@@ -22,6 +22,9 @@
     selectedInputOption: selectedInputOption$ | async,
     selectedStartDateInputOption: selectedStartDateInputOption$ | async,
     selectedExpirationDateInputOption: selectedExpirationDateInputOption$ | async,
+    selectedPublicationDateInputOption: selectedPublicationDateInputOption$ | async,
+    selectedSendDateInputOption: selectedSendDateInputOption$ | async,
+    selectedResponseDeadlineInputOption: selectedResponseDeadlineInputOption$ | async,
     pluginId: pluginId$ | async,
     loading: loading$ | async,
     context: context$ | async,
@@ -39,7 +42,7 @@
         [disabled]="obs.disabled"
         [title]="'inputTypeBesluitToggle' | pluginTranslate: obs.pluginId | async"
         [radioValues]="inputTypeOptions$ | async"
-        [defaultValue]="selectedInputOption$ | async"
+        [defaultValue]="obs.prefill?.inputTypeBesluitToggle || (selectedInputOption$ | async)"
         [margin]="true"
       >
       </v-radio>
@@ -131,7 +134,7 @@
         [disabled]="obs.disabled"
         [required]="true"
         [tooltip]="'ingangsdatumTooltip' | pluginTranslate: obs.pluginId | async"
-        [widthPx]="100"
+        [widthPx]="350"
         [margin]="true"
       ></v-date-picker>
 
@@ -167,7 +170,7 @@
         [disabled]="obs.disabled"
         [required]="false"
         [tooltip]="'vervaldatumTooltip' | pluginTranslate: obs.pluginId | async"
-        [widthPx]="100"
+        [widthPx]="350"
         [margin]="true"
       ></v-date-picker>
 
@@ -183,36 +186,111 @@
         [margin]="true"
       ></v-select>
 
+      <v-radio
+        name="inputTypePublicationDateToggle"
+        [disabled]="obs.disabled"
+        [title]="'inputTypePublicationDateToggle' | pluginTranslate: obs.pluginId | async"
+        [radioValues]="publicationDateInputTypeOptions$ | async"
+        [defaultValue]="obs.prefill?.inputTypePublicationDateToggle || 'selection'"
+        [margin]="true"
+      >
+      </v-radio>
+
+      <v-input
+        *ngIf="obs.selectedPublicationDateInputOption === 'text'"
+        name="publicatiedatum"
+        [title]="'publicatiedatum' | pluginTranslate: obs.pluginId | async"
+        [defaultValue]="obs.prefill?.publicatiedatum"
+        [disabled]="obs.disabled"
+        [required]="false"
+        [trim]="true"
+        [tooltip]="'publicatiedatumTooltip' | pluginTranslate: obs.pluginId | async"
+        [widthPx]="350"
+        [margin]="true"
+      >
+      </v-input>
+
       <v-date-picker
+        *ngIf="obs.selectedPublicationDateInputOption === 'selection'"
         name="publicatiedatum"
         [title]="'publicatiedatum' | pluginTranslate: obs.pluginId | async"
         [defaultDate]="obs.prefill?.publicatiedatum"
         [disabled]="obs.disabled"
         [required]="false"
         [tooltip]="'publicatiedatumTooltip' | pluginTranslate: obs.pluginId | async"
-        [widthPx]="100"
+        [widthPx]="350"
         [margin]="true"
       ></v-date-picker>
 
+      <v-radio
+        name="inputTypeSendDateToggle"
+        [disabled]="obs.disabled"
+        [title]="'inputTypeSendDateToggle' | pluginTranslate: obs.pluginId | async"
+        [radioValues]="sendDateInputTypeOptions$ | async"
+        [defaultValue]="obs.prefill?.inputTypeSendDateToggle || 'selection'"
+        [margin]="true"
+      >
+      </v-radio>
+
+      <v-input
+        *ngIf="obs.selectedSendDateInputOption === 'text'"
+        name="verzenddatum"
+        [title]="'verzenddatum' | pluginTranslate: obs.pluginId | async"
+        [defaultValue]="obs.prefill?.verzenddatum"
+        [disabled]="obs.disabled"
+        [required]="false"
+        [trim]="true"
+        [tooltip]="'verzenddatumTooltip' | pluginTranslate: obs.pluginId | async"
+        [widthPx]="350"
+        [margin]="true"
+      >
+      </v-input>
+
       <v-date-picker
+        *ngIf="obs.selectedSendDateInputOption === 'selection'"
         name="verzenddatum"
         [title]="'verzenddatum' | pluginTranslate: obs.pluginId | async"
         [defaultDate]="obs.prefill?.verzenddatum"
         [disabled]="obs.disabled"
         [required]="false"
         [tooltip]="'verzenddatumTooltip' | pluginTranslate: obs.pluginId | async"
-        [widthPx]="100"
+        [widthPx]="350"
         [margin]="true"
       ></v-date-picker>
 
+      <v-radio
+        name="inputTypeResponseDeadlineToggle"
+        [disabled]="obs.disabled"
+        [title]="'inputTypeResponseDeadlineToggle' | pluginTranslate: obs.pluginId | async"
+        [radioValues]="responseDeadlineInputTypeOptions$ | async"
+        [defaultValue]="obs.prefill?.inputTypeResponseDeadlineToggle || 'selection'"
+        [margin]="true"
+      >
+      </v-radio>
+
+      <v-input
+        *ngIf="obs.selectedResponseDeadlineInputOption === 'text'"
+        name="uiterlijkeReactieDatum"
+        [title]="'uiterlijkeReactieDatum' | pluginTranslate: obs.pluginId | async"
+        [defaultValue]="obs.prefill?.uiterlijkeReactieDatum"
+        [disabled]="obs.disabled"
+        [required]="false"
+        [trim]="true"
+        [tooltip]="'uiterlijkeReactieDatumTooltip' | pluginTranslate: obs.pluginId | async"
+        [widthPx]="350"
+        [margin]="true"
+      >
+      </v-input>
+
       <v-date-picker
+        *ngIf="obs.selectedResponseDeadlineInputOption === 'selection'"
         name="uiterlijkeReactieDatum"
         [title]="'uiterlijkeReactieDatum' | pluginTranslate: obs.pluginId | async"
         [defaultDate]="obs.prefill?.uiterlijkeReactieDatum"
         [disabled]="obs.disabled"
         [required]="false"
         [tooltip]="'uiterlijkeReactieDatumTooltip' | pluginTranslate: obs.pluginId | async"
-        [widthPx]="100"
+        [widthPx]="350"
         [margin]="true"
       ></v-date-picker>
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/create-zaak-besluit/create-zaak-besluit-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/components/create-zaak-besluit/create-zaak-besluit-configuration.component.ts
@@ -80,6 +80,9 @@ export class CreateZaakBesluitConfigurationComponent
   readonly selectedInputOption$ = new BehaviorSubject<InputOption>('selection');
   readonly selectedStartDateInputOption$ = new BehaviorSubject<InputOption>('selection');
   readonly selectedExpirationDateInputOption$ = new BehaviorSubject<InputOption>('selection');
+  readonly selectedPublicationDateInputOption$ = new BehaviorSubject<InputOption>('selection');
+  readonly selectedSendDateInputOption$ = new BehaviorSubject<InputOption>('selection');
+  readonly selectedResponseDeadlineInputOption$ = new BehaviorSubject<InputOption>('selection');
   readonly loading$ = new BehaviorSubject<boolean>(true);
   readonly pluginId$ = new BehaviorSubject<string>('');
   readonly clearBesluitSelection$ = new Subject<void>();
@@ -101,6 +104,9 @@ export class CreateZaakBesluitConfigurationComponent
 
   readonly startDateInputTypeOptions$ = this.inputTypeOptions$;
   readonly expirationDateInputTypeOptions$ = this.inputTypeOptions$;
+  readonly publicationDateInputTypeOptions$ = this.inputTypeOptions$;
+  readonly sendDateInputTypeOptions$ = this.inputTypeOptions$;
+  readonly responseDeadlineInputTypeOptions$ = this.inputTypeOptions$;
 
   private readonly formValue$ = new BehaviorSubject<CreateZaakBesluitConfig | null>(null);
   private readonly valid$ = new BehaviorSubject<boolean>(false);
@@ -138,6 +144,18 @@ export class CreateZaakBesluitConfigurationComponent
 
     if (formValue.inputTypeExpirationDateToggle) {
       this.selectedExpirationDateInputOption$.next(formValue.inputTypeExpirationDateToggle);
+    }
+
+    if (formValue.inputTypePublicationDateToggle) {
+      this.selectedPublicationDateInputOption$.next(formValue.inputTypePublicationDateToggle);
+    }
+
+    if (formValue.inputTypeSendDateToggle) {
+      this.selectedSendDateInputOption$.next(formValue.inputTypeSendDateToggle);
+    }
+
+    if (formValue.inputTypeResponseDeadlineToggle) {
+      this.selectedResponseDeadlineInputOption$.next(formValue.inputTypeResponseDeadlineToggle);
     }
   }
 

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/besluiten-api/models/config.ts
@@ -39,6 +39,9 @@ interface CreateZaakBesluitConfig {
   inputTypeBesluitToggle?: InputOption;
   inputTypeStartingDateToggle?: InputOption;
   inputTypeExpirationDateToggle?: InputOption;
+  inputTypePublicationDateToggle?: InputOption;
+  inputTypeSendDateToggle?: InputOption;
+  inputTypeResponseDeadlineToggle?: InputOption;
 }
 interface LinkDocumentToBesluitConfig {
   besluitUrl: string;


### PR DESCRIPTION
 for Besluiten api

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/346

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Go to Process link → add/edit a Besluiten API → "Create Zaak Besluit" action.
- [ ] For Publicatiedatum, Verzenddatum, and Uiterlijke reactie datum you should now see a radio toggle (text vs. selection):
    - selection → date picker (default)
    - text → free-text input accepting pv:publicatiedatum or doc:/besluit/publicatiedatum.
- [ ] Verify the tooltips mention the value resolver + date format examples.
- [ ] Save, reopen → confirm prefill restores the chosen toggle + values.
- [ ] Confirm the resolved dates are correct on the Case Details

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
