### PR TITLE
Story 292: Add a Modal/Panel display type option to the start event process link

### DIFF
--- a/backend/form/src/main/kotlin/com/ritense/form/processlink/FormProcessLinkActivityHandler.kt
+++ b/backend/form/src/main/kotlin/com/ritense/form/processlink/FormProcessLinkActivityHandler.kt
@@ -82,6 +82,7 @@ class FormProcessLinkActivityHandler(
             FormTaskOpenResultProperties(
                 processLink.formDefinitionId,
                 formDefinition.asJson(),
+                formDisplayType = processLink.formDisplayType,
                 formSize = processLink.formSize
             )
         )

--- a/backend/form/src/test/kotlin/com/ritense/form/service/FormProcessLinkActivityHandlerIntTest.kt
+++ b/backend/form/src/test/kotlin/com/ritense/form/service/FormProcessLinkActivityHandlerIntTest.kt
@@ -22,6 +22,7 @@ import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthor
 import com.ritense.document.domain.impl.request.NewDocumentRequest
 import com.ritense.document.service.DocumentService
 import com.ritense.form.BaseIntegrationTest
+import com.ritense.form.domain.FormDisplayType
 import com.ritense.form.domain.FormProcessLink
 import com.ritense.form.domain.FormSizes
 import com.ritense.form.domain.request.CreateFormDefinitionRequest
@@ -81,6 +82,7 @@ internal class FormProcessLinkActivityHandlerIntTest : BaseIntegrationTest() {
             activityType = ActivityTypeWithEventName.START_EVENT_START,
             formDefinitionId = UUID.fromString(formDefinition.id?.toString()),
             viewModelEnabled = false,
+            formDisplayType = FormDisplayType.panel,
             formSize = FormSizes.large
         )
         runWithoutAuthorization {
@@ -93,6 +95,7 @@ internal class FormProcessLinkActivityHandlerIntTest : BaseIntegrationTest() {
 
             assertEquals("form", result.type)
             assertEquals(formDefinition.id?.toString(), result.properties.formDefinitionId.toString())
+            assertEquals(FormDisplayType.panel, result.properties.formDisplayType)
             assertEquals(FormSizes.large, result.properties.formSize)
             JSONAssert.assertEquals(
                 getForm(),

--- a/documentation/release-notes/13.x.x/13.33.0/README.md
+++ b/documentation/release-notes/13.x.x/13.33.0/README.md
@@ -36,14 +36,6 @@
   Input and output mappings on building block call activities can now reference nested paths in the case or building
   block document (e.g. `/person/name`), instead of only top-level properties.
 
-* **Start supporting process forms in the case detail panel**
-
-  The process link configuration of a start event now offers a **Display type** option (Modal or Panel), defaulting to
-  **Modal**. When a supporting process is started from the **Start** button with its start event configured as
-  **Panel**, the start form opens in the case detail panel, the same way user task forms can. This requires the active
-  tab to expose a panel. Otherwise the form opens in the modal as before. Form types that rely on view models or custom
-  UI components always open in the modal.
-
 ## Bugfixes
 
 * **Empty building block mapping dropdowns**

--- a/documentation/release-notes/13.x.x/13.33.0/README.md
+++ b/documentation/release-notes/13.x.x/13.33.0/README.md
@@ -36,6 +36,14 @@
   Input and output mappings on building block call activities can now reference nested paths in the case or building
   block document (e.g. `/person/name`), instead of only top-level properties.
 
+* **Start supporting process forms in the case detail panel**
+
+  The process link configuration of a start event now offers a **Display type** option (Modal or Panel), defaulting to
+  **Modal**. When a supporting process is started from the **Start** button with its start event configured as
+  **Panel**, the start form opens in the case detail panel, the same way user task forms can. This requires the active
+  tab to expose a panel. Otherwise the form opens in the modal as before. Form types that rely on view models or custom
+  UI components always open in the modal.
+
 ## Bugfixes
 
 * **Empty building block mapping dropdowns**

--- a/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.html
+++ b/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.html
@@ -62,6 +62,7 @@
         caseDetailLayout: caseDetailLayout$ | async,
         openTaskAndProcessLinkInModal: openTaskAndProcessLinkInModal$ | async,
         taskAndProcessLinkOpenedInPanel: taskAndProcessLinkOpenedInPanel$ | async,
+        startFormPanel: startFormPanel$ | async,
         isDarkMode: isDarkMode$ | async,
         compactMode: compactMode$ | async,
         tabContentContainerMaxHeight: tabContentContainerMaxHeight$ | async,
@@ -124,15 +125,23 @@
         >
           @if (tabContentObs.showTaskList) {
             <div class="task-panel">
-              @if (!tabContentObs.taskAndProcessLinkOpenedInPanel) {
-                <valtimo-case-detail-task-list
-                  [openTaskAndProcessLinkInModal]="tabContentObs.openTaskAndProcessLinkInModal"
-                  (taskClickEvent)="onTaskClickEvent($event)"
-                  (formSubmitEvent)="onFormSubmitEvent()"
-                ></valtimo-case-detail-task-list>
-              }
+              @if (tabContentObs.startFormPanel) {
+                <div class="start-form-panel">
+                  <section class="start-form-panel__header">
+                    <h4 class="start-form-panel__title">{{ tabContentObs.startFormPanel.title }}</h4>
 
-              @if (tabContentObs.taskAndProcessLinkOpenedInPanel) {
+                    <button cdsButton="ghost" [iconOnly]="true" (click)="onStartFormPanelClose()">
+                      <svg cdsIcon="close" size="16"></svg>
+                    </button>
+                  </section>
+
+                  <section class="start-form-panel__body">
+                    <ng-container
+                      *ngTemplateOutlet="tabContentObs.startFormPanel.template"
+                    ></ng-container>
+                  </section>
+                </div>
+              } @else if (tabContentObs.taskAndProcessLinkOpenedInPanel) {
                 <valtimo-case-detail-task-detail
                   [taskAndProcessLink]="tabContentObs.taskAndProcessLinkOpenedInPanel"
                   (activeChange)="onActiveChangeEvent($event)"
@@ -141,6 +150,12 @@
                   (dueDateChanged)="onDueDateChanged()"
                 >
                 </valtimo-case-detail-task-detail>
+              } @else {
+                <valtimo-case-detail-task-list
+                  [openTaskAndProcessLinkInModal]="tabContentObs.openTaskAndProcessLinkInModal"
+                  (taskClickEvent)="onTaskClickEvent($event)"
+                  (formSubmitEvent)="onFormSubmitEvent()"
+                ></valtimo-case-detail-task-list>
               }
             </div>
           }

--- a/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.scss
+++ b/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.scss
@@ -119,6 +119,38 @@
   transition: height 0.15s ease-in-out;
 }
 
+.start-form-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cds-layer);
+  padding: 8px 16px 16px 16px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  &__title {
+    margin: 0;
+    color: var(--cds-text-primary);
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 24px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__body {
+    flex: 1;
+    overflow-y: auto;
+  }
+}
+
 .split-area {
   &__content {
     height: 100% !important;

--- a/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.ts
+++ b/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.ts
@@ -26,7 +26,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import {ActivatedRoute, NavigationStart, ParamMap, Params, Router} from '@angular/router';
-import {ChevronDown16} from '@carbon/icons';
+import {ChevronDown16, Close16} from '@carbon/icons';
 import {TranslateService} from '@ngx-translate/core';
 import {PermissionService} from '@valtimo/access-control';
 import {
@@ -124,6 +124,8 @@ export class CaseDetailComponent implements AfterViewInit, OnDestroy {
 
   public readonly taskAndProcessLinkOpenedInPanel$ =
     this.caseDetailLayoutService.taskAndProcessLinkOpenedInPanel$;
+
+  public readonly startFormPanel$ = this.caseDetailLayoutService.startFormPanel$;
 
   private readonly _caseStatusKey$ = new BehaviorSubject<string | null | 'NOT_AVAILABLE'>(null);
 
@@ -374,7 +376,7 @@ export class CaseDetailComponent implements AfterViewInit, OnDestroy {
     this.initBreadcrumb();
     this.openWidthObserver();
     this.pageTitleService.disableReset();
-    this.iconService.registerAll([ChevronDown16]);
+    this.iconService.registerAll([ChevronDown16, Close16]);
     this.setDocumentStyle();
     this.enableResetOnBackNavigation();
     this.openWidgetProcessSubscription();
@@ -409,12 +411,19 @@ export class CaseDetailComponent implements AfterViewInit, OnDestroy {
   }
 
   public startItem(item: StartableItem): void {
-    this.supportingProcessStart.openModalForStartableItem(
-      item,
-      this.documentId,
-      this.caseDefinitionKey,
-      this.caseDefinitionVersionTag
-    );
+    this.showTaskList$.pipe(take(1)).subscribe(showTaskList => {
+      this.supportingProcessStart.openModalForStartableItem(
+        item,
+        this.documentId,
+        this.caseDefinitionKey,
+        this.caseDefinitionVersionTag,
+        showTaskList
+      );
+    });
+  }
+
+  public onStartFormPanelClose(): void {
+    this.supportingProcessStart.closePanel();
   }
 
   public openWidgetProcessSubscription(): void {
@@ -558,6 +567,7 @@ export class CaseDetailComponent implements AfterViewInit, OnDestroy {
     // }
 
     if (!tab.showTasks) this.openTaskAndProcessLinkInModal$.next(null);
+    this.supportingProcessStart.closePanel();
     this.tabLoader.load(tab);
     this.setDocumentStyle();
   }

--- a/frontend/projects/valtimo/case/src/lib/components/case-supporting-process-start-modal/case-supporting-process-start-modal.component.html
+++ b/frontend/projects/valtimo/case/src/lib/components/case-supporting-process-start-modal/case-supporting-process-start-modal.component.html
@@ -22,11 +22,7 @@
 >
   <cds-modal-header [showCloseButton]="true" (closeSelect)="onCloseSelect()" [cdsLayer]="1"
     ><h3 cdsModalHeaderHeading>
-      {{
-        (processDefinitionKey$ | async | translate) !== (processDefinitionKey$ | async)
-          ? (processDefinitionKey$ | async | translate)
-          : (processName$ | async)
-      }}
+      {{ modalTitle$ | async }}
     </h3>
   </cds-modal-header>
 
@@ -34,62 +30,69 @@
     <ng-template #formViewModelComponent></ng-template>
     <ng-template #formCustomComponent></ng-template>
 
-    @if (isLoading$ | async) {
-      <div class="loading-container">
-        <cds-loading size="sm"></cds-loading>
-      </div>
-    }
-
-    @if (
-      !(isLoading$ | async) &&
-      (startProcessLinkType$ | async) === 'form' &&
-      (formDefinition$ | async)
-    ) {
-      <valtimo-form-io
-        #form
-        [submission]="submission$ | async"
-        [form]="formDefinition$ | async"
-        [options]="options$ | async"
-        (submit)="onSubmit($event)"
-      ></valtimo-form-io>
-    }
-
-    @if (
-      !(isLoading$ | async) &&
-      (startProcessLinkType$ | async) === 'form-flow' &&
-      (formFlowInstanceId$ | async)
-    ) {
-      <valtimo-form-flow
-        #formFlow
-        [formFlowInstanceId]="formFlowInstanceId$ | async"
-        (formFlowComplete)="formSubmitted()"
-      ></valtimo-form-flow>
-    }
-
-    @if (
-      !(isLoading$ | async) &&
-      !(formDefinition$ | async) &&
-      !(formFlowInstanceId$ | async) &&
-      (startProcessLinkType$ | async) !== 'ui-component'
-    ) {
-      <div class="bg-warning text-black mb-0 p-3 text-center">
-        {{
-          isAdmin
-            ? ('formManagement.noFormDefinitionFoundAdmin' | translate)
-            : ('formManagement.noFormDefinitionFoundUser' | translate)
-        }}
-      </div>
-
-      <div class="mb-0 mt-4 p-3 text-center">
-        <button
-          class="btn btn-secondary btn-space"
-          type="button"
-          (click)="gotoFormLinkScreen()"
-          id="form-link-button"
-        >
-          {{ 'formManagement.gotoProcessLinksButton' | translate }}
-        </button>
-      </div>
+    @if (modalOpen$ | async) {
+      <ng-container *ngTemplateOutlet="startForm"></ng-container>
     }
   </section>
 </cds-modal>
+
+<ng-template #startForm>
+  @if (isLoading$ | async) {
+    <div class="loading-container">
+      <cds-loading size="sm"></cds-loading>
+    </div>
+  }
+
+  @if (
+    !(isLoading$ | async) &&
+    (startProcessLinkType$ | async) === 'form' &&
+    (formDefinition$ | async)
+  ) {
+    <valtimo-form-io
+      #form
+      [submission]="submission$ | async"
+      [form]="formDefinition$ | async"
+      [options]="options$ | async"
+      [errors]="formErrors$ | async"
+      (submit)="onSubmit($event)"
+    ></valtimo-form-io>
+  }
+
+  @if (
+    !(isLoading$ | async) &&
+    (startProcessLinkType$ | async) === 'form-flow' &&
+    (formFlowInstanceId$ | async)
+  ) {
+    <valtimo-form-flow
+      #formFlow
+      [formFlowInstanceId]="formFlowInstanceId$ | async"
+      (formFlowComplete)="formSubmitted()"
+    ></valtimo-form-flow>
+  }
+
+  @if (
+    !(isLoading$ | async) &&
+    !(formDefinition$ | async) &&
+    !(formFlowInstanceId$ | async) &&
+    (startProcessLinkType$ | async) !== 'ui-component'
+  ) {
+    <div class="bg-warning text-black mb-0 p-3 text-center">
+      {{
+        isAdmin
+          ? ('formManagement.noFormDefinitionFoundAdmin' | translate)
+          : ('formManagement.noFormDefinitionFoundUser' | translate)
+      }}
+    </div>
+
+    <div class="mb-0 mt-4 p-3 text-center">
+      <button
+        class="btn btn-secondary btn-space"
+        type="button"
+        (click)="gotoFormLinkScreen()"
+        id="form-link-button"
+      >
+        {{ 'formManagement.gotoProcessLinksButton' | translate }}
+      </button>
+    </div>
+  }
+</ng-template>

--- a/frontend/projects/valtimo/case/src/lib/components/case-supporting-process-start-modal/case-supporting-process-start-modal.component.ts
+++ b/frontend/projects/valtimo/case/src/lib/components/case-supporting-process-start-modal/case-supporting-process-start-modal.component.ts
@@ -22,11 +22,13 @@ import {
   OnDestroy,
   Optional,
   Output,
+  TemplateRef,
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
 import {Router} from '@angular/router';
+import {TranslateService} from '@ngx-translate/core';
 import {FormioBeforeSubmit, FormioForm} from '@formio/angular';
 import {
   CarbonModalSize,
@@ -41,13 +43,15 @@ import {
   FORM_CUSTOM_COMPONENT_TOKEN,
   FormCustomComponent,
   FormCustomComponentConfig,
+  FormDisplayType,
   FormSize,
   formSizeToCarbonModalSizeMap,
   ProcessLinkService,
 } from '@valtimo/process-link';
 import {BehaviorSubject, combineLatest, Subscription, switchMap} from 'rxjs';
-import {take} from 'rxjs/operators';
+import {map, take} from 'rxjs/operators';
 import {FORM_VIEW_MODEL_TOKEN, FormViewModel} from '@valtimo/shared';
+import {CaseDetailLayoutService} from '../../services';
 
 const DEFAULT_START_MODAL_SIZE: CarbonModalSize = 'sm';
 
@@ -64,6 +68,7 @@ export class CaseSupportingProcessStartModalComponent implements OnDestroy {
   public formViewModelDynamicContainer: ViewContainerRef;
   @ViewChild('formCustomComponent', {static: false, read: ViewContainerRef})
   public formCustomComponentDynamicContainer: ViewContainerRef;
+  @ViewChild('startForm', {static: false}) public startFormTemplate: TemplateRef<any>;
 
   @Input() isAdmin: boolean;
   @Output() formSubmit = new EventEmitter();
@@ -83,6 +88,7 @@ export class CaseSupportingProcessStartModalComponent implements OnDestroy {
   public readonly modalOpen$ = new BehaviorSubject<boolean>(false);
   public readonly modalSize$ = new BehaviorSubject<CarbonModalSize>(DEFAULT_START_MODAL_SIZE);
   public readonly isLoading$ = new BehaviorSubject<boolean>(true);
+  public readonly formErrors$ = new BehaviorSubject<string[]>([]);
   private readonly _formCustomComponentConfig$ = new BehaviorSubject<
     FormCustomComponentConfig | {}
   >({});
@@ -92,12 +98,30 @@ export class CaseSupportingProcessStartModalComponent implements OnDestroy {
 
   public readonly closeModalEvent = new EventEmitter();
 
+  public readonly modalTitle$ = combineLatest([
+    this.processDefinitionKey$,
+    this.processName$,
+    this.translateService.stream('key'),
+  ]).pipe(
+    map(([processDefinitionKey, processName]) => {
+      const translated = this.translateService.instant(processDefinitionKey);
+      return translated !== processDefinitionKey ? translated : processName;
+    })
+  );
+
+  // Whether the active tab exposes a panel and the start form may render in it.
+  private _panelAvailable = false;
+  // Whether the current start form is being rendered in the panel instead of the modal.
+  private _displayInPanel = false;
+
   private _formViewModelSubscription!: Subscription;
 
   constructor(
     private readonly router: Router,
     private readonly processService: ProcessService,
     private readonly processLinkService: ProcessLinkService,
+    private readonly translateService: TranslateService,
+    private readonly caseDetailLayoutService: CaseDetailLayoutService,
     @Optional() @Inject(FORM_VIEW_MODEL_TOKEN) private readonly formViewModel: FormViewModel,
     @Optional()
     @Inject(FORM_CUSTOM_COMPONENT_TOKEN)
@@ -130,31 +154,61 @@ export class CaseSupportingProcessStartModalComponent implements OnDestroy {
       .subscribe(startProcessResult => {
         this.isLoading$.next(false);
 
-        if (startProcessResult) {
-          this.startProcessLinkType$.next(startProcessResult.type);
-
-          switch (startProcessResult.type) {
-            case 'form':
-              this.formDefinition$.next(startProcessResult.properties.prefilledForm);
-              this.processLinkId$.next(startProcessResult.processLinkId);
-              this.setModalSize(startProcessResult.properties.formSize);
-              break;
-            case 'form-flow':
-              this.formFlowInstanceId$.next(startProcessResult.properties.formFlowInstanceId);
-              break;
-            case 'form-view-model':
-              this.formDefinition$.next(startProcessResult.properties.formDefinition);
-              this.setFormViewModelComponent(startProcessResult.properties.formName);
-              this.openCdsModal();
-              break;
-            case 'ui-component':
-              this.setFormCustomComponent(startProcessResult.properties.componentKey);
-              this.openCdsModal();
-              break;
-          }
+        if (!startProcessResult) {
+          // No process link configured: show the modal with the "no form" guidance.
           this.openCdsModal();
+          return;
+        }
+
+        this.startProcessLinkType$.next(startProcessResult.type);
+
+        const displayType: FormDisplayType | undefined =
+          startProcessResult.properties?.formDisplayType;
+        const formSize: FormSize = startProcessResult.properties?.formSize ?? 'medium';
+
+        switch (startProcessResult.type) {
+          case 'form':
+            this.formDefinition$.next(startProcessResult.properties.prefilledForm);
+            this.processLinkId$.next(startProcessResult.processLinkId);
+            this.openStartForm(displayType, formSize);
+            break;
+          case 'form-flow':
+            this.formFlowInstanceId$.next(startProcessResult.properties.formFlowInstanceId);
+            this.openStartForm(displayType, formSize);
+            break;
+          case 'form-view-model':
+            // Dynamically rendered forms rely on view-container refs that only exist inside the
+            // modal, so they always open in the modal regardless of the configured display type.
+            this.formDefinition$.next(startProcessResult.properties.formDefinition);
+            this.setFormViewModelComponent(startProcessResult.properties.formName);
+            this.openCdsModal();
+            break;
+          case 'ui-component':
+            this.setFormCustomComponent(startProcessResult.properties.componentKey);
+            this.openCdsModal();
+            break;
         }
       });
+  }
+
+  private openStartForm(displayType: FormDisplayType | undefined, formSize: FormSize): void {
+    if (this._panelAvailable && displayType === 'panel') {
+      this._displayInPanel = true;
+      combineLatest([this.processDefinitionKey$, this.processName$])
+        .pipe(take(1))
+        .subscribe(([processDefinitionKey, processName]) => {
+          const translated = this.translateService.instant(processDefinitionKey);
+          const title = translated !== processDefinitionKey ? translated : processName;
+          this.caseDetailLayoutService.openStartFormPanel(
+            {template: this.startFormTemplate, title},
+            formSize
+          );
+        });
+    } else {
+      this._displayInPanel = false;
+      this.setModalSize(formSize);
+      this.openCdsModal();
+    }
   }
 
   private setModalSize(formSize?: FormSize): void {
@@ -167,8 +221,12 @@ export class CaseSupportingProcessStartModalComponent implements OnDestroy {
     item: StartableItem,
     documentId: string,
     caseDefinitionKey: string,
-    caseDefinitionVersionTag: string
+    caseDefinitionVersionTag: string,
+    panelAvailable = false
   ): void {
+    // Reset any panel left open by a previous start so its content does not linger.
+    this.closeStartForm();
+    this._panelAvailable = panelAvailable;
     this.isLoading$.next(true);
     this.documentId$.next(documentId);
     this.caseDefinitionKey$.next(caseDefinitionKey);
@@ -196,11 +254,11 @@ export class CaseSupportingProcessStartModalComponent implements OnDestroy {
     this.options$.next(options);
 
     this.loadProcessLink();
-    this.openCdsModal();
   }
 
   public onSubmit(submission: FormioSubmission): void {
     this.formioSubmission$.next(submission);
+    this.formErrors$.next([]);
 
     if (this.processLinkId$.getValue()) {
       combineLatest([this.processLinkId$, this.documentId$])
@@ -215,21 +273,36 @@ export class CaseSupportingProcessStartModalComponent implements OnDestroy {
             this.formSubmitted();
           },
           error: errors => {
-            this.form.showErrors(errors);
+            // Push server-side errors via input binding so they render in both the modal and the
+            // panel (in panel mode the formio ViewChild lives in the host component's view).
+            this.formErrors$.next(errors);
           },
         });
     }
   }
 
   public formSubmitted(): void {
-    this.closeCdsModal();
+    this.closeStartForm();
     this.formSubmit.emit();
     this.isLoading$.next(true);
     this.formDefinition$.next(null);
   }
 
+  public closePanel(): void {
+    this.closeStartForm();
+  }
+
+  private closeStartForm(): void {
+    if (this._displayInPanel) {
+      this._displayInPanel = false;
+      this.caseDetailLayoutService.closeStartFormPanel();
+    } else {
+      this.closeCdsModal();
+    }
+  }
+
   public gotoFormLinkScreen(): void {
-    this.closeCdsModal();
+    this.closeStartForm();
 
     if (this._buildingBlockDefinitionKey && this._buildingBlockDefinitionVersionTag) {
       this.router.navigate([

--- a/frontend/projects/valtimo/case/src/lib/services/case-detail-layout.service.ts
+++ b/frontend/projects/valtimo/case/src/lib/services/case-detail-layout.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, TemplateRef} from '@angular/core';
 import {FormDisplayType, FormSize, TaskWithProcessLink} from '@valtimo/process-link';
 import {BehaviorSubject, combineLatest, filter, map, Observable, startWith} from 'rxjs';
 import {
@@ -29,12 +29,18 @@ import {CaseDetailLayout} from '../models';
 import {CaseTabService} from './case-tab.service';
 import {PageHeaderService} from '@valtimo/components';
 
+export interface StartFormPanel {
+  template: TemplateRef<any>;
+  title: string;
+}
+
 @Injectable()
 export class CaseDetailLayoutService {
   private readonly _tabContentContainerWidth$ = new BehaviorSubject<number | null>(null);
   private readonly _showTaskList$ = this.caseTabService.showTaskList$;
   private readonly _taskAndProcessLinkOpenedInPanel$ =
     new BehaviorSubject<TaskWithProcessLink | null>(null);
+  private readonly _startFormPanel$ = new BehaviorSubject<StartFormPanel | null>(null);
   private readonly _formDisplayType$ = new BehaviorSubject<FormDisplayType>(
     CASE_DETAIL_DEFAULT_DISPLAY_TYPE
   );
@@ -55,6 +61,10 @@ export class CaseDetailLayoutService {
 
   public get taskAndProcessLinkOpenedInPanel$(): Observable<TaskWithProcessLink | null> {
     return this._taskAndProcessLinkOpenedInPanel$.asObservable();
+  }
+
+  public get startFormPanel$(): Observable<StartFormPanel | null> {
+    return this._startFormPanel$.asObservable();
   }
 
   public get formDisplaySize$(): Observable<FormSize> {
@@ -84,6 +94,7 @@ export class CaseDetailLayoutService {
     this.tabContentContainerWidth$,
     this._showTaskList$,
     this._taskAndProcessLinkOpenedInPanel$,
+    this._startFormPanel$,
     this._formDisplayType$,
     this._formDisplaySize$,
   ]).pipe(
@@ -92,11 +103,16 @@ export class CaseDetailLayoutService {
         tabContentContainerWidth,
         showTaskList,
         taskAndProcessLinkOpenedInPanel,
+        startFormPanel,
         formDisplayType,
         formDisplaySize,
       ]) => {
         if (!showTaskList) {
           return this.getInitialLayout();
+        }
+
+        if (startFormPanel) {
+          return this.getPanelLayout(tabContentContainerWidth ?? 0, formDisplaySize);
         }
 
         if (!taskAndProcessLinkOpenedInPanel) {
@@ -119,6 +135,16 @@ export class CaseDetailLayoutService {
 
   public setTaskAndProcessLinkOpenedInPanel(value: TaskWithProcessLink | null): void {
     this._taskAndProcessLinkOpenedInPanel$.next(value);
+  }
+
+  public openStartFormPanel(value: StartFormPanel, formSize: FormSize): void {
+    this.setFormDisplayType('panel');
+    this.setFormDisplaySize(formSize);
+    this._startFormPanel$.next(value);
+  }
+
+  public closeStartFormPanel(): void {
+    this._startFormPanel$.next(null);
   }
 
   public setFormDisplayType(type: FormDisplayType): void {

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io/form-io.component.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io/form-io.component.ts
@@ -73,6 +73,9 @@ export class FormioComponent implements OnInit, OnChanges, OnDestroy {
   @Input() set readOnly(readOnlyValue: boolean) {
     this.readOnly$.next(readOnlyValue);
   }
+  @Input() set errors(errorsValue: Array<string>) {
+    this.errors$.next(errorsValue ?? []);
+  }
   @Input() formRefresh$!: Subject<FormioRefreshValue>;
 
   // eslint-disable-next-line @angular-eslint/no-output-native

--- a/frontend/projects/valtimo/process-link/src/lib/components/form-display-configuration/form-display-configuration.component.html
+++ b/frontend/projects/valtimo/process-link/src/lib/components/form-display-configuration/form-display-configuration.component.html
@@ -26,7 +26,7 @@
     saving: saving$ | async,
   } as obs"
 >
-  @if (obs.isUserTask) {
+  @if (obs.isUserTask || obs.isStartEvent) {
     <cds-combo-box
       [placeholder]="'processLinkSteps.displayType.placeholder' | translate"
       [label]="'processLinkSteps.displayType.label' | translate"

--- a/frontend/projects/valtimo/process-link/src/lib/components/form-display-configuration/form-display-configuration.component.ts
+++ b/frontend/projects/valtimo/process-link/src/lib/components/form-display-configuration/form-display-configuration.component.ts
@@ -102,7 +102,11 @@ export class FormDisplayConfigurationComponent implements OnInit, OnDestroy {
           this._subtitles$.next(selectedProcessLink.subtitles ?? []);
         }
 
-        if (this.isStartEvent$.getValue()) this.disableFormSizeInput$.next(false);
+        if (this.isStartEvent$.getValue()) {
+          // Start events always allow a form size and default the display type to 'modal'.
+          this.disableFormSizeInput$.next(false);
+          if (!this.formDisplayValue$.getValue()) this.updateFormDisplayType('modal');
+        }
       })
     );
   }

--- a/frontend/projects/valtimo/process-link/src/lib/components/select-form/select-form.component.ts
+++ b/frontend/projects/valtimo/process-link/src/lib/components/select-form/select-form.component.ts
@@ -101,6 +101,7 @@ export class SelectFormComponent implements OnInit, OnDestroy {
   private isStartEvent$ = new BehaviorSubject<boolean>(false);
 
   private readonly _DEFAULT_FORM_DISPLAY_TYPE: FormDisplayType = 'panel';
+  private readonly _DEFAULT_START_EVENT_FORM_DISPLAY_TYPE: FormDisplayType = 'modal';
   private readonly _DEFAULT_FORM_DISPLAY_SIZE: FormSize = 'medium';
 
   constructor(
@@ -202,6 +203,10 @@ export class SelectFormComponent implements OnInit, OnDestroy {
           ...(isUserTask && {
             formDisplayType: this.formDisplayValue || this._DEFAULT_FORM_DISPLAY_TYPE,
           }),
+          ...(isStartEvent && {
+            formDisplayType:
+              this.formDisplayValue || this._DEFAULT_START_EVENT_FORM_DISPLAY_TYPE,
+          }),
           ...((isUserTask || isStartEvent) && {
             formSize: this.formSizeValue || this._DEFAULT_FORM_DISPLAY_SIZE,
           }),
@@ -231,6 +236,10 @@ export class SelectFormComponent implements OnInit, OnDestroy {
           viewModelEnabled,
           ...(isUserTask && {
             formDisplayType: this.formDisplayValue || this._DEFAULT_FORM_DISPLAY_TYPE,
+          }),
+          ...(isStartEvent && {
+            formDisplayType:
+              this.formDisplayValue || this._DEFAULT_START_EVENT_FORM_DISPLAY_TYPE,
           }),
           ...((isUserTask || isStartEvent) && {
             formSize: this.formSizeValue || this._DEFAULT_FORM_DISPLAY_SIZE,

--- a/frontend/projects/valtimo/process/src/lib/models/process.model.ts
+++ b/frontend/projects/valtimo/process/src/lib/models/process.model.ts
@@ -64,6 +64,8 @@ type StartProcessLinkType = 'form' | 'form-flow' | 'form-view-model' | 'url' | '
 
 type StartProcessLinkFormSize = 'extraSmall' | 'small' | 'medium' | 'large';
 
+type StartProcessLinkFormDisplayType = 'modal' | 'panel';
+
 interface ProcessDefinitionStartProcessLink {
   processLinkId: string;
   type: StartProcessLinkType;
@@ -76,6 +78,7 @@ interface ProcessDefinitionStartProcessLink {
     url?: string;
     componentKey?: string;
     formSize?: StartProcessLinkFormSize;
+    formDisplayType?: StartProcessLinkFormDisplayType;
   };
 }
 

--- a/frontend/projects/valtimo/shared/assets/core/en.json
+++ b/frontend/projects/valtimo/shared/assets/core/en.json
@@ -2462,8 +2462,8 @@
       "options": {"modal": "Modal", "panel": "Panel"}
     },
     "formSize": {
-      "label": "Select modal size",
-      "placeholder": "Select a modal size",
+      "label": "Select form size",
+      "placeholder": "Select a form size",
       "options": {
         "extraSmall": "Extra small",
         "small": "Small",

--- a/frontend/projects/valtimo/shared/assets/core/nl.json
+++ b/frontend/projects/valtimo/shared/assets/core/nl.json
@@ -2495,8 +2495,8 @@
       "options": {"modal": "Modaal", "panel": "Panel"}
     },
     "formSize": {
-      "label": "Selecteer modaal-grootte",
-      "placeholder": "Selecteer een modaal-grootte",
+      "label": "Selecteer formuliergrootte",
+      "placeholder": "Selecteer een formuliergrootte",
       "options": {
         "extraSmall": "Extra klein",
         "small": "Klein",


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/292

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: story/dispaly-type-start-events

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ]  Open a process (for example, Bezwaar process), click on the Start Event, choose type Form, select a form and configure "Select display type" (e.g. Panel), and save.
 - [ ] Go to the case list of that case definition and click "Create New Case": the start form modal should open always as a modal.
- [ ]  Go to the Case Details, start a process and check that it's display like the selection you made (panel or modal) and also the size matches with the correct one.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
