### PR TITLE
CI: fix release pipeline workflows

### DIFF
--- a/.github/workflows/backend_build_test_libraries.yml
+++ b/.github/workflows/backend_build_test_libraries.yml
@@ -189,8 +189,32 @@ jobs:
 
   integration-testing-mysql:
     runs-on: ubuntu-latest
-    needs: [check_cache, build_libraries]
-    if: ${{ needs.check_cache.outputs.cache-hit != 'true' }}
+    needs: [determine-tests, check_cache, build_libraries]
+    # Heavy job: run only when there is no build cache AND the run is either a
+    # PR from a feature/* branch or one of the main integration branches. Regular
+    # PRs skip the full MySQL matrix to keep them cheap.
+    if: >
+      needs.check_cache.outputs.cache-hit != 'true' &&
+      (
+        (github.event_name == 'pull_request' && startsWith(github.head_ref, 'feature/')) ||
+        (
+          github.ref_type == 'branch' &&
+          (
+            startsWith(github.ref_name, 'development/') ||
+            startsWith(github.ref_name, 'rc/') ||
+            startsWith(github.ref_name, 'release/') ||
+            github.ref_name == 'next-minor' ||
+            github.ref_name == 'next-major'
+          )
+        )
+      )
+    strategy:
+      matrix:
+        # Reuse the Postgres integration-test matrix: every module that registers
+        # an `:integrationTesting` task also registers `:integrationTestingMysql`
+        # (see backend/gradle/test.gradle), so appending `Mysql` below runs the
+        # MySQL variant of each suite.
+        integration_test_suite: ${{ fromJson(needs.determine-tests.outputs.integration_test_matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -204,22 +228,26 @@ jobs:
         with:
           name: backend-build-output
           path: .
-      - name: Run MySQL integration test (verzoek)
-        run: ./gradlew :backend:zgw:verzoek:integrationTestingMysql
+      - name: Run MySQL integration test suite
+        run: ./gradlew ${{ matrix.integration_test_suite }}Mysql
 
   security-testing:
     needs: [determine-tests, check_cache, build_libraries]
     strategy:
       matrix:
         security_test_suite: ${{ fromJson(needs.determine-tests.outputs.security_test_matrix) }}
-    if: |
-      github.ref_type == 'branch' &&
+    # Run on the main integration branches, plus PRs from a feature/* branch.
+    if: >
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'feature/')) ||
       (
-        startsWith(github.ref_name, 'development/') ||
-        startsWith(github.ref_name, 'rc/') ||
-        startsWith(github.ref_name, 'release/') ||
-        github.ref_name == 'next-minor' ||
-        github.ref_name == 'next-major'
+        github.ref_type == 'branch' &&
+        (
+          startsWith(github.ref_name, 'development/') ||
+          startsWith(github.ref_name, 'rc/') ||
+          startsWith(github.ref_name, 'release/') ||
+          github.ref_name == 'next-minor' ||
+          github.ref_name == 'next-major'
+        )
       )
     runs-on: ubuntu-latest
     steps:
@@ -245,7 +273,7 @@ jobs:
       always() &&
       needs.unit-testing.result == 'success' &&
       needs.integration-testing.result == 'success' &&
-      needs.integration-testing-mysql.result == 'success' &&
+      (needs.integration-testing-mysql.result == 'success' || needs.integration-testing-mysql.result == 'skipped') &&
       (needs.security-testing.result == 'success' || needs.security-testing.result == 'skipped')
     needs:
       - check_cache

--- a/.github/workflows/frontend_build_test_libraries.yml
+++ b/.github/workflows/frontend_build_test_libraries.yml
@@ -183,6 +183,10 @@ jobs:
 
   # 'lint' can run in parallel with 'build_and_test'
   lint:
+    # Explicit condition (not the implicit success()) so an intentionally skipped
+    # ancestor — e.g. check_cache on release/* branches — does not cascade and skip
+    # lint. Run whenever the packages were installed successfully.
+    if: ${{ always() && needs.install_packages.result == 'success' }}
     needs:
       - install_packages
     runs-on: ubuntu-latest

--- a/.github/workflows/start_release.yml
+++ b/.github/workflows/start_release.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:
+          # Push with the valtimo-platform PAT — not GITHUB_TOKEN — so the new
+          # release/<version> branch can be created despite the repository ruleset
+          # that restricts branch creation (GITHUB_TOKEN is not on the bypass list).
+          token: ${{ secrets.VALTIMO_RELEASE_PIPELINE_VALTIMOPLATFORM }}
           ref: ${{ inputs.source_branch }}
           fetch-depth: 0
 

--- a/.github/workflows/start_release_candidate.yml
+++ b/.github/workflows/start_release_candidate.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:
+          # Push with the valtimo-platform PAT — not GITHUB_TOKEN — so the new
+          # rc/<version> branch can be created despite the repository ruleset that
+          # restricts branch creation (GITHUB_TOKEN is not on the bypass list).
+          token: ${{ secrets.VALTIMO_RELEASE_PIPELINE_VALTIMOPLATFORM }}
           ref: ${{ inputs.source_branch }}
           fetch-depth: 0
 


### PR DESCRIPTION
## What

Fixes several issues in the CI/release workflows discovered while debugging the 13.36.0 release run.

- **`start_release` / `start_release_candidate`**: check out with the release PAT (`VALTIMO_RELEASE_PIPELINE_VALTIMOPLATFORM`) instead of `GITHUB_TOKEN`, so the new `release/*` / `rc/*` branch can be created. `GITHUB_TOKEN` is not on the `protect-release/*` ruleset bypass list; the PAT's account is (via team membership).
- **frontend `lint`**: add an explicit `if` so an intentionally skipped ancestor (`check_cache` on `release/*` branches) no longer cascades into skipping `lint`.
- **backend `integration-testing-mysql`**: run the full MySQL integration matrix (previously only `:backend:zgw:verzoek`), reusing the Postgres suite list with `Mysql` appended. Gated to `feature/*` PRs and the main integration branches.
- **backend `security-testing`**: additionally run on `feature/*` PRs (kept the existing main-branch gate).
- **backend `cache-libraries-build`**: tolerate a **skipped** `integration-testing-mysql` so regular PRs still cache built libraries.

## Gating result

| Scenario | unit | postgres-int | lint | all-mysql | security |
|---|---|---|---|---|---|
| Regular PR | ✓ | ✓ | ✓ | – | – |
| `feature/*` PR | ✓ | ✓ | ✓ | ✓ | ✓ |
| Main branch / release | ✓ | ✓ | ✓ | ✓ | ✓ |

Validated with `actionlint` (no new findings).