### PR TITLE
Add Catalogi API plugin action to retrieve informatieobjecttypen

### DIFF
--- a/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/bpmn/catalogi-get-typen.bpmn
+++ b/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/bpmn/catalogi-get-typen.bpmn
@@ -1,64 +1,82 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_17rq342" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.38.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0">
-  <bpmn:process id="catalogi-get-typen" name="Catalogi - Get typen" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.38.1" expressionLanguage="http://www.w3.org/1999/XPath" id="Definitions_17rq342" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0" targetNamespace="http://bpmn.io/schema/bpmn" typeLanguage="http://www.w3.org/2001/XMLSchema">
+  <bpmn:process camunda:versionTag="CD:bezwaar:1.0.1" id="catalogi-get-typen" isClosed="false" isExecutable="true" name="Catalogi - Get typen" processType="None">
+    <bpmn:startEvent id="StartEvent_1" isInterrupting="true" parallelMultiple="false">
       <bpmn:outgoing>Flow_17xklrh</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_17xklrh" sourceRef="StartEvent_1" targetRef="get-status-typen" />
-    <bpmn:sequenceFlow id="Flow_0s95ctv" sourceRef="get-status-typen" targetRef="get-resultaat-typen" />
+    <bpmn:sequenceFlow id="Flow_17xklrh" sourceRef="StartEvent_1" targetRef="get-status-typen"/>
+    <bpmn:sequenceFlow id="Flow_0s95ctv" sourceRef="get-status-typen" targetRef="get-resultaat-typen"/>
     <bpmn:endEvent id="Event_1bu80xq">
       <bpmn:incoming>Flow_189qqft</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0diuqjl" sourceRef="get-resultaat-typen" targetRef="validate-fetched-typen" />
-    <bpmn:serviceTask id="get-status-typen" name="Get Status typen">
+    <bpmn:sequenceFlow id="Flow_0diuqjl" sourceRef="get-resultaat-typen" targetRef="get-informatieobject-typen"/>
+    <bpmn:serviceTask camunda:asyncAfter="true" camunda:expression="${null}" completionQuantity="1" id="get-status-typen" implementation="##WebService" isForCompensation="false" name="Get Status typen" startQuantity="1">
       <bpmn:incoming>Flow_17xklrh</bpmn:incoming>
       <bpmn:outgoing>Flow_0s95ctv</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="get-resultaat-typen" name="Get Resultaat typen">
+    <bpmn:serviceTask camunda:asyncAfter="true" camunda:expression="${null}" completionQuantity="1" id="get-resultaat-typen" implementation="##WebService" isForCompensation="false" name="Get Resultaat typen" startQuantity="1">
       <bpmn:incoming>Flow_0s95ctv</bpmn:incoming>
       <bpmn:outgoing>Flow_0diuqjl</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_189qqft" sourceRef="validate-fetched-typen" targetRef="Event_1bu80xq" />
-    <bpmn:userTask id="validate-fetched-typen" name="Valideer opgehaalde typen" camunda:candidateGroups="ROLE_USER">
-      <bpmn:incoming>Flow_0diuqjl</bpmn:incoming>
+    <bpmn:sequenceFlow id="Flow_189qqft" sourceRef="validate-fetched-typen" targetRef="Event_1bu80xq"/>
+    <bpmn:userTask camunda:candidateGroups="ROLE_USER" completionQuantity="1" id="validate-fetched-typen" implementation="##unspecified" isForCompensation="false" name="Valideer opgehaalde typen" startQuantity="1">
+      <bpmn:incoming>Flow_05bdmyt</bpmn:incoming>
       <bpmn:outgoing>Flow_189qqft</bpmn:outgoing>
     </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_05bdmyt" sourceRef="get-informatieobject-typen" targetRef="validate-fetched-typen"/>
+    <bpmn:serviceTask camunda:asyncAfter="true" camunda:expression="${null}" completionQuantity="1" id="get-informatieobject-typen" implementation="##WebService" isForCompensation="false" name="Get Informatieobject typen" startQuantity="1">
+      <bpmn:incoming>Flow_0diuqjl</bpmn:incoming>
+      <bpmn:outgoing>Flow_05bdmyt</bpmn:outgoing>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="catalogi-get-typen">
-      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="182" y="102" width="36" height="36" />
+    <bpmndi:BPMNPlane bpmnElement="catalogi-get-typen" id="BPMNPlane_1">
+      <bpmndi:BPMNShape bpmnElement="StartEvent_1" id="StartEvent_1_di">
+        <dc:Bounds height="36" width="36" x="182" y="102"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1bu80xq_di" bpmnElement="Event_1bu80xq">
-        <dc:Bounds x="742" y="102" width="36" height="36" />
+      <bpmndi:BPMNShape bpmnElement="Event_1bu80xq" id="Event_1bu80xq_di">
+        <dc:Bounds height="36" width="36" x="872" y="102"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0e7s3jf_di" bpmnElement="get-status-typen">
-        <dc:Bounds x="270" y="80" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape bpmnElement="get-status-typen" id="Activity_0e7s3jf_di">
+        <dc:Bounds height="80" width="100" x="270" y="80"/>
+        <bpmndi:BPMNLabel/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0p34kqa_di" bpmnElement="get-resultaat-typen">
-        <dc:Bounds x="430" y="80" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape bpmnElement="get-resultaat-typen" id="Activity_0p34kqa_di">
+        <dc:Bounds height="80" width="100" x="430" y="80"/>
+        <bpmndi:BPMNLabel/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1gqkfw6_di" bpmnElement="validate-fetched-typen">
-        <dc:Bounds x="590" y="80" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape bpmnElement="validate-fetched-typen" id="Activity_1gqkfw6_di">
+        <dc:Bounds height="80" width="100" x="730" y="80"/>
+        <bpmndi:BPMNLabel/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_17xklrh_di" bpmnElement="Flow_17xklrh">
-        <di:waypoint x="218" y="120" />
-        <di:waypoint x="270" y="120" />
+      <bpmndi:BPMNShape bpmnElement="get-informatieobject-typen" id="Activity_08ceywd_di">
+        <dc:Bounds height="80" width="100" x="580" y="80"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="Flow_17xklrh" id="Flow_17xklrh_di">
+        <di:waypoint x="218" y="120"/>
+        <di:waypoint x="270" y="120"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0s95ctv_di" bpmnElement="Flow_0s95ctv">
-        <di:waypoint x="370" y="120" />
-        <di:waypoint x="430" y="120" />
+      <bpmndi:BPMNEdge bpmnElement="Flow_0s95ctv" id="Flow_0s95ctv_di">
+        <di:waypoint x="370" y="120"/>
+        <di:waypoint x="430" y="120"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0diuqjl_di" bpmnElement="Flow_0diuqjl">
-        <di:waypoint x="530" y="120" />
-        <di:waypoint x="590" y="120" />
+      <bpmndi:BPMNEdge bpmnElement="Flow_0diuqjl" id="Flow_0diuqjl_di">
+        <di:waypoint x="530" y="120"/>
+        <di:waypoint x="580" y="120"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189qqft_di" bpmnElement="Flow_189qqft">
-        <di:waypoint x="690" y="120" />
-        <di:waypoint x="742" y="120" />
+      <bpmndi:BPMNEdge bpmnElement="Flow_189qqft" id="Flow_189qqft_di">
+        <di:waypoint x="830" y="120"/>
+        <di:waypoint x="872" y="120"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="Flow_05bdmyt" id="Flow_05bdmyt_di">
+        <di:waypoint x="680" y="120"/>
+        <di:waypoint x="730" y="120"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/bpmn/catalogi-get-typen.bpmn
+++ b/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/bpmn/catalogi-get-typen.bpmn
@@ -6,12 +6,12 @@
   xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
   xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.38.1" expressionLanguage="http://www.w3.org/1999/XPath" id="Definitions_17rq342" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0" targetNamespace="http://bpmn.io/schema/bpmn" typeLanguage="http://www.w3.org/2001/XMLSchema">
   <bpmn:process camunda:versionTag="CD:bezwaar:1.0.1" id="catalogi-get-typen" isClosed="false" isExecutable="true" name="Catalogi - Get typen" processType="None">
-    <bpmn:startEvent id="StartEvent_1" isInterrupting="true" parallelMultiple="false">
+    <bpmn:startEvent id="start-event" isInterrupting="true" parallelMultiple="false">
       <bpmn:outgoing>Flow_17xklrh</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_17xklrh" sourceRef="StartEvent_1" targetRef="get-status-typen"/>
+    <bpmn:sequenceFlow id="Flow_17xklrh" sourceRef="start-event" targetRef="get-status-typen"/>
     <bpmn:sequenceFlow id="Flow_0s95ctv" sourceRef="get-status-typen" targetRef="get-resultaat-typen"/>
-    <bpmn:endEvent id="Event_1bu80xq">
+    <bpmn:endEvent id="end-event">
       <bpmn:incoming>Flow_189qqft</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0diuqjl" sourceRef="get-resultaat-typen" targetRef="get-informatieobject-typen"/>
@@ -23,7 +23,7 @@
       <bpmn:incoming>Flow_0s95ctv</bpmn:incoming>
       <bpmn:outgoing>Flow_0diuqjl</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_189qqft" sourceRef="validate-fetched-typen" targetRef="Event_1bu80xq"/>
+    <bpmn:sequenceFlow id="Flow_189qqft" sourceRef="validate-fetched-typen" targetRef="end-event"/>
     <bpmn:userTask camunda:candidateGroups="ROLE_USER" completionQuantity="1" id="validate-fetched-typen" implementation="##unspecified" isForCompensation="false" name="Valideer opgehaalde typen" startQuantity="1">
       <bpmn:incoming>Flow_05bdmyt</bpmn:incoming>
       <bpmn:outgoing>Flow_189qqft</bpmn:outgoing>
@@ -36,10 +36,10 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane bpmnElement="catalogi-get-typen" id="BPMNPlane_1">
-      <bpmndi:BPMNShape bpmnElement="StartEvent_1" id="StartEvent_1_di">
+      <bpmndi:BPMNShape bpmnElement="start-event" id="StartEvent_1_di">
         <dc:Bounds height="36" width="36" x="182" y="102"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="Event_1bu80xq" id="Event_1bu80xq_di">
+      <bpmndi:BPMNShape bpmnElement="end-event" id="Event_1bu80xq_di">
         <dc:Bounds height="36" width="36" x="872" y="102"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="get-status-typen" id="Activity_0e7s3jf_di">

--- a/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/form/start-form-catalogi-get-typen.form.json
+++ b/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/form/start-form-catalogi-get-typen.form.json
@@ -6,7 +6,7 @@
       "type" : "htmlelement",
       "input" : false,
       "label" : "HTML",
-      "content" : "Klik start om Status en Resultaat typen op te halen bij de Catalogi API.",
+      "content" : "Klik start om Status, Resultaat en Informatieobject typen op te halen bij de Catalogi API.",
       "tableView" : false,
       "refreshOnChange" : false
     },

--- a/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/form/start-form-catalogi-get-typen.form.json
+++ b/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/form/start-form-catalogi-get-typen.form.json
@@ -1,44 +1,64 @@
 {
-    "display": "form",
-    "components": [
-        {
-            "label": "HTML",
-            "content": "Klik start om Status en Resultaat typen op te halen bij de Catalogi API.",
-            "refreshOnChange": false,
-            "key": "html",
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false
-        },
-        {
-            "label": "Proces variabele - Status typen",
-            "key": "pv.statusTypenPV",
-            "type": "textfield",
-            "input": true,
-            "validate": {
-                "required": true
-            },
-            "defaultValue": "statusTypen",
-            "disabled": true
-        },
-        {
-            "label": "Proces variabele - Resultaat typen",
-            "key": "pv.resultaatTypenPV",
-            "type": "textfield",
-            "input": true,
-            "validate": {
-                "required": true
-            },
-            "defaultValue": "resultaatTypen",
-            "disabled": true
-        },
-        {
-            "type": "button",
-            "label": "Start",
-            "key": "submit",
-            "disableOnInvalid": true,
-            "input": true,
-            "tableView": false
-        }
-    ]
+  "display" : "form",
+  "components" : [
+    {
+      "key" : "html",
+      "type" : "htmlelement",
+      "input" : false,
+      "label" : "HTML",
+      "content" : "Klik start om Status en Resultaat typen op te halen bij de Catalogi API.",
+      "tableView" : false,
+      "refreshOnChange" : false
+    },
+    {
+      "key" : "pv.statusTypenPV",
+      "type" : "textfield",
+      "input" : true,
+      "label" : "Proces variabele - Status typen",
+      "disabled" : true,
+      "validate" : {
+        "required" : true
+      },
+      "attributes" : {
+        "data-testid" : "start-form-catalogi-get-typen-pv.statusTypenPV"
+      },
+      "defaultValue" : "statusTypen"
+    },
+    {
+      "key" : "pv.resultaatTypenPV",
+      "type" : "textfield",
+      "input" : true,
+      "label" : "Proces variabele - Resultaat typen",
+      "disabled" : true,
+      "validate" : {
+        "required" : true
+      },
+      "attributes" : {
+        "data-testid" : "start-form-catalogi-get-typen-pv.resultaatTypenPV"
+      },
+      "defaultValue" : "resultaatTypen"
+    },
+    {
+      "key" : "pv.informatieObjectTypenPV",
+      "type" : "textfield",
+      "input" : true,
+      "label" : "Proces variabele - Informatieobject typen",
+      "disabled" : true,
+      "validate" : {
+        "required" : true
+      },
+      "attributes" : {
+        "data-testid" : "start-form-catalogi-get-typen-pv.informatieObjectTypenPV"
+      },
+      "defaultValue" : "informatieObjectTypen"
+    },
+    {
+      "key" : "submit",
+      "type" : "button",
+      "input" : true,
+      "label" : "Start",
+      "tableView" : false,
+      "disableOnInvalid" : true
+    }
+  ]
 }

--- a/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/form/user-task-validate-typen.form.json
+++ b/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/form/user-task-validate-typen.form.json
@@ -1,64 +1,616 @@
 {
-    "display": "form",
-    "components": [
-        {
-            "key": "statusType",
-            "type": "select",
-            "input": true,
-            "label": "Status type",
-            "widget": "choicesjs",
-            "validate": {
-                "required": true
-            },
-            "dataSrc": "custom",
-            "template": "<span>{{ item.name }}</span>",
-            "idPath": "url",
-            "data": {
-                "custom": "values = data['statusTypenContainer'];"
-            }
-        },
-        {
-            "key": "statusTypenContainer",
-            "type": "hidden",
-            "input": true,
-            "label": "Status typen container",
-            "persistent": "client-only",
-            "properties": {
-                "sourceKey": "pv:statusTypen"
-            }
-        },
-        {
-            "key": "resultaatType",
-            "type": "select",
-            "input": true,
-            "label": "Resultaat type",
-            "widget": "choicesjs",
-            "validate": {
-                "required": true
-            },
-            "dataSrc": "custom",
-            "template": "<span>{{ item.name }}</span>",
-            "idPath": "url",
-            "data": {
-                "custom": "values = data['resultaatTypenContainer'];"
-            }
-        },
-        {
-            "key": "resultaatTypenContainer",
-            "type": "hidden",
-            "input": true,
-            "label": "Resultaat typen container",
-            "persistent": "client-only",
-            "properties": {
-                "sourceKey": "pv:resultaatTypen"
-            }
-        },
-        {
-            "type": "button",
-            "key": "submit",
-            "label": "Submit",
-            "disableOnInvalid": true,
-            "input": true
-        }
-    ]
+  "display" : "form",
+  "components" : [
+    {
+      "id" : "e8cw1b9",
+      "key" : "statusType",
+      "data" : {
+        "url" : "",
+        "json" : "",
+        "custom" : "values = data['statusTypenContainer'];",
+        "values" : [
+          {
+            "label" : "",
+            "value" : ""
+          }
+        ],
+        "resource" : ""
+      },
+      "type" : "select",
+      "input" : true,
+      "label" : "Status type",
+      "limit" : 100,
+      "addons" : [],
+      "filter" : "",
+      "hidden" : false,
+      "idPath" : "url",
+      "prefix" : "",
+      "suffix" : "",
+      "unique" : false,
+      "widget" : "choicesjs",
+      "dataSrc" : "custom",
+      "dbIndex" : false,
+      "overlay" : {
+        "top" : "",
+        "left" : "",
+        "style" : "",
+        "width" : "",
+        "height" : ""
+      },
+      "tooltip" : "",
+      "disabled" : false,
+      "lazyLoad" : true,
+      "multiple" : false,
+      "redrawOn" : "",
+      "tabindex" : "",
+      "template" : "<span>{{ item.name }}</span>",
+      "validate" : {
+        "custom" : "",
+        "unique" : false,
+        "multiple" : false,
+        "required" : true,
+        "customPrivate" : false,
+        "onlyAvailableItems" : false,
+        "strictDateValidation" : false
+      },
+      "autofocus" : false,
+      "encrypted" : false,
+      "hideLabel" : false,
+      "indexeddb" : {
+        "filter" : {}
+      },
+      "minSearch" : 0,
+      "modalEdit" : false,
+      "protected" : false,
+      "refreshOn" : "",
+      "tableView" : true,
+      "attributes" : {
+        "data-testid" : "user-task-validate-typen-statusType"
+      },
+      "errorLabel" : "",
+      "persistent" : true,
+      "properties" : {},
+      "validateOn" : "change",
+      "clearOnHide" : true,
+      "conditional" : {
+        "eq" : "",
+        "show" : null,
+        "when" : null
+      },
+      "customClass" : "",
+      "description" : "",
+      "fuseOptions" : {
+        "include" : "score",
+        "threshold" : 0.3
+      },
+      "ignoreCache" : false,
+      "placeholder" : "",
+      "searchField" : "",
+      "authenticate" : false,
+      "defaultValue" : null,
+      "selectFields" : "",
+      "customOptions" : {},
+      "dataGridLabel" : false,
+      "labelPosition" : "top",
+      "readOnlyValue" : false,
+      "searchEnabled" : true,
+      "showCharCount" : false,
+      "showWordCount" : false,
+      "uniqueOptions" : false,
+      "valueProperty" : "",
+      "calculateValue" : "",
+      "clearOnRefresh" : false,
+      "searchDebounce" : 0.3,
+      "useExactSearch" : false,
+      "calculateServer" : false,
+      "selectThreshold" : 0.3,
+      "allowMultipleMasks" : false,
+      "customDefaultValue" : "",
+      "allowCalculateOverride" : false
+    },
+    {
+      "id" : "epwoyb",
+      "key" : "statusTypenContainer",
+      "type" : "hidden",
+      "input" : true,
+      "label" : "Status typen container",
+      "addons" : [],
+      "hidden" : false,
+      "prefix" : "",
+      "suffix" : "",
+      "unique" : false,
+      "widget" : {
+        "type" : "input"
+      },
+      "dbIndex" : false,
+      "overlay" : {
+        "top" : "",
+        "left" : "",
+        "style" : "",
+        "width" : "",
+        "height" : ""
+      },
+      "tooltip" : "",
+      "disabled" : false,
+      "multiple" : false,
+      "redrawOn" : "",
+      "tabindex" : "",
+      "validate" : {
+        "custom" : "",
+        "unique" : false,
+        "multiple" : false,
+        "required" : false,
+        "customPrivate" : false,
+        "strictDateValidation" : false
+      },
+      "autofocus" : false,
+      "encrypted" : false,
+      "hideLabel" : false,
+      "inputType" : "hidden",
+      "modalEdit" : false,
+      "protected" : false,
+      "refreshOn" : "",
+      "tableView" : false,
+      "attributes" : {
+        "data-testid" : "user-task-validate-typen-statusTypenContainer"
+      },
+      "errorLabel" : "",
+      "persistent" : "client-only",
+      "properties" : {
+        "sourceKey" : "pv:statusTypen"
+      },
+      "validateOn" : "change",
+      "clearOnHide" : true,
+      "conditional" : {
+        "eq" : "",
+        "show" : null,
+        "when" : null
+      },
+      "customClass" : "",
+      "description" : "",
+      "placeholder" : "",
+      "defaultValue" : null,
+      "dataGridLabel" : false,
+      "labelPosition" : "top",
+      "showCharCount" : false,
+      "showWordCount" : false,
+      "calculateValue" : "",
+      "calculateServer" : false,
+      "allowMultipleMasks" : false,
+      "customDefaultValue" : "",
+      "allowCalculateOverride" : false
+    },
+    {
+      "id" : "ewdaepa",
+      "key" : "resultaatType",
+      "data" : {
+        "url" : "",
+        "json" : "",
+        "custom" : "values = data['resultaatTypenContainer'];",
+        "values" : [
+          {
+            "label" : "",
+            "value" : ""
+          }
+        ],
+        "resource" : ""
+      },
+      "type" : "select",
+      "input" : true,
+      "label" : "Resultaat type",
+      "limit" : 100,
+      "addons" : [],
+      "filter" : "",
+      "hidden" : false,
+      "idPath" : "url",
+      "prefix" : "",
+      "suffix" : "",
+      "unique" : false,
+      "widget" : "choicesjs",
+      "dataSrc" : "custom",
+      "dbIndex" : false,
+      "overlay" : {
+        "top" : "",
+        "left" : "",
+        "style" : "",
+        "width" : "",
+        "height" : ""
+      },
+      "tooltip" : "",
+      "disabled" : false,
+      "lazyLoad" : true,
+      "multiple" : false,
+      "redrawOn" : "",
+      "tabindex" : "",
+      "template" : "<span>{{ item.name }}</span>",
+      "validate" : {
+        "custom" : "",
+        "unique" : false,
+        "multiple" : false,
+        "required" : true,
+        "customPrivate" : false,
+        "onlyAvailableItems" : false,
+        "strictDateValidation" : false
+      },
+      "autofocus" : false,
+      "encrypted" : false,
+      "hideLabel" : false,
+      "indexeddb" : {
+        "filter" : {}
+      },
+      "minSearch" : 0,
+      "modalEdit" : false,
+      "protected" : false,
+      "refreshOn" : "",
+      "tableView" : true,
+      "attributes" : {
+        "data-testid" : "user-task-validate-typen-resultaatType"
+      },
+      "errorLabel" : "",
+      "persistent" : true,
+      "properties" : {},
+      "validateOn" : "change",
+      "clearOnHide" : true,
+      "conditional" : {
+        "eq" : "",
+        "show" : null,
+        "when" : null
+      },
+      "customClass" : "",
+      "description" : "",
+      "fuseOptions" : {
+        "include" : "score",
+        "threshold" : 0.3
+      },
+      "ignoreCache" : false,
+      "placeholder" : "",
+      "searchField" : "",
+      "authenticate" : false,
+      "defaultValue" : null,
+      "selectFields" : "",
+      "customOptions" : {},
+      "dataGridLabel" : false,
+      "labelPosition" : "top",
+      "readOnlyValue" : false,
+      "searchEnabled" : true,
+      "showCharCount" : false,
+      "showWordCount" : false,
+      "uniqueOptions" : false,
+      "valueProperty" : "",
+      "calculateValue" : "",
+      "clearOnRefresh" : false,
+      "searchDebounce" : 0.3,
+      "useExactSearch" : false,
+      "calculateServer" : false,
+      "selectThreshold" : 0.3,
+      "allowMultipleMasks" : false,
+      "customDefaultValue" : "",
+      "allowCalculateOverride" : false
+    },
+    {
+      "id" : "esrs6af",
+      "key" : "resultaatTypenContainer",
+      "type" : "hidden",
+      "input" : true,
+      "label" : "Resultaat typen container",
+      "addons" : [],
+      "hidden" : false,
+      "prefix" : "",
+      "suffix" : "",
+      "unique" : false,
+      "widget" : {
+        "type" : "input"
+      },
+      "dbIndex" : false,
+      "overlay" : {
+        "top" : "",
+        "left" : "",
+        "style" : "",
+        "width" : "",
+        "height" : ""
+      },
+      "tooltip" : "",
+      "disabled" : false,
+      "multiple" : false,
+      "redrawOn" : "",
+      "tabindex" : "",
+      "validate" : {
+        "custom" : "",
+        "unique" : false,
+        "multiple" : false,
+        "required" : false,
+        "customPrivate" : false,
+        "strictDateValidation" : false
+      },
+      "autofocus" : false,
+      "encrypted" : false,
+      "hideLabel" : false,
+      "inputType" : "hidden",
+      "modalEdit" : false,
+      "protected" : false,
+      "refreshOn" : "",
+      "tableView" : false,
+      "attributes" : {
+        "data-testid" : "user-task-validate-typen-resultaatTypenContainer"
+      },
+      "errorLabel" : "",
+      "persistent" : "client-only",
+      "properties" : {
+        "sourceKey" : "pv:resultaatTypen"
+      },
+      "validateOn" : "change",
+      "clearOnHide" : true,
+      "conditional" : {
+        "eq" : "",
+        "show" : null,
+        "when" : null
+      },
+      "customClass" : "",
+      "description" : "",
+      "placeholder" : "",
+      "defaultValue" : null,
+      "dataGridLabel" : false,
+      "labelPosition" : "top",
+      "showCharCount" : false,
+      "showWordCount" : false,
+      "calculateValue" : "",
+      "calculateServer" : false,
+      "allowMultipleMasks" : false,
+      "customDefaultValue" : "",
+      "allowCalculateOverride" : false
+    },
+    {
+      "id" : "el3qde",
+      "key" : "informatieObjectType",
+      "data" : {
+        "url" : "",
+        "json" : "",
+        "custom" : "values = data['informatieObjectTypenContainer'];",
+        "values" : [
+          {
+            "label" : "",
+            "value" : ""
+          }
+        ],
+        "resource" : ""
+      },
+      "type" : "select",
+      "input" : true,
+      "label" : "Informatieobject typen",
+      "limit" : 100,
+      "addons" : [],
+      "filter" : "",
+      "hidden" : false,
+      "idPath" : "url",
+      "prefix" : "",
+      "suffix" : "",
+      "unique" : false,
+      "widget" : "choicesjs",
+      "dataSrc" : "custom",
+      "dbIndex" : false,
+      "overlay" : {
+        "top" : "",
+        "left" : "",
+        "style" : "",
+        "width" : "",
+        "height" : ""
+      },
+      "tooltip" : "",
+      "disabled" : false,
+      "lazyLoad" : true,
+      "multiple" : false,
+      "redrawOn" : "",
+      "tabindex" : "",
+      "template" : "<span>{{ item.name }}</span>",
+      "validate" : {
+        "custom" : "",
+        "unique" : false,
+        "multiple" : false,
+        "required" : true,
+        "customPrivate" : false,
+        "onlyAvailableItems" : false,
+        "strictDateValidation" : false
+      },
+      "autofocus" : false,
+      "encrypted" : false,
+      "hideLabel" : false,
+      "indexeddb" : {
+        "filter" : {}
+      },
+      "minSearch" : 0,
+      "modalEdit" : false,
+      "protected" : false,
+      "refreshOn" : "",
+      "tableView" : true,
+      "attributes" : {
+        "data-testid" : "user-task-validate-typen-informatieObjectType"
+      },
+      "errorLabel" : "",
+      "persistent" : true,
+      "properties" : {},
+      "validateOn" : "change",
+      "clearOnHide" : true,
+      "conditional" : {
+        "eq" : "",
+        "show" : null,
+        "when" : null
+      },
+      "customClass" : "",
+      "description" : "",
+      "fuseOptions" : {
+        "include" : "score",
+        "threshold" : 0.3
+      },
+      "ignoreCache" : false,
+      "placeholder" : "",
+      "searchField" : "",
+      "authenticate" : false,
+      "defaultValue" : null,
+      "selectFields" : "",
+      "customOptions" : {},
+      "dataGridLabel" : false,
+      "labelPosition" : "top",
+      "readOnlyValue" : false,
+      "searchEnabled" : true,
+      "showCharCount" : false,
+      "showWordCount" : false,
+      "uniqueOptions" : false,
+      "valueProperty" : "",
+      "calculateValue" : "",
+      "clearOnRefresh" : false,
+      "searchDebounce" : 0.3,
+      "useExactSearch" : false,
+      "calculateServer" : false,
+      "selectThreshold" : 0.3,
+      "allowMultipleMasks" : false,
+      "customDefaultValue" : "",
+      "allowCalculateOverride" : false
+    },
+    {
+      "id" : "e2v3b6",
+      "key" : "informatieObjectTypenContainer",
+      "type" : "hidden",
+      "input" : true,
+      "label" : "Informatieobject typen container",
+      "addons" : [],
+      "hidden" : false,
+      "prefix" : "",
+      "suffix" : "",
+      "unique" : false,
+      "widget" : {
+        "type" : "input"
+      },
+      "dbIndex" : false,
+      "overlay" : {
+        "top" : "",
+        "left" : "",
+        "style" : "",
+        "width" : "",
+        "height" : ""
+      },
+      "tooltip" : "",
+      "disabled" : false,
+      "multiple" : false,
+      "redrawOn" : "",
+      "tabindex" : "",
+      "validate" : {
+        "custom" : "",
+        "unique" : false,
+        "multiple" : false,
+        "required" : false,
+        "customPrivate" : false,
+        "strictDateValidation" : false
+      },
+      "autofocus" : false,
+      "encrypted" : false,
+      "hideLabel" : false,
+      "inputType" : "hidden",
+      "modalEdit" : false,
+      "protected" : false,
+      "refreshOn" : "",
+      "tableView" : false,
+      "attributes" : {
+        "data-testid" : "user-task-validate-typen-informatieObjectTypenContainer"
+      },
+      "errorLabel" : "",
+      "persistent" : "client-only",
+      "properties" : {
+        "sourceKey" : "pv:informatieObjectTypen"
+      },
+      "validateOn" : "change",
+      "clearOnHide" : true,
+      "conditional" : {
+        "eq" : "",
+        "show" : null,
+        "when" : null
+      },
+      "customClass" : "",
+      "description" : "",
+      "placeholder" : "",
+      "defaultValue" : null,
+      "dataGridLabel" : false,
+      "labelPosition" : "top",
+      "showCharCount" : false,
+      "showWordCount" : false,
+      "calculateValue" : "",
+      "calculateServer" : false,
+      "allowMultipleMasks" : false,
+      "customDefaultValue" : "",
+      "allowCalculateOverride" : false
+    },
+    {
+      "id" : "e2jd2hj",
+      "key" : "submit",
+      "size" : "md",
+      "type" : "button",
+      "block" : false,
+      "input" : true,
+      "label" : "Submit",
+      "theme" : "primary",
+      "action" : "submit",
+      "addons" : [],
+      "hidden" : false,
+      "prefix" : "",
+      "suffix" : "",
+      "unique" : false,
+      "widget" : {
+        "type" : "input"
+      },
+      "dbIndex" : false,
+      "overlay" : {
+        "top" : "",
+        "left" : "",
+        "style" : "",
+        "width" : "",
+        "height" : ""
+      },
+      "tooltip" : "",
+      "disabled" : false,
+      "leftIcon" : "",
+      "multiple" : false,
+      "redrawOn" : "",
+      "tabindex" : "",
+      "validate" : {
+        "custom" : "",
+        "unique" : false,
+        "multiple" : false,
+        "required" : false,
+        "customPrivate" : false,
+        "strictDateValidation" : false
+      },
+      "autofocus" : false,
+      "encrypted" : false,
+      "hideLabel" : false,
+      "modalEdit" : false,
+      "protected" : false,
+      "refreshOn" : "",
+      "rightIcon" : "",
+      "tableView" : false,
+      "attributes" : {},
+      "errorLabel" : "",
+      "persistent" : false,
+      "properties" : {},
+      "validateOn" : "change",
+      "clearOnHide" : true,
+      "conditional" : {
+        "eq" : "",
+        "show" : null,
+        "when" : null
+      },
+      "customClass" : "",
+      "description" : "",
+      "placeholder" : "",
+      "defaultValue" : null,
+      "dataGridLabel" : true,
+      "labelPosition" : "top",
+      "showCharCount" : false,
+      "showWordCount" : false,
+      "calculateValue" : "",
+      "calculateServer" : false,
+      "disableOnInvalid" : true,
+      "allowMultipleMasks" : false,
+      "customDefaultValue" : "",
+      "allowCalculateOverride" : false
+    }
+  ]
 }

--- a/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/process-link/catalogi-get-typen.process-link.json
+++ b/backend/apps/dev/src/main/resources/config/case/bezwaar/1-0-1/process-link/catalogi-get-typen.process-link.json
@@ -1,36 +1,69 @@
 [
-    {
-        "activityId": "start-event",
-        "activityType": "bpmn:StartEvent:start",
-        "processLinkType": "form",
-        "formDefinitionName": "start-form-catalogi-get-typen"
+  {
+    "activityId" : "start-event",
+    "activityType" : "bpmn:StartEvent:start",
+    "formDefinitionName" : "start-form-catalogi-get-typen",
+    "viewModelEnabled" : false,
+    "formDisplayType" : "modal",
+    "formSize" : "medium",
+    "subtitles" : [],
+    "processLinkType" : "form"
+  },
+  {
+    "activityId" : "get-informatieobject-typen",
+    "activityType" : "bpmn:ServiceTask:start",
+    "pluginConfigurationId" : "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec",
+    "pluginActionDefinitionKey" : "get-informatieobjecttypen",
+    "actionProperties" : {
+      "zaaktypeUrl" : null,
+      "processVariable" : "pv:informatieObjectTypenPV"
     },
-    {
-        "activityId": "get-status-typen",
-        "activityType": "bpmn:ServiceTask:start",
-        "pluginConfigurationId": "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec",
-        "pluginActionDefinitionKey": "get-statustypen",
-        "actionProperties": {
-            "processVariable": "pv:statusTypenPV"
-        },
-        "processLinkType": "plugin"
+    "referenceType" : "FIXED",
+    "pluginDefinitionKey" : "catalogiapi",
+    "processLinkType" : "plugin"
+  },
+  {
+    "activityId" : "StartEvent_1",
+    "activityType" : "bpmn:StartEvent:start",
+    "formDefinitionName" : "start-form-catalogi-get-typen",
+    "viewModelEnabled" : false,
+    "formDisplayType" : "modal",
+    "formSize" : "medium",
+    "subtitles" : null,
+    "processLinkType" : "form"
+  },
+  {
+    "activityId" : "get-status-typen",
+    "activityType" : "bpmn:ServiceTask:start",
+    "pluginConfigurationId" : "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec",
+    "pluginActionDefinitionKey" : "get-statustypen",
+    "actionProperties" : {
+      "processVariable" : "pv:statusTypenPV"
     },
-    {
-        "activityId": "get-resultaat-typen",
-        "activityType": "bpmn:ServiceTask:start",
-        "pluginConfigurationId": "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec",
-        "pluginActionDefinitionKey": "get-resultaattypen",
-        "actionProperties": {
-            "processVariable": "pv:resultaatTypenPV"
-        },
-        "processLinkType": "plugin"
+    "referenceType" : "FIXED",
+    "pluginDefinitionKey" : "catalogiapi",
+    "processLinkType" : "plugin"
+  },
+  {
+    "activityId" : "get-resultaat-typen",
+    "activityType" : "bpmn:ServiceTask:start",
+    "pluginConfigurationId" : "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec",
+    "pluginActionDefinitionKey" : "get-resultaattypen",
+    "actionProperties" : {
+      "processVariable" : "pv:resultaatTypenPV"
     },
-    {
-        "activityId": "validate-fetched-typen",
-        "activityType": "bpmn:UserTask:create",
-        "formDefinitionName": "user-task-validate-typen",
-        "processLinkType": "form",
-        "formDisplayType": "modal",
-        "formSize": "medium"
-    }
+    "referenceType" : "FIXED",
+    "pluginDefinitionKey" : "catalogiapi",
+    "processLinkType" : "plugin"
+  },
+  {
+    "activityId" : "validate-fetched-typen",
+    "activityType" : "bpmn:UserTask:create",
+    "formDefinitionName" : "user-task-validate-typen",
+    "viewModelEnabled" : false,
+    "formDisplayType" : "modal",
+    "formSize" : "medium",
+    "subtitles" : [],
+    "processLinkType" : "form"
+  }
 ]

--- a/backend/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiPlugin.kt
+++ b/backend/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiPlugin.kt
@@ -270,12 +270,41 @@ class CatalogiApiPlugin(
         }
     }
 
+    @PluginAction(
+        key = "get-informatieobjecttypen",
+        title = "Get Informatieobjecttypen",
+        description = "Retrieve the informatieobjecttypen and save them in a process variable",
+        activityTypes = [ActivityTypeWithEventName.SERVICE_TASK_START, ActivityTypeWithEventName.CALL_ACTIVITY_START]
+    )
+    fun getInformatieobjecttypen(
+        execution: DelegateExecution,
+        @PluginActionProperty processVariable: String,
+        @PluginActionProperty zaaktypeUrl: String? = null
+    ) {
+        logger.debug { "Retrieving informatieobjecttypen and storing these in process variable: $processVariable" }
+        zaaktypeUriFrom(zaaktypeUrl, execution).let { zaaktypeUri ->
+            withLoggingContext(
+                CATALOGI_API.ZAAKTYPE to zaaktypeUri.toString()
+            ) {
+                getInformatieobjecttypes(zaaktypeUri).map { informatieobjecttype ->
+                    mapOf(
+                        URL_KEY to informatieobjecttype.url!!.toASCIIString(),
+                        NAME_KEY to informatieobjecttype.omschrijving
+                    )
+                }.let { informatieobjecttypen ->
+                    execution.setVariable(processVariable, informatieobjecttypen)
+                }
+                logger.info { "Setting process variable $processVariable with (retrieved) informatieobjecttypen" }
+            }
+        }
+    }
+
     fun getInformatieobjecttypes(
         zaakTypeUrl: URI,
     ): List<Informatieobjecttype> {
         withLoggingContext(CATALOGI_API.ZAAKTYPEINFORMATIEOBJECTTYPE to zaakTypeUrl.toString()) {
             var currentPage = 1
-            var currentResults: Page<ZaaktypeInformatieobjecttype>?
+            var currentResults: Page<ZaaktypeInformatieobjecttype>
             val results = mutableListOf<Informatieobjecttype>()
 
             do {
@@ -317,7 +346,7 @@ class CatalogiApiPlugin(
                 }
 
                 results.addAll(filteredTypes)
-            } while (currentResults?.next != null)
+            } while (currentResults.next != null)
 
             return results
         }
@@ -350,7 +379,7 @@ class CatalogiApiPlugin(
     fun getRoltypes(zaakTypeUrl: URI): List<Roltype> {
         withLoggingContext(CATALOGI_API.ROLTYPE to zaakTypeUrl.toString()) {
             var currentPage = 1
-            var currentResults: Page<Roltype>?
+            var currentResults: Page<Roltype>
             val results = mutableListOf<Roltype>()
 
             do {
@@ -364,7 +393,7 @@ class CatalogiApiPlugin(
                     )
                 )
                 results.addAll(currentResults.results)
-            } while (currentResults?.next != null)
+            } while (currentResults.next != null)
 
             return results
         }
@@ -373,7 +402,7 @@ class CatalogiApiPlugin(
     fun getStatustypen(zaakTypeUrl: URI): List<Statustype> {
         withLoggingContext(CATALOGI_API.STATUSTYPE to zaakTypeUrl.toString()) {
             var currentPage = 1
-            var currentResults: Page<Statustype>?
+            var currentResults: Page<Statustype>
             val results = mutableListOf<Statustype>()
 
             do {
@@ -387,7 +416,7 @@ class CatalogiApiPlugin(
                     )
                 )
                 results.addAll(currentResults.results)
-            } while (currentResults?.next != null)
+            } while (currentResults.next != null)
 
             return results
         }
@@ -414,7 +443,7 @@ class CatalogiApiPlugin(
     fun getResultaattypen(zaakTypeUrl: URI): List<Resultaattype> {
         withLoggingContext(CATALOGI_API.RESULTAATTYPE to zaakTypeUrl.toString()) {
             var currentPage = 1
-            var currentResults: Page<Resultaattype>?
+            var currentResults: Page<Resultaattype>
             val results = mutableListOf<Resultaattype>()
 
             do {
@@ -428,7 +457,7 @@ class CatalogiApiPlugin(
                     )
                 )
                 results.addAll(currentResults.results)
-            } while (currentResults?.next != null)
+            } while (currentResults.next != null)
 
             return results
         }
@@ -455,7 +484,7 @@ class CatalogiApiPlugin(
     fun getBesluittypen(zaakTypeUrl: URI): List<Besluittype> {
         withLoggingContext(CATALOGI_API.BESLUITTYPE to zaakTypeUrl.toString()) {
             var currentPage = 1
-            var currentResults: Page<Besluittype>?
+            var currentResults: Page<Besluittype>
             val results = mutableListOf<Besluittype>()
 
             do {
@@ -469,7 +498,7 @@ class CatalogiApiPlugin(
                     )
                 )
                 results.addAll(currentResults.results)
-            } while (currentResults?.next != null)
+            } while (currentResults.next != null)
 
             return results
         }

--- a/backend/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginTest.kt
+++ b/backend/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginTest.kt
@@ -806,8 +806,15 @@ internal class CatalogiApiPluginTest : BaseTest() {
             zaaktypeUrl = zaaktypeUrl
         )
 
-        verify(execution, times(1))
-            .setVariable(eq(processVariable), any<List<Map<String, String>>>())
+        verify(execution, times(1)).setVariable(
+            eq(processVariable),
+            eq(
+                listOf(
+                    mapOf("url" to informatieObjectTypeUrl("1"), "name" to "first document"),
+                    mapOf("url" to informatieObjectTypeUrl("2"), "name" to "second document")
+                )
+            )
+        )
     }
 
     @Test
@@ -836,8 +843,14 @@ internal class CatalogiApiPluginTest : BaseTest() {
             zaaktypeUrl = null
         )
 
-        verify(execution, times(1))
-            .setVariable(eq(processVariable), any<List<Map<String, String>>>())
+        verify(execution, times(1)).setVariable(
+            eq(processVariable),
+            eq(
+                listOf(
+                    mapOf("url" to informatieObjectTypeUrl("1"), "name" to "first document")
+                )
+            )
+        )
     }
 
     private fun mockInformatieobjecttypes(

--- a/backend/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginTest.kt
+++ b/backend/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginTest.kt
@@ -780,6 +780,66 @@ internal class CatalogiApiPluginTest : BaseTest() {
         assertEquals("No informatieobjecttype was found with 'omschrijving': 'Onbekend document'", exception.message)
     }
 
+    @Test
+    fun `should get informatieobjecttypen for zaaktype specified via property`() {
+        val processVariable = "informatieobjecttypenProcessVar"
+        val zaaktypeUrl = zaaktypeUrl()
+        val execution = mockExecution()
+
+        mockInformatieobjecttypes(
+            zaaktypeUrl = zaaktypeUrl.toURI(),
+            informatieobjecttypes = listOf(
+                informatieobjecttype(
+                    url = informatieObjectTypeUrl("1").toURI(),
+                    omschrijving = "first document"
+                ),
+                informatieobjecttype(
+                    url = informatieObjectTypeUrl("2").toURI(),
+                    omschrijving = "second document"
+                )
+            )
+        )
+
+        plugin.getInformatieobjecttypen(
+            execution = execution,
+            processVariable = processVariable,
+            zaaktypeUrl = zaaktypeUrl
+        )
+
+        verify(execution, times(1))
+            .setVariable(eq(processVariable), any<List<Map<String, String>>>())
+    }
+
+    @Test
+    fun `should get informatieobjecttypen for zaaktype via linked zaak`() {
+        val processVariable = "informatieobjecttypenProcessVar"
+        val zaaktypeUrl = zaaktypeUrl()
+        val documentId = documentId()
+        val document = mockDocument(documentId.toUUID())
+        val execution = mockExecution(documentId)
+
+        mockDocumentService(documentId, document)
+        mockZaakTypeUrlProvider(zaaktypeUrl.toURI())
+        mockInformatieobjecttypes(
+            zaaktypeUrl = zaaktypeUrl.toURI(),
+            informatieobjecttypes = listOf(
+                informatieobjecttype(
+                    url = informatieObjectTypeUrl("1").toURI(),
+                    omschrijving = "first document"
+                )
+            )
+        )
+
+        plugin.getInformatieobjecttypen(
+            execution = execution,
+            processVariable = processVariable,
+            zaaktypeUrl = null
+        )
+
+        verify(execution, times(1))
+            .setVariable(eq(processVariable), any<List<Map<String, String>>>())
+    }
+
     private fun mockInformatieobjecttypes(
         zaaktypeUrl: URI,
         informatieobjecttypes: List<Informatieobjecttype>

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -195,6 +195,7 @@
 
 * [Release notes](release-notes/release-notes.md)
 * [13.x.x](release-notes/13.x.x/)
+  * [13.36.0](release-notes/13.x.x/13.36.0/README.md)
   * [13.35.0](release-notes/13.x.x/13.35.0/README.md)
   * [13.34.0](release-notes/13.x.x/13.34.0/README.md)
   * [13.33.0](release-notes/13.x.x/13.33.0/README.md)

--- a/documentation/features/plugins/configure-catalogi-api-plugin.md
+++ b/documentation/features/plugins/configure-catalogi-api-plugin.md
@@ -143,3 +143,12 @@ When creating a process link the following properties have to be entered:
 
 * **Informatieobjecttype**. The description (omschrijving) of the informatieobjecttype to look up.
 * **Process variable name**. This is the name of the process variable which value will be set to the found informatieobjecttype URL.
+
+### Retrieve informatieobjecttypen
+
+This action retrieves a list of informatieobjecttypen (containing the name and URL of each informatieobjecttype) and will assign it to a process variable.
+
+When creating a process link the following properties have to be entered:
+
+* **Process variable name**. This is the name of the process variable which value will be set to the found informatieobjecttypen collection.
+* **Zaaktype URL** (optional). This is the URL of the zaaktype for which the informatieobjecttypen should be retrieved.

--- a/documentation/release-notes/13.x.x/13.36.0/README.md
+++ b/documentation/release-notes/13.x.x/13.36.0/README.md
@@ -1,0 +1,24 @@
+# 13.36.0
+
+{% hint style="info" %}
+**Release date 08-07-2026**
+{% endhint %}
+
+## New Features
+
+* **Catalogi API plugin action: Get Informatieobjecttypen**
+
+  A new plugin action `get-informatieobjecttypen` has been added to the Catalogi API plugin. This action retrieves the
+  collection of informatieobjecttypen belonging to a zaaktype and stores it — as a list of `{url, name}` entries — in a
+  process variable. The zaaktype is taken from the linked case by default, or from an optional zaaktype URL. See
+  [Catalogi API plugin](../../../features/plugins/configure-catalogi-api-plugin.md#retrieve-informatieobjecttypen).
+
+## Enhancements
+
+* **New enhancement title**
+
+  New enhancement explanation.
+
+## Bugfixes
+
+* New bugfix.

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/catalogi-api-plugin-module.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/catalogi-api-plugin-module.ts
@@ -26,6 +26,7 @@ import {GetResultaattypenConfigurationComponent} from './components/get-resultaa
 import {GetResultaattypeConfigurationComponent} from './components/get-resultaattype/get-resultaattype-configuration.component';
 import {GetEigenschapConfigurationComponent} from './components/get-eigenschap/get-eigenschap-configuration.component';
 import {GetInformatieobjecttypeConfigurationComponent} from './components/get-informatieobjecttype/get-informatieobjecttype-configuration.component';
+import {GetInformatieobjecttypenConfigurationComponent} from './components/get-informatieobjecttypen/get-informatieobjecttypen-configuration.component';
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import {GetInformatieobjecttypeConfigurationComponent} from './components/get-in
     GetStatustypeConfigurationComponent,
     GetEigenschapConfigurationComponent,
     GetInformatieobjecttypeConfigurationComponent,
+    GetInformatieobjecttypenConfigurationComponent,
   ],
   imports: [
     CommonModule,
@@ -55,6 +57,7 @@ import {GetInformatieobjecttypeConfigurationComponent} from './components/get-in
     GetStatustypenConfigurationComponent,
     GetEigenschapConfigurationComponent,
     GetInformatieobjecttypeConfigurationComponent,
+    GetInformatieobjecttypenConfigurationComponent,
   ],
 })
 export class CatalogiApiPluginModule {}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/catalogi-api-plugin.specification.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/catalogi-api-plugin.specification.ts
@@ -23,6 +23,7 @@ import {GetResultaattypenConfigurationComponent} from './components/get-resultaa
 import {GetResultaattypeConfigurationComponent} from './components/get-resultaattype/get-resultaattype-configuration.component';
 import {GetEigenschapConfigurationComponent} from './components/get-eigenschap/get-eigenschap-configuration.component';
 import {GetInformatieobjecttypeConfigurationComponent} from './components/get-informatieobjecttype/get-informatieobjecttype-configuration.component';
+import {GetInformatieobjecttypenConfigurationComponent} from './components/get-informatieobjecttypen/get-informatieobjecttypen-configuration.component';
 import {CATALOGI_API_PLUGIN_LOGO_BASE64} from './assets';
 
 const catalogiApiPluginSpecification: PluginSpecification = {
@@ -37,6 +38,7 @@ const catalogiApiPluginSpecification: PluginSpecification = {
     'get-statustype': GetStatustypeConfigurationComponent,
     'get-eigenschap': GetEigenschapConfigurationComponent,
     'get-informatieobjecttype': GetInformatieobjecttypeConfigurationComponent,
+    'get-informatieobjecttypen': GetInformatieobjecttypenConfigurationComponent,
   },
   pluginTranslations: {
     nl: {
@@ -94,6 +96,9 @@ const catalogiApiPluginSpecification: PluginSpecification = {
       informatieobjecttypeTooltip: 'Omschrijving van het informatieobjecttype.',
       informatieobjecttypeProcessVariableTooltip:
         'Nadat het informatieobjecttype is opgehaald, wordt deze opgeslagen in een procesvariabele met deze naam.',
+      'get-informatieobjecttypen': 'Informatieobjecttypen opvragen',
+      getInformatieobjecttypenInformation:
+        'De Informatieobjecttypen behorende bij het Zaaktype worden opgehaald en daarna opgeslagen in een procesvariabele.',
     },
     en: {
       title: 'Catalogi API',
@@ -148,6 +153,9 @@ const catalogiApiPluginSpecification: PluginSpecification = {
       informatieobjecttypeTooltip: 'Description of the informatieobjecttype.',
       informatieobjecttypeProcessVariableTooltip:
         'After the informatieobjecttype is retrieved, it is stored in a process variable with this name.',
+      'get-informatieobjecttypen': 'Retrieve informatieobjecttypen',
+      getInformatieobjecttypenInformation:
+        'The Informatieobjecttypen belonging to the Zaaktype are retrieved and then stored in a process variable.',
     },
   },
 };

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/components/get-informatieobjecttypen/get-informatieobjecttypen-configuration.component.html
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/components/get-informatieobjecttypen/get-informatieobjecttypen-configuration.component.html
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+@if ({
+  disabled: disabled$ | async,
+  prefill: prefillConfiguration$ ? (prefillConfiguration$ | async) : null,
+}; as obs) {
+  <v-paragraph [margin]="true" [italic]="true">
+    {{ 'getInformatieobjecttypenInformation' | pluginTranslate: pluginId | async }}
+  </v-paragraph>
+
+  <v-form (valueChange)="formValueChange($event)">
+    <v-input
+      name="processVariable"
+      [title]="'processVariable' | pluginTranslate: pluginId | async"
+      [margin]="true"
+      [defaultValue]="obs.prefill?.processVariable"
+      [disabled]="obs.disabled"
+      [required]="true"
+      [trim]="true"
+      [tooltip]="'processVariableTooltip' | pluginTranslate: pluginId | async"
+      [fullWidth]="true"
+    >
+    </v-input>
+
+    <v-input
+      name="zaaktypeUrl"
+      [title]="'zaaktypeUrl' | pluginTranslate: pluginId | async"
+      [margin]="true"
+      [defaultValue]="obs.prefill?.zaaktypeUrl"
+      [disabled]="obs.disabled"
+      [required]="false"
+      [trim]="true"
+      [tooltip]="'zaaktypeUrlTooltip' | pluginTranslate: pluginId | async"
+      [fullWidth]="true"
+    >
+    </v-input>
+  </v-form>
+}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/components/get-informatieobjecttypen/get-informatieobjecttypen-configuration.component.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/components/get-informatieobjecttypen/get-informatieobjecttypen-configuration.component.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {BehaviorSubject, combineLatest, Observable, Subscription, take} from 'rxjs';
+import {FunctionConfigurationComponent} from '../../../../models';
+import {GetInformatieobjecttypenConfig} from '../../models';
+
+@Component({
+  standalone: false,
+  selector: 'valtimo-get-informatieobjecttypen-configuration',
+  templateUrl: './get-informatieobjecttypen-configuration.component.html',
+})
+export class GetInformatieobjecttypenConfigurationComponent
+  implements FunctionConfigurationComponent, OnInit, OnDestroy
+{
+  @Input() disabled$: Observable<boolean>;
+  @Input() pluginId: string;
+  @Input() prefillConfiguration$: Observable<GetInformatieobjecttypenConfig>;
+  @Input() save$: Observable<void>;
+  @Output() configuration: EventEmitter<GetInformatieobjecttypenConfig> =
+    new EventEmitter<GetInformatieobjecttypenConfig>();
+  @Output() valid: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+  private readonly _formValue$ = new BehaviorSubject<GetInformatieobjecttypenConfig | null>(null);
+  private _saveSubscription!: Subscription;
+  private readonly _valid$ = new BehaviorSubject<boolean>(false);
+
+  public ngOnInit(): void {
+    this.openSaveSubscription();
+  }
+
+  public ngOnDestroy(): void {
+    this._saveSubscription?.unsubscribe();
+  }
+
+  public formValueChange(formValue: GetInformatieobjecttypenConfig): void {
+    this._formValue$.next(formValue);
+    this.handleValid(formValue);
+  }
+
+  private handleValid(formValue: GetInformatieobjecttypenConfig): void {
+    const valid = !!formValue.processVariable;
+
+    this._valid$.next(valid);
+    this.valid.emit(valid);
+  }
+
+  private openSaveSubscription(): void {
+    this._saveSubscription = this.save$?.subscribe(save => {
+      combineLatest([this._formValue$, this._valid$])
+        .pipe(take(1))
+        .subscribe(([formValue, valid]) => {
+          if (valid) {
+            this.configuration.emit(formValue);
+          }
+        });
+    });
+  }
+}

--- a/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/models/config.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/plugins/catalogi-api/models/config.ts
@@ -56,6 +56,11 @@ interface GetInformatieobjecttypeConfig {
   processVariable: string;
 }
 
+interface GetInformatieobjecttypenConfig {
+  processVariable: string;
+  zaaktypeUrl?: string;
+}
+
 export {
   CatalogiApiConfig,
   GetBesluittypeConfig,
@@ -65,4 +70,5 @@ export {
   GetStatustypeConfig,
   GetEigenschapConfig,
   GetInformatieobjecttypeConfig,
+  GetInformatieobjecttypenConfig,
 };

--- a/frontend/projects/valtimo/plugin/src/public-api.ts
+++ b/frontend/projects/valtimo/plugin/src/public-api.ts
@@ -115,6 +115,7 @@ export * from './lib/plugins/catalogi-api/components/get-statustypen/get-statust
 export * from './lib/plugins/catalogi-api/components/get-statustype/get-statustype-configuration.component';
 export * from './lib/plugins/catalogi-api/components/get-eigenschap/get-eigenschap-configuration.component';
 export * from './lib/plugins/catalogi-api/components/get-informatieobjecttype/get-informatieobjecttype-configuration.component';
+export * from './lib/plugins/catalogi-api/components/get-informatieobjecttypen/get-informatieobjecttypen-configuration.component';
 /* notificaties api plugin */
 export * from './lib/plugins/notificaties-api/notificaties-api-plugin.module';
 export * from './lib/plugins/notificaties-api/notificaties-api-plugin.specification';


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: generiekzaakafhandelcomponent/gzac-issues#785 (inspired by generiekzaakafhandelcomponent/gzac-issues#225)

Adds a new `get-informatieobjecttypen` plugin action to the Catalogi API plugin. It retrieves the informatieobjecttypen (document types) belonging to a zaaktype and stores them in a process variable as a list of `{url, name}` entries — mirroring the existing `get-statustypen` / `get-resultaattypen` actions.

The fetch logic already existed (`CatalogiApiPlugin.getInformatieobjecttypes(zaakTypeUrl)`); only the singular `get-informatieobjecttype` (resolve one URL by omschrijving) action was exposed. This PR adds the plural overview action plus its frontend configuration component, so the list can be retrieved into a process variable while configuring a BPMN within a case or building block. The work is self-contained in `backend/zgw/catalogi-api` and the frontend `catalogi-api` plugin — no dependency on the Documenten API module.

Specify the code branch location: story/gh-785_catalogi-api-overview-of-informatieobjecttypes-for-given-zaaktype

**Relevant comments:**
> The zaaktype is derived from the linked zaak by default, or from an optional `zaaktypeUrl` action property (same pattern as `get-statustypen`). Only valid, non-concept types are returned (existing geldigheid filtering in `getInformatieobjecttypes`). No new REST endpoint was added — only the plugin action.

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [x] Configure a "Retrieve informatieobjecttypen" service task in a BPMN process link, set a process variable (optionally a zaaktype URL)
- [x] Run the process against a case whose zaaktype has linked informatieobjecttypen
- [x] Confirm the process variable holds the list of `{url, name}` entries

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
