### PR TITLE
784: Fix task list tab reset when opening a shared URL

### DIFF
--- a/documentation/release-notes/13.x.x/13.36.0/README.md
+++ b/documentation/release-notes/13.x.x/13.36.0/README.md
@@ -23,3 +23,8 @@
 
 * Dashboard widgets can now group and filter on more case fields, such as the `case:internalStatus` and
   `case:definitionId.key`.
+
+* **Shared task list URLs now open on the correct tab**
+
+  Opening a copied or bookmarked task list URL now lands on the tab it was saved from (for example *All tasks*),
+  instead of defaulting to the first tab.

--- a/frontend/projects/valtimo/task/src/lib/components/task-list/task-list.component.ts
+++ b/frontend/projects/valtimo/task/src/lib/components/task-list/task-list.component.ts
@@ -497,7 +497,11 @@ export class TaskListComponent implements OnInit, OnDestroy {
           : configuredTabs.filter(tab => tab !== TaskListTab.TEAM);
 
       this.visibleTabs$.next(tabs);
-      this.taskListService.setSelectedTaskType(tabs[0]);
+
+      const urlTab = this.taskListQueryParamService.getTaskListQueryParams()?.selectedTaskType;
+      this.taskListService.setSelectedTaskType(
+        urlTab && tabs.includes(urlTab) ? urlTab : tabs[0]
+      );
     });
   }
 


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/784

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: story/784-fix-task-list-tab-url

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ]  Go to the Task list
- [ ]  Switch to a tab that is not the first one (e.g. All tasks).
- [ ]  Apply a filter or two, click 'Search' button
- [ ]  Copy the URL from the browser address bar
- [ ]  Open that URL in a new tab 
- [ ]  Verify that you land on the same tab (e.g. All tasks) with the filters applied (not on the first tab (My tasks))
- [ ]  To check, open the plain task list URL without a specific tab → it should open on the first tab, as before.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
