### PR TITLE
Documenten API plugin: download document action resolves by document ID, not just URL

### DIFF
--- a/backend/app/gzac/src/main/resources/logback-spring.xml
+++ b/backend/app/gzac/src/main/resources/logback-spring.xml
@@ -23,6 +23,7 @@
 
     <logger name="com.ritense.valtimo" level="#logback.loglevel#"/>
     <logger name="com.ritense.valtimo.web.logging" level="DEBUG"/>
+    <logger name="com.ritense.valtimo.web.sse" level="WARN"/>
 
     <logger name="ch.qos.logback" level="WARN"/>
     <logger name="com.amazonaws" level="WARN"/>
@@ -32,6 +33,7 @@
     <logger name="com.ryantenney" level="WARN"/>
     <logger name="com.sun" level="WARN"/>
     <logger name="com.zaxxer" level="WARN"/>
+    <logger name="io.github.resilience4j.circuitbreaker" level="WARN"/>
     <logger name="io.hypersistence.utils.hibernate" level="WARN"/>
     <logger name="jakarta.activation" level="WARN"/>
     <logger name="jakarta.mail" level="WARN"/>
@@ -48,6 +50,7 @@
     <logger name="org.hibernate.engine.jdbc.spi" level="INFO"/>
     <logger name="org.hibernate.validator" level="WARN"/>
     <logger name="org.operaton" level="INFO"/>
+    <logger name="org.postgresql" level="WARN"/>
     <logger name="org.springframework" level="WARN"/>
     <logger name="org.springframework.cache" level="WARN"/>
     <logger name="org.springframework.cloud" level="WARN"/>

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -218,10 +218,7 @@ class DocumentenApiPlugin(
         execution: DelegateExecution,
         @PluginActionProperty processVariableName: String? = null
     ): String {
-        val documentUrlString = execution.getVariable(DOCUMENT_URL_PROCESS_VAR) as String?
-            ?: throw IllegalStateException("Failed to download document. No process variable '$DOCUMENT_URL_PROCESS_VAR' found.")
-        check(documentUrlString.startsWith(url.toASCIIString())) { "Failed to download document with url '$documentUrlString'. Document isn't part of Documenten API with url '$url'." }
-        val documentUrl = URI(documentUrlString)
+        val documentUrl = resolveDownloadDocumentUrl(execution)
         val caseDocumentId = UUID.fromString(execution.businessKey)
             ?: throw IllegalStateException("Failed to store document. Business key is null.")
 
@@ -439,6 +436,23 @@ class DocumentenApiPlugin(
         if (apiVersion != null && !documentenApiVersionService.isValidVersion(apiVersion!!)) {
             throw ValidationException("Unknown API version '$apiVersion'.")
         }
+    }
+
+    private fun resolveDownloadDocumentUrl(execution: DelegateExecution): URI {
+        val documentUrlString = execution.getVariable(DOCUMENT_URL_PROCESS_VAR) as String?
+        if (documentUrlString != null) {
+            check(documentUrlString.startsWith(url.toASCIIString())) {
+                "Failed to download document with url '$documentUrlString'. Document isn't part of Documenten API with url '$url'."
+            }
+            return URI(documentUrlString)
+        }
+        val documentId = execution.getVariable(DOCUMENT_ID_PROCESS_VAR) as String?
+        if (documentId != null) {
+            return createInformatieObjectUrl(documentId)
+        }
+        throw IllegalStateException(
+            "Failed to download document. No process variable '$DOCUMENT_URL_PROCESS_VAR' or '$DOCUMENT_ID_PROCESS_VAR' found."
+        )
     }
 
     private fun getResourceId(

--- a/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/backend/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -439,14 +439,16 @@ class DocumentenApiPlugin(
     }
 
     private fun resolveDownloadDocumentUrl(execution: DelegateExecution): URI {
-        val documentUrlString = execution.getVariable(DOCUMENT_URL_PROCESS_VAR) as String?
+        val documentUrlString = (execution.getVariable(DOCUMENT_URL_PROCESS_VAR) as String?)
+            ?.takeIf { it.isNotBlank() }
         if (documentUrlString != null) {
             check(documentUrlString.startsWith(url.toASCIIString())) {
                 "Failed to download document with url '$documentUrlString'. Document isn't part of Documenten API with url '$url'."
             }
             return URI(documentUrlString)
         }
-        val documentId = execution.getVariable(DOCUMENT_ID_PROCESS_VAR) as String?
+        val documentId = (execution.getVariable(DOCUMENT_ID_PROCESS_VAR) as String?)
+            ?.takeIf { it.isNotBlank() }
         if (documentId != null) {
             return createInformatieObjectUrl(documentId)
         }

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
@@ -91,7 +91,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
             }
         """
 
-        //since we do not have an actual authentication plugin in this context we will mock one
+        //since we do not have an actual authentication plugin in this context, we will mock one
         val mockedId = PluginConfigurationId.existingId(UUID.fromString("c850401b-9331-4cb6-8f1c-3e34b12e3d55"))
         doReturn(Optional.of(mock<PluginConfiguration>())).whenever(pluginConfigurationRepository).findById(mockedId)
 
@@ -134,13 +134,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
             "test".byteInputStream(), mutableMapOf(MetadataType.FILE_SIZE.key to 4L)
         )
 
-        val newDocumentRequest = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY,
-            "profile",
-            "1.0.0",
-            objectMapper.createObjectNode()
-        )
-        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest)
+        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
             .withProcessVars(mapOf("localDocumentVariableName" to documentId))
 
         val newDocumentAndStartProcessResult =
@@ -200,13 +194,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
             mapOf(MetadataType.FILE_NAME.key to "my-document.pdf")
         )
 
-        val newDocumentRequest = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY,
-            "profile",
-            "1.0.0",
-            objectMapper.createObjectNode()
-        )
-        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest)
+        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
             .withProcessVars(mapOf("localDocumentVariableName" to documentId))
 
         runWithoutAuthorization { processDocumentService.newDocumentAndStartProcess(request) }
@@ -224,13 +212,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
         saveProcessLink("download-document", "{}")
         val documentUrl = "${server.url("/")}enkelvoudiginformatieobjecten/$DOCUMENT_ID"
 
-        val newDocumentRequest = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY,
-            "profile",
-            "1.0.0",
-            objectMapper.createObjectNode()
-        )
-        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest)
+        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
             .withProcessVars(mapOf("documentUrl" to documentUrl))
 
         runWithoutAuthorization { processDocumentService.newDocumentAndStartProcess(request) }
@@ -259,13 +241,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
         )
         val documentUrl = "${server.url("/")}enkelvoudiginformatieobjecten/$DOCUMENT_ID"
 
-        val newDocumentRequest = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY,
-            "profile",
-            "1.0.0",
-            objectMapper.createObjectNode()
-        )
-        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest)
+        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
             .withProcessVars(mapOf("documentUrl" to documentUrl))
 
         runWithoutAuthorization { processDocumentService.newDocumentAndStartProcess(request) }
@@ -284,14 +260,52 @@ internal class DocumentenApiPluginIT @Autowired constructor(
     }
 
     @Test
+    fun `should download document by documentId process variable`() {
+        saveProcessLink("download-document", "{}")
+
+        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
+            .withProcessVars(mapOf("documentId" to DOCUMENT_ID))
+
+        runWithoutAuthorization { processDocumentService.newDocumentAndStartProcess(request) }
+
+        val resourceId = runtimeService.createVariableInstanceQuery()
+            .variableName("resourceId")
+            .singleResult()
+            .value as String
+        val documentInputStream = temporaryResourceStorageService.getResourceContentAsInputStream(resourceId)
+        val documentMetadata = temporaryResourceStorageService.getResourceMetadata(resourceId)
+        assertEquals("TEST_DOCUMENT_CONTENT", documentInputStream.bufferedReader().use { it.readText() })
+        assertNotNull(documentMetadata[MetadataType.DOCUMENT_ID.key])
+        assertEquals("passport.jpg", documentMetadata[MetadataType.FILE_NAME.key])
+        assertEquals("Passport", documentMetadata["title"])
+        assertEquals("My passport", documentMetadata["description"])
+    }
+
+    @Test
+    fun `should prefer documentUrl over documentId when both are present`() {
+        saveProcessLink("download-document", "{}")
+        val documentUrl = "${server.url("/")}enkelvoudiginformatieobjecten/$DOCUMENT_ID"
+
+        // documentId points at a non-existent document; success proves documentUrl was used.
+        val request = NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
+            .withProcessVars(mapOf("documentUrl" to documentUrl, "documentId" to "non-existent-id"))
+
+        runWithoutAuthorization { processDocumentService.newDocumentAndStartProcess(request) }
+
+        val resourceId = runtimeService.createVariableInstanceQuery()
+            .variableName("resourceId")
+            .singleResult()
+            .value as String
+        val documentInputStream = temporaryResourceStorageService.getResourceContentAsInputStream(resourceId)
+        assertEquals("TEST_DOCUMENT_CONTENT", documentInputStream.bufferedReader().use { it.readText() })
+    }
+
+    @Test
     fun `should set documentUrl process variable on related process when processInstanceId is present`() {
         // Start related (target) process first, without an upload link
-        val relatedDocReq = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY, "profile", "1.0.0", objectMapper.createObjectNode()
-        )
         runWithoutAuthorization {
             processDocumentService.newDocumentAndStartProcess(
-                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, relatedDocReq)
+                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
             )
         }
 
@@ -319,12 +333,9 @@ internal class DocumentenApiPluginIT @Autowired constructor(
         )
 
         // Start uploader process that will trigger the action
-        val uploadReq = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY, "profile", "1.0.0", objectMapper.createObjectNode()
-        )
         runWithoutAuthorization {
             processDocumentService.newDocumentAndStartProcess(
-                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, uploadReq)
+                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
                     .withProcessVars(mapOf("resourceId" to resourceId))
             )
         }
@@ -343,12 +354,9 @@ internal class DocumentenApiPluginIT @Autowired constructor(
     @Test
     fun `should set custom process variable name when provided in metadata`() {
         // Start related (target) process first
-        val relatedDocReq = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY, "profile", "1.0.0", objectMapper.createObjectNode()
-        )
         runWithoutAuthorization {
             processDocumentService.newDocumentAndStartProcess(
-                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, relatedDocReq)
+                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
             )
         }
 
@@ -380,12 +388,9 @@ internal class DocumentenApiPluginIT @Autowired constructor(
         )
 
         // Start uploader process
-        val uploadReq = NewDocumentRequest(
-            DOCUMENT_DEFINITION_KEY, "profile", "1.0.0", objectMapper.createObjectNode()
-        )
         runWithoutAuthorization {
             processDocumentService.newDocumentAndStartProcess(
-                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, uploadReq)
+                NewDocumentAndStartProcessRequest(PROCESS_DEFINITION_KEY, newDocumentRequest())
                     .withProcessVars(mapOf("resourceId" to resourceId))
             )
         }
@@ -438,6 +443,13 @@ internal class DocumentenApiPluginIT @Autowired constructor(
         }
         server.dispatcher = dispatcher
     }
+
+    private fun newDocumentRequest() = NewDocumentRequest(
+        DOCUMENT_DEFINITION_KEY,
+        "profile",
+        "1.0.0",
+        objectMapper.createObjectNode()
+    )
 
     private fun handleDocumentRequest(zone: String = "Z"): MockResponse {
         val body = """

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.documentenapi
 
+import com.ritense.documentenapi.DocumentenApiPlugin.Companion.DOCUMENT_ID_PROCESS_VAR
 import com.ritense.documentenapi.DocumentenApiPlugin.Companion.DOCUMENT_URL_PROCESS_VAR
 import com.ritense.documentenapi.DocumentenApiPlugin.Companion.RESOURCE_ID_PROCESS_VAR
 import com.ritense.documentenapi.client.CreateDocumentRequest
@@ -28,8 +29,8 @@ import com.ritense.documentenapi.client.DocumentenApiClient
 import com.ritense.documentenapi.client.ObjectInformatieObject
 import com.ritense.documentenapi.client.ObjectInformatieObjectRequest
 import com.ritense.documentenapi.client.PatchDocumentRequest
-import com.ritense.documentenapi.event.DocumentCreated
 import com.ritense.documentenapi.domain.DocumentenApiVersion
+import com.ritense.documentenapi.event.DocumentCreated
 import com.ritense.documentenapi.service.DocumentenApiVersionService
 import com.ritense.documentenapi.service.DocumentenApiVersionService.Companion.MINIMUM_VERSION
 import com.ritense.plugin.annotation.Plugin
@@ -47,7 +48,6 @@ import com.ritense.valtimo.operaton.service.OperatonRuntimeService
 import com.ritense.zgw.Rsin
 import com.ritense.zgw.domain.Vertrouwelijkheid
 import org.apache.commons.io.IOUtils
-import org.operaton.bpm.engine.delegate.DelegateExecution
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -58,6 +58,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.operaton.bpm.engine.delegate.DelegateExecution
 import org.springframework.context.ApplicationEventPublisher
 import java.io.ByteArrayInputStream
 import java.net.URI
@@ -76,7 +77,6 @@ internal class DocumentenApiPluginTest {
     lateinit var runtimeService: OperatonRuntimeService
     lateinit var virusScanService: VirusScanService
 
-
     @BeforeEach
     fun setUp() {
         pluginService = mock()
@@ -92,7 +92,8 @@ internal class DocumentenApiPluginTest {
             pluginDefinition = pluginDefinition,
             title = "title"
         )
-        whenever(pluginService.findPluginConfiguration(any(), any())).thenReturn(pluginConfiguration)
+        whenever(pluginService.findPluginConfiguration(any(), any()))
+            .thenReturn(pluginConfiguration)
 
         client = mock()
         runtimeService = mock()
@@ -113,32 +114,32 @@ internal class DocumentenApiPluginTest {
         whenever(executionMock.businessKey).thenReturn(null)
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            objectMapper,
-            mutableListOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = objectMapper,
+            documentDeleteHandlers = mutableListOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
 
         val exception = assertThrows<IllegalStateException> {
             plugin.storeTemporaryDocument(
-                executionMock,
-                "test.ext",
-                Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
-                "title",
-                "description",
-                "localDocumentVariableName",
-                "storedDocumentVariableName",
-                "type",
-                "taal",
-                IN_BEWERKING
+                execution = executionMock,
+                fileName = "test.ext",
+                confidentialityLevel = Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
+                title = "title",
+                description = "description",
+                localDocumentLocation = "localDocumentVariableName",
+                storedDocumentUrl = "storedDocumentVariableName",
+                informatieobjecttype = "type",
+                taal = "taal",
+                status = IN_BEWERKING
             )
         }
         assertEquals("Failed to store document. Business key is null.", exception.message)
@@ -158,13 +159,13 @@ internal class DocumentenApiPluginTest {
         val inputStream = ByteArrayInputStream(content.toByteArray())
         val virusScanEnabledForDocumentenApiPlugin = false
         val result = CreateDocumentResult(
-            "returnedUrl",
-            "returnedAuthor",
-            "returnedFileName",
-            1L,
-            OffsetDateTime.parse("2020-01-01T01:01:01Z"),
-            listOf(),
-            null
+            url = "returnedUrl",
+            auteur = "returnedAuthor",
+            bestandsnaam = "returnedFileName",
+            bestandsomvang = 1L,
+            beginRegistratie = OffsetDateTime.parse("2020-01-01T01:01:01Z"),
+            bestandsdelen = listOf(),
+            lock = null
         )
 
         whenever(executionMock.getVariable("localDocumentVariableName"))
@@ -175,16 +176,16 @@ internal class DocumentenApiPluginTest {
         whenever(client.storeDocument(any(), any(), any(), any())).thenReturn(result)
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            objectMapper,
-            mutableListOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = objectMapper,
+            documentDeleteHandlers = mutableListOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -203,16 +204,16 @@ internal class DocumentenApiPluginTest {
         ).thenReturn(pluginConfiguration)
 
         plugin.storeTemporaryDocument(
-            executionMock,
-            "test.ext",
-            Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
-            "title",
-            "description",
-            "localDocumentVariableName",
-            "storedDocumentVariableName",
-            "type",
-            "taal",
-            IN_BEWERKING
+            execution = executionMock,
+            fileName = "test.ext",
+            confidentialityLevel = Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
+            title = "title",
+            description = "description",
+            localDocumentLocation = "localDocumentVariableName",
+            storedDocumentUrl = "storedDocumentVariableName",
+            informatieobjecttype = "type",
+            taal = "taal",
+            status = IN_BEWERKING
         )
 
         val apiRequestCaptor = argumentCaptor<CreateDocumentRequest>()
@@ -256,13 +257,13 @@ internal class DocumentenApiPluginTest {
         val inputStream = ByteArrayInputStream(content.toByteArray())
         val virusScanEnabledForDocumentenApiPlugin = true
         val result = CreateDocumentResult(
-            "returnedUrl",
-            "returnedAuthor",
-            "returnedFileName",
-            1L,
-            OffsetDateTime.parse("2020-01-01T01:01:01Z"),
-            listOf(),
-            null
+            url = "returnedUrl",
+            auteur = "returnedAuthor",
+            bestandsnaam = "returnedFileName",
+            bestandsomvang = 1L,
+            beginRegistratie = OffsetDateTime.parse("2020-01-01T01:01:01Z"),
+            bestandsdelen = listOf(),
+            lock = null
         )
         val byFileResult = VirusScanResult(
             status = VirusScanStatus.VIRUS_FOUND,
@@ -280,16 +281,16 @@ internal class DocumentenApiPluginTest {
         whenever(client.storeDocument(any(), any(), any(), any())).thenReturn(result)
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            objectMapper,
-            mutableListOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = objectMapper,
+            documentDeleteHandlers = mutableListOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -309,16 +310,16 @@ internal class DocumentenApiPluginTest {
 
         assertThrows<VirusDetectedException> {
             plugin.storeTemporaryDocument(
-                executionMock,
-                "test.ext",
-                Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
-                "title",
-                "description",
-                "localDocumentVariableName",
-                "storedDocumentVariableName",
-                "type",
-                "taal",
-                IN_BEWERKING
+                execution = executionMock,
+                fileName = "test.ext",
+                confidentialityLevel = Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
+                title = "title",
+                description = "description",
+                localDocumentLocation = "localDocumentVariableName",
+                storedDocumentUrl = "storedDocumentVariableName",
+                informatieobjecttype = "type",
+                taal = "taal",
+                status = IN_BEWERKING
             )
         }
     }
@@ -337,13 +338,13 @@ internal class DocumentenApiPluginTest {
         val inputStream = ByteArrayInputStream(content.toByteArray())
         val virusScanEnabledForDocumentenApiPlugin = true
         val result = CreateDocumentResult(
-            "returnedUrl",
-            "returnedAuthor",
-            "returnedFileName",
-            1L,
-            OffsetDateTime.parse("2020-01-01T01:01:01Z"),
-            listOf(),
-            null
+            url = "returnedUrl",
+            auteur = "returnedAuthor",
+            bestandsnaam = "returnedFileName",
+            bestandsomvang = 1L,
+            beginRegistratie = OffsetDateTime.parse("2020-01-01T01:01:01Z"),
+            bestandsdelen = listOf(),
+            lock = null
         )
 
         whenever(executionMock.getVariable("localDocumentVariableName"))
@@ -356,16 +357,16 @@ internal class DocumentenApiPluginTest {
         whenever(client.storeDocument(any(), any(), any(), any())).thenReturn(result)
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            objectMapper,
-            mutableListOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = objectMapper,
+            documentDeleteHandlers = mutableListOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -384,16 +385,16 @@ internal class DocumentenApiPluginTest {
         ).thenReturn(pluginConfiguration)
 
         plugin.storeTemporaryDocument(
-            executionMock,
-            "test.ext",
-            Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
-            "title",
-            "description",
-            "localDocumentVariableName",
-            "storedDocumentVariableName",
-            "type",
-            "taal",
-            IN_BEWERKING
+            execution = executionMock,
+            fileName = "test.ext",
+            confidentialityLevel = Vertrouwelijkheid.ZAAKVERTROUWELIJK.key,
+            title = "title",
+            description = "description",
+            localDocumentLocation = "localDocumentVariableName",
+            storedDocumentUrl = "storedDocumentVariableName",
+            informatieobjecttype = "type",
+            taal = "taal",
+            status = IN_BEWERKING
         )
 
         val apiRequestCaptor = argumentCaptor<CreateDocumentRequest>()
@@ -416,13 +417,13 @@ internal class DocumentenApiPluginTest {
         val virusScanEnabledForDocumentenApiPlugin = false
         val inputStream = ByteArrayInputStream(content.toByteArray())
         val result = CreateDocumentResult(
-            "returnedUrl",
-            "returnedAuthor",
-            "returnedFileName",
-            1L,
-            OffsetDateTime.now(),
-            listOf(),
-            null
+            url = "returnedUrl",
+            auteur = "returnedAuthor",
+            bestandsnaam = "returnedFileName",
+            bestandsomvang = 1L,
+            beginRegistratie = OffsetDateTime.now(),
+            bestandsdelen = listOf(),
+            lock = null
         )
 
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR))
@@ -461,16 +462,16 @@ internal class DocumentenApiPluginTest {
         ).thenReturn(pluginConfiguration)
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            MapperSingleton.get(),
-            mutableListOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = mutableListOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -512,13 +513,13 @@ internal class DocumentenApiPluginTest {
         val inputStream = ByteArrayInputStream(content.toByteArray())
         val virusScanEnabledForDocumentenApiPlugin = false
         val result = CreateDocumentResult(
-            "returnedUrl",
-            "returnedAuthor",
-            "returnedFileName",
-            1L,
-            OffsetDateTime.now(),
-            listOf(),
-            null
+            url = "returnedUrl",
+            auteur = "returnedAuthor",
+            bestandsnaam = "returnedFileName",
+            bestandsomvang = 1L,
+            beginRegistratie = OffsetDateTime.now(),
+            bestandsdelen = listOf(),
+            lock = null
         )
 
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR))
@@ -539,16 +540,16 @@ internal class DocumentenApiPluginTest {
         whenever(client.storeDocument(any(), any(), any(), any())).thenReturn(result)
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            MapperSingleton.get(),
-            listOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -598,16 +599,16 @@ internal class DocumentenApiPluginTest {
         val virusScanEnabledForDocumentenApiPlugin = false
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            MapperSingleton.get(),
-            listOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -621,9 +622,9 @@ internal class DocumentenApiPluginTest {
         val caseDocumentIdCaptor = argumentCaptor<UUID>()
 
         verify(client).getInformatieObject(
-            authorizationCaptor.capture(),
-            caseDocumentIdCaptor.capture(),
-            informatieObjectUrlCaptor.capture(),
+            authentication = authorizationCaptor.capture(),
+            caseDocumentId = caseDocumentIdCaptor.capture(),
+            objectUrl = informatieObjectUrlCaptor.capture(),
         )
 
         assertEquals(informatieObjectUrl, informatieObjectUrlCaptor.firstValue)
@@ -640,16 +641,16 @@ internal class DocumentenApiPluginTest {
         val informatieObjectUrl = URI("http://some-url/informatie-object/123")
         val caseDocumentId = UUID.randomUUID()
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            MapperSingleton.get(),
-            listOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -672,9 +673,9 @@ internal class DocumentenApiPluginTest {
 
         val exception = assertThrows<Exception> {
             plugin.modifyInformatieObject(
-                caseDocumentId,
-                informatieObjectUrl,
-                PatchDocumentRequest(LocalDate.now(), "Nieuwe titel", "auteur", DEFINITIEF, "taal")
+                caseDocumentId = caseDocumentId,
+                documentUrl = informatieObjectUrl,
+                patchDocumentRequest = PatchDocumentRequest(LocalDate.now(), "Nieuwe titel", "auteur", DEFINITIEF, "taal")
             )
         }
         assertEquals("InformatieObject 123 with status 'definitief' cannot be updated in Documenten API with '1.0.0'", exception.message)
@@ -694,30 +695,30 @@ internal class DocumentenApiPluginTest {
         whenever(client.getAuditTrail(any(), any(), any())).thenReturn(emptyList())
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            MapperSingleton.get(),
-            listOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
         plugin.authenticationPluginConfiguration = authenticationMock
 
         plugin.getAuditTrail(
-            executionMock,
-            documentUrl,
-            "myAuditTrailVar"
+            execution = executionMock,
+            documentUrl = documentUrl,
+            processVariableName = "myAuditTrailVar"
         )
 
         verify(client).getAuditTrail(
-            eq(authenticationMock),
-            eq(UUID.fromString("123e4567-e89b-12d3-a456-426655440000")),
-            eq(documentUrl)
+            authentication = eq(authenticationMock),
+            caseDocumentId = eq(UUID.fromString("123e4567-e89b-12d3-a456-426655440000")),
+            documentUrl = eq(documentUrl)
         )
         verify(executionMock).setVariable(eq("myAuditTrailVar"), any<String>())
     }
@@ -732,24 +733,24 @@ internal class DocumentenApiPluginTest {
         val documentUrl = URI("http://other-url/enkelvoudiginformatieobjecten/some-uuid")
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            MapperSingleton.get(),
-            listOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
 
         val exception = assertThrows<IllegalStateException> {
             plugin.getAuditTrail(
-                executionMock,
-                documentUrl,
-                "myAuditTrailVar"
+                execution = executionMock,
+                documentUrl = documentUrl,
+                processVariableName = "myAuditTrailVar"
             )
         }
         assertEquals(
@@ -770,16 +771,16 @@ internal class DocumentenApiPluginTest {
         whenever(executionMock.businessKey).thenReturn(null)
 
         val plugin = DocumentenApiPlugin(
-            client,
-            storageService,
-            applicationEventPublisher,
-            MapperSingleton.get(),
-            listOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            virusScanEnabledForDocumentenApiPlugin
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = virusScanEnabledForDocumentenApiPlugin
         )
         plugin.url = URI("http://some-url")
 
@@ -799,16 +800,16 @@ internal class DocumentenApiPluginTest {
         apiVersion: String? = null,
     ): DocumentenApiPlugin {
         val plugin = DocumentenApiPlugin(
-            client,
-            mock(),
-            mock(),
-            MapperSingleton.get(),
-            listOf(),
-            documentenApiVersionService,
-            pluginService,
-            runtimeService,
-            virusScanService,
-            false
+            client = client,
+            storageService = mock(),
+            applicationEventPublisher = mock(),
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = false
         )
         plugin.url = URI("http://some-url")
         plugin.bronorganisatie = "123456789"
@@ -821,10 +822,14 @@ internal class DocumentenApiPluginTest {
     fun `should delegate linkDocumentToObject to client when feature is supported`() {
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val documentenApiVersionService: DocumentenApiVersionService = mock()
-        val version = DocumentenApiVersion("1.5.0-baseflow", supportsObjectInformatieObjecten = true)
+        val version = DocumentenApiVersion(version = "1.5.0-baseflow", supportsObjectInformatieObjecten = true)
         whenever(documentenApiVersionService.getVersionByTag("1.5.0-baseflow")).thenReturn(version)
 
-        val plugin = createPlugin(documentenApiVersionService, authenticationMock, "1.5.0-baseflow")
+        val plugin = createPlugin(
+            documentenApiVersionService = documentenApiVersionService,
+            authenticationMock = authenticationMock,
+            apiVersion = "1.5.0-baseflow"
+        )
 
         val request = ObjectInformatieObjectRequest(
             informatieobject = URI("http://some-url/enkelvoudiginformatieobjecten/123"),
@@ -853,7 +858,10 @@ internal class DocumentenApiPluginTest {
         whenever(documentenApiVersionService.getVersionByTag("1.0.0"))
             .thenReturn(DocumentenApiVersion("1.0.0", supportsObjectInformatieObjecten = false))
 
-        val plugin = createPlugin(documentenApiVersionService, apiVersion = "1.0.0")
+        val plugin = createPlugin(
+            documentenApiVersionService = documentenApiVersionService,
+            apiVersion = "1.0.0"
+        )
 
         val exception = assertThrows<Exception> {
             plugin.linkDocumentToObject(
@@ -868,34 +876,48 @@ internal class DocumentenApiPluginTest {
         assertEquals("Documenten API version '1.0.0' does not support objectinformatieobjecten", exception.message)
     }
 
-
     @Test
     fun `should delegate deleteDocumentLink to client when feature is supported`() {
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val documentenApiVersionService: DocumentenApiVersionService = mock()
-        val version = DocumentenApiVersion("1.5.0-baseflow", supportsObjectInformatieObjecten = true)
+        val version = DocumentenApiVersion(version = "1.5.0-baseflow", supportsObjectInformatieObjecten = true)
         whenever(documentenApiVersionService.getVersionByTag("1.5.0-baseflow")).thenReturn(version)
 
-        val plugin = createPlugin(documentenApiVersionService, authenticationMock, "1.5.0-baseflow")
+        val plugin = createPlugin(
+            documentenApiVersionService = documentenApiVersionService,
+            authenticationMock = authenticationMock,
+            apiVersion = "1.5.0-baseflow"
+        )
 
         val objectInformatieObjectUrl = URI("http://some-url/objectinformatieobjecten/789")
         val caseDocumentId = UUID.randomUUID()
 
         plugin.deleteDocumentLink(caseDocumentId, objectInformatieObjectUrl)
 
-        verify(client).deleteDocumentLink(authenticationMock, plugin.url, caseDocumentId, objectInformatieObjectUrl)
+        verify(client).deleteDocumentLink(
+            authentication = authenticationMock,
+            baseUrl = plugin.url,
+            caseDocumentId = caseDocumentId,
+            url = objectInformatieObjectUrl
+        )
     }
 
     @Test
     fun `should throw when deleteDocumentLink is called on unsupported version`() {
         val documentenApiVersionService: DocumentenApiVersionService = mock()
         whenever(documentenApiVersionService.getVersionByTag("1.0.0"))
-            .thenReturn(DocumentenApiVersion("1.0.0", supportsObjectInformatieObjecten = false))
+            .thenReturn(DocumentenApiVersion(version = "1.0.0", supportsObjectInformatieObjecten = false))
 
-        val plugin = createPlugin(documentenApiVersionService, apiVersion = "1.0.0")
+        val plugin = createPlugin(
+            documentenApiVersionService = documentenApiVersionService,
+            apiVersion = "1.0.0"
+        )
 
         val exception = assertThrows<Exception> {
-            plugin.deleteDocumentLink(UUID.randomUUID(), URI("http://some-url/objectinformatieobjecten/789"))
+            plugin.deleteDocumentLink(
+                caseDocumentId = UUID.randomUUID(),
+                objectInformatieObjectUrl = URI("http://some-url/objectinformatieobjecten/789")
+            )
         }
         assertEquals("Documenten API version '1.0.0' does not support objectinformatieobjecten", exception.message)
     }
@@ -904,10 +926,14 @@ internal class DocumentenApiPluginTest {
     fun `should linkDocumentToObject via plugin action using documentUrl process variable`() {
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val documentenApiVersionService: DocumentenApiVersionService = mock()
-        val version = DocumentenApiVersion("1.5.0-baseflow", supportsObjectInformatieObjecten = true)
+        val version = DocumentenApiVersion(version = "1.5.0-baseflow", supportsObjectInformatieObjecten = true)
         whenever(documentenApiVersionService.getVersionByTag("1.5.0-baseflow")).thenReturn(version)
 
-        val plugin = createPlugin(documentenApiVersionService, authenticationMock, "1.5.0-baseflow")
+        val plugin = createPlugin(
+            documentenApiVersionService = documentenApiVersionService,
+            authenticationMock = authenticationMock,
+            apiVersion = "1.5.0-baseflow"
+        )
 
         val execution = mock<DelegateExecution>()
         val caseDocumentId = UUID.fromString("123e4567-e89b-12d3-a456-426655440000")
@@ -950,9 +976,12 @@ internal class DocumentenApiPluginTest {
     fun `should throw when linkDocumentToObject plugin action has no documentUrl process variable`() {
         val documentenApiVersionService: DocumentenApiVersionService = mock()
         whenever(documentenApiVersionService.getVersionByTag("1.5.0-baseflow"))
-            .thenReturn(DocumentenApiVersion("1.5.0-baseflow", supportsObjectInformatieObjecten = true))
+            .thenReturn(DocumentenApiVersion(version = "1.5.0-baseflow", supportsObjectInformatieObjecten = true))
 
-        val plugin = createPlugin(documentenApiVersionService, apiVersion = "1.5.0-baseflow")
+        val plugin = createPlugin(
+            documentenApiVersionService = documentenApiVersionService,
+            apiVersion = "1.5.0-baseflow"
+        )
 
         val execution = mock<DelegateExecution>()
         whenever(execution.businessKey).thenReturn("123e4567-e89b-12d3-a456-426655440000")
@@ -971,10 +1000,14 @@ internal class DocumentenApiPluginTest {
     fun `should deleteDocumentLink via plugin action`() {
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val documentenApiVersionService: DocumentenApiVersionService = mock()
-        val version = DocumentenApiVersion("1.5.0-baseflow", supportsObjectInformatieObjecten = true)
+        val version = DocumentenApiVersion(version = "1.5.0-baseflow", supportsObjectInformatieObjecten = true)
         whenever(documentenApiVersionService.getVersionByTag("1.5.0-baseflow")).thenReturn(version)
 
-        val plugin = createPlugin(documentenApiVersionService, authenticationMock, "1.5.0-baseflow")
+        val plugin = createPlugin(
+            documentenApiVersionService = documentenApiVersionService,
+            authenticationMock = authenticationMock,
+            apiVersion = "1.5.0-baseflow"
+        )
 
         val execution = mock<DelegateExecution>()
         val caseDocumentId = UUID.fromString("123e4567-e89b-12d3-a456-426655440000")
@@ -984,5 +1017,109 @@ internal class DocumentenApiPluginTest {
         plugin.deleteDocumentLink(execution, linkUrl)
 
         verify(client).deleteDocumentLink(authenticationMock, plugin.url, caseDocumentId, URI(linkUrl))
+    }
+
+    @Test
+    fun `should download document via plugin action using documentId process variable`() {
+        val storageService: TemporaryResourceStorageService = mock()
+        val applicationEventPublisher: ApplicationEventPublisher = mock()
+        val authenticationMock = mock<DocumentenApiAuthentication>()
+        val documentenApiVersionService: DocumentenApiVersionService = mock()
+        val executionMock = mock<DelegateExecution>()
+        val documentId = "3bd88200-11cb-45cf-a742-da01261755b1"
+        val caseDocumentId = "123e4567-e89b-12d3-a456-426655440000"
+
+        whenever(executionMock.getVariable(DOCUMENT_URL_PROCESS_VAR))
+            .thenReturn(null)
+        whenever(executionMock.getVariable(DOCUMENT_ID_PROCESS_VAR))
+            .thenReturn(documentId)
+        whenever(executionMock.businessKey)
+            .thenReturn(caseDocumentId)
+        whenever(client.getInformatieObject(any<DocumentenApiAuthentication>(), any<UUID>(), any<URI>()))
+            .thenReturn(
+                DocumentInformatieObject(
+                    url = URI("http://some-url/enkelvoudiginformatieobjecten/$documentId"),
+                    bronorganisatie = Rsin("000000000"),
+                    creatiedatum = LocalDate.now(),
+                    titel = "titel",
+                    auteur = "auteur",
+                    taal = "taal",
+                    beginRegistratie = OffsetDateTime.now(),
+                    status = DEFINITIEF,
+                    bestandsnaam = "passport.jpg"
+                )
+            )
+        whenever(client.downloadInformatieObjectContent(any<DocumentenApiAuthentication>(), any<UUID>(), any<URI>()))
+            .thenReturn(ByteArrayInputStream("content".toByteArray()))
+        whenever(storageService.store(any(), any()))
+            .thenReturn("tempResourceId")
+
+        val plugin = DocumentenApiPlugin(
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = false
+        )
+        plugin.url = URI("http://some-url")
+        plugin.bronorganisatie = "123456789"
+        plugin.authenticationPluginConfiguration = authenticationMock
+
+        val result = plugin.downloadInformatieObject(executionMock)
+
+        assertEquals("tempResourceId", result)
+
+        val expectedDocumentUrl = URI("http://some-url/enkelvoudiginformatieobjecten/$documentId")
+        verify(client).getInformatieObject(
+            authentication = eq(authenticationMock),
+            caseDocumentId = eq(UUID.fromString(caseDocumentId)),
+            objectUrl = eq(expectedDocumentUrl)
+        )
+        verify(client).downloadInformatieObjectContent(
+            authentication = eq(authenticationMock),
+            caseDocumentId = eq(UUID.fromString(caseDocumentId)),
+            objectUrl = eq(expectedDocumentUrl)
+        )
+        verify(executionMock).setVariable(RESOURCE_ID_PROCESS_VAR, "tempResourceId")
+    }
+
+    @Test
+    fun `should throw when download plugin action has neither documentUrl nor documentId`() {
+        val storageService: TemporaryResourceStorageService = mock()
+        val applicationEventPublisher: ApplicationEventPublisher = mock()
+        val documentenApiVersionService: DocumentenApiVersionService = mock()
+        val executionMock = mock<DelegateExecution>()
+
+        whenever(executionMock.getVariable(DOCUMENT_URL_PROCESS_VAR))
+            .thenReturn(null)
+        whenever(executionMock.getVariable(DOCUMENT_ID_PROCESS_VAR))
+            .thenReturn(null)
+
+        val plugin = DocumentenApiPlugin(
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = false
+        )
+        plugin.url = URI("http://some-url")
+
+        val exception = assertThrows<IllegalStateException> {
+            plugin.downloadInformatieObject(executionMock)
+        }
+        assertEquals(
+            "Failed to download document. No process variable '$DOCUMENT_URL_PROCESS_VAR' or '$DOCUMENT_ID_PROCESS_VAR' found.",
+            exception.message
+        )
     }
 }

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -1089,6 +1089,75 @@ internal class DocumentenApiPluginTest {
     }
 
     @Test
+    fun `should fall back to documentId when documentUrl process variable is blank`() {
+        val storageService: TemporaryResourceStorageService = mock()
+        val applicationEventPublisher: ApplicationEventPublisher = mock()
+        val authenticationMock = mock<DocumentenApiAuthentication>()
+        val documentenApiVersionService: DocumentenApiVersionService = mock()
+        val executionMock = mock<DelegateExecution>()
+        val documentId = "3bd88200-11cb-45cf-a742-da01261755b1"
+        val caseDocumentId = "123e4567-e89b-12d3-a456-426655440000"
+
+        whenever(executionMock.getVariable(DOCUMENT_URL_PROCESS_VAR))
+            .thenReturn("")
+        whenever(executionMock.getVariable(DOCUMENT_ID_PROCESS_VAR))
+            .thenReturn(documentId)
+        whenever(executionMock.businessKey)
+            .thenReturn(caseDocumentId)
+        whenever(client.getInformatieObject(any<DocumentenApiAuthentication>(), any<UUID>(), any<URI>()))
+            .thenReturn(
+                DocumentInformatieObject(
+                    url = URI("http://some-url/enkelvoudiginformatieobjecten/$documentId"),
+                    bronorganisatie = Rsin("000000000"),
+                    creatiedatum = LocalDate.now(),
+                    titel = "titel",
+                    auteur = "auteur",
+                    taal = "taal",
+                    beginRegistratie = OffsetDateTime.now(),
+                    status = DEFINITIEF,
+                    bestandsnaam = "passport.jpg"
+                )
+            )
+        whenever(client.downloadInformatieObjectContent(any<DocumentenApiAuthentication>(), any<UUID>(), any<URI>()))
+            .thenReturn(ByteArrayInputStream("content".toByteArray()))
+        whenever(storageService.store(any(), any()))
+            .thenReturn("tempResourceId")
+
+        val plugin = DocumentenApiPlugin(
+            client = client,
+            storageService = storageService,
+            applicationEventPublisher = applicationEventPublisher,
+            objectMapper = MapperSingleton.get(),
+            documentDeleteHandlers = listOf(),
+            documentenApiVersionService = documentenApiVersionService,
+            pluginService = pluginService,
+            runtimeService = runtimeService,
+            virusScanService = virusScanService,
+            virusScanEnabledForDocumentenApiPlugin = false
+        )
+        plugin.url = URI("http://some-url")
+        plugin.bronorganisatie = "123456789"
+        plugin.authenticationPluginConfiguration = authenticationMock
+
+        val result = plugin.downloadInformatieObject(executionMock)
+
+        assertEquals("tempResourceId", result)
+
+        val expectedDocumentUrl = URI("http://some-url/enkelvoudiginformatieobjecten/$documentId")
+        verify(client).getInformatieObject(
+            authentication = eq(authenticationMock),
+            caseDocumentId = eq(UUID.fromString(caseDocumentId)),
+            objectUrl = eq(expectedDocumentUrl)
+        )
+        verify(client).downloadInformatieObjectContent(
+            authentication = eq(authenticationMock),
+            caseDocumentId = eq(UUID.fromString(caseDocumentId)),
+            objectUrl = eq(expectedDocumentUrl)
+        )
+        verify(executionMock).setVariable(RESOURCE_ID_PROCESS_VAR, "tempResourceId")
+    }
+
+    @Test
     fun `should throw when download plugin action has neither documentUrl nor documentId`() {
         val storageService: TemporaryResourceStorageService = mock()
         val applicationEventPublisher: ApplicationEventPublisher = mock()

--- a/documentation/features/plugins/configure-documenten-api-plugin.md
+++ b/documentation/features/plugins/configure-documenten-api-plugin.md
@@ -74,12 +74,14 @@ This process link does the following steps:
 
 ### Download document
 
-The **Download document** action downloads a document from the Documenten API and saves it as a temporary file. No configuration data has to be provided in order to configure this plugin action.
+The **Download document** action downloads a document from the Documenten API and saves it as a temporary file.
+
+The document to download is resolved from either the `documentUrl` or the `documentId` process variable. When both are present, `documentUrl` takes precedence. When only `documentId` is present, the document URL is built from the plugin's configured base URL. If neither variable is present, the action fails.
 
 This process link does the following steps:
 
-1. Take the document URL that is saved in the process variable `documentUrl`.
-2. Download the document and saves it to a temporary file.
+1. Resolves the document URL from the process variable `documentUrl`, or builds it from the process variable `documentId` when `documentUrl` is not present.
+2. Downloads the document and saves it to a temporary file.
 3. Creates a new process variable with the name of your choosing, by default: `resourceId`, containing the temporary file ID.
 
 ### Get audit trail

--- a/documentation/release-notes/13.x.x/13.35.0/README.md
+++ b/documentation/release-notes/13.x.x/13.35.0/README.md
@@ -45,6 +45,12 @@ elements and displays an error panel. Clicking an error navigates to the element
   It is now possible to configure the default state for the sidebar (collapsed or not) application wide via the settings
   page. User specific settings overwrite this.
 
+* **Download document by document ID in the Documenten API plugin**
+
+  The *download document* action now also works when only the document ID is available. It reads the `documentId`
+  process variable and builds the document URL from the plugin's configured base URL. The existing `documentUrl`
+  process variable still takes precedence when both are present, so existing processes are unaffected.
+
 ## Bugfixes
 
 * **Sortable controls hidden for non-sortable paths**

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api/components/download-document/download-document-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api/components/download-document/download-document-configuration.component.html
@@ -14,6 +14,9 @@
   ~ limitations under the License.
   -->
 
+<v-paragraph [margin]="true" [italic]="true">
+  {{ 'downloadDocumentMessage' | pluginTranslate: pluginId | async }}
+</v-paragraph>
 <v-form
   (valueChange)="formValueChange($event)"
   *ngIf="{

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api/documenten-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/documenten-api/documenten-api-plugin.specification.ts
@@ -114,9 +114,13 @@ const documentenApiPluginSpecification: PluginSpecification = {
       apiVersion: 'Documenten API versie',
       apiVersionTooltip: 'Selecteer de versie van de Documenten API',
       downloadDocumentMessage:
-        'Het downloaden van een document vanuit de Documenten API vereist geen configuratie.',
+        "Downloadt een document vanuit de Documenten API en slaat dit op als tijdelijk document. " +
+        "Het te downloaden document wordt bepaald op basis van de procesvariabele 'documentUrl' of 'documentId'; " +
+        "als beide aanwezig zijn heeft 'documentUrl' voorrang.",
       processVariableName:
         'Wat is de naam van de procesvariabele waarnaar u het document wilt downloaden?',
+      processVariableTooltip:
+        'De naam van de procesvariabele waarin de referentie naar het gedownloade document wordt opgeslagen.',
       linkDocumentToObjectMessage:
         "Koppelt het document waarvan de URL is opgeslagen in de procesvariabele 'documentUrl' aan een object. " +
         "Procesvariabelen kunnen worden gebruikt met de notatie 'pv:variabelenaam'.",
@@ -220,9 +224,13 @@ const documentenApiPluginSpecification: PluginSpecification = {
       apiVersion: 'Documenten API version',
       apiVersionTooltip: 'Select the version of the Documenten API',
       downloadDocumentMessage:
-        'Downloading a document form the Documenten API does not require any configuration.',
+        "Downloads a document from the Documenten API and stores it as a temporary document. " +
+        "The document is identified by either the 'documentUrl' or the 'documentId' process variable; " +
+        "when both are present 'documentUrl' takes precedence.",
       processVariableName:
         'What is the name of the process variable you want to download the document to?',
+      processVariableTooltip:
+        'The name of the process variable in which the reference to the downloaded document is stored.',
       linkDocumentToObjectMessage:
         "Links the document whose URL is stored in the process variable 'documentUrl' to an object. For Zaak items use the Zaken API to ensure backwards compatibility." +
         "Process variables can be referenced using the notation 'pv:variableName'.",


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/781

The Documenten API plugin's **Download document** action (`download-document`) could only resolve a document from the full `documentUrl` process variable. Processes that only retained the bare document ID — stored in the `documentId` process variable by the plugin's *store* actions — had to reconstruct the full URL themselves before downloading, which is awkward and error-prone (especially in Building Block flows).

This PR extends the action to resolve the document to download from **either** `documentUrl` **or** `documentId`:

- `documentUrl` takes precedence when both are present, so existing processes are unaffected.
- When only `documentId` is present, the document URL is built from the plugin's configured base URL via the existing `createInformatieObjectUrl(documentId)` helper (`{baseUrl}/enkelvoudiginformatieobjecten/{documentId}`).
- When neither variable is present, the action throws a descriptive `IllegalStateException` naming both variables.

The resolution logic was extracted into a private `resolveDownloadDocumentUrl(execution)` method. No new public client methods were added — existing `getInformatieObject` / `downloadInformatieObjectContent` overloads are reused. The `documentUrl` ownership guard (URL must start with the plugin's configured base URL) is preserved; the `documentId` path needs no host check since the URL is built from the plugin's own base URL.

Frontend: the **Download document** configuration screen now shows an explanatory paragraph (`downloadDocumentMessage`), updated NL/EN translations describe the `documentUrl`/`documentId` resolution and precedence, and a `processVariableTooltip` translation was added for the output-variable field.

Documentation: the plugin feature docs and the `13.35.0` release notes were updated.

Also included: minor `logback-spring.xml` log-level tweaks (`com.ritense.valtimo.web.sse`, `io.github.resilience4j.circuitbreaker`, `org.postgresql` set to `WARN`) to reduce dev-app noise.

Specify the code branch location: `story/gh-781_documenten-api_download-document-supports-document-id` → `next-minor`

**Relevant comments:**
> The unit test diff is large mostly due to a mechanical refactor of `DocumentenApiPluginTest` to use named constructor/method arguments; the behavioral additions are the two new download tests (documentId path + missing-variable error path).

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Describe the testing steps
- [ ] Configure a Documenten API plugin and a process with the **Download document** action.
- [ ] Start a process that sets only the `documentId` process variable → document is downloaded and `resourceId` (or configured output variable) is set.
- [ ] Start a process that sets both `documentUrl` and `documentId` → `documentUrl` is used (precedence).
- [ ] Start a process that sets neither → action fails with an `IllegalStateException` naming both `documentUrl` and `documentId`.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
