### PR TITLE
GHi-535: Improved process definition validation with more checks and clearer messaging

### DIFF
--- a/backend/process-link/src/main/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidator.kt
+++ b/backend/process-link/src/main/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidator.kt
@@ -1,18 +1,18 @@
 /*
  *
- *  * Copyright 2015-2026 Ritense BV, the Netherlands.
- *  *
- *  * Licensed under EUPL, Version 1.2 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" basis,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/backend/process-link/src/main/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidator.kt
+++ b/backend/process-link/src/main/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidator.kt
@@ -1,17 +1,19 @@
 /*
- * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
- * Licensed under EUPL, Version 1.2 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *  *
+ *  * Licensed under EUPL, Version 1.2 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
  *
- * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 package com.ritense.processlink.validation
@@ -19,6 +21,7 @@ package com.ritense.processlink.validation
 import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
 import org.operaton.bpm.impl.juel.Builder
 import org.operaton.bpm.model.bpmn.BpmnModelInstance
+import org.operaton.bpm.model.bpmn.instance.BoundaryEvent
 import org.operaton.bpm.model.bpmn.instance.BusinessRuleTask
 import org.operaton.bpm.model.bpmn.instance.CallActivity
 import org.operaton.bpm.model.bpmn.instance.ConditionalEventDefinition
@@ -39,6 +42,7 @@ import org.operaton.bpm.model.bpmn.instance.SequenceFlow
 import org.operaton.bpm.model.bpmn.instance.ServiceTask
 import org.operaton.bpm.model.bpmn.instance.SignalEventDefinition
 import org.operaton.bpm.model.bpmn.instance.StartEvent
+import org.operaton.bpm.model.bpmn.instance.SubProcess
 import org.operaton.bpm.model.bpmn.instance.TerminateEventDefinition
 import org.operaton.bpm.model.bpmn.instance.TimerEventDefinition
 import org.operaton.bpm.model.bpmn.instance.UserTask
@@ -143,6 +147,9 @@ class ProcessDefinitionValidator(
         process: Process,
         errors: MutableList<ProcessDefinitionValidationError>
     ) {
+        val boundaryEvents = process.getChildElementsByType(BoundaryEvent::class.java)
+        val activitiesWithBoundaryEvents = boundaryEvents.mapNotNull { it.attachedTo?.id }.toSet()
+
         process.getChildElementsByType(FlowNode::class.java).forEach { node ->
             if (node is StartEvent) {
                 if (node.getOutgoing().isEmpty()) {
@@ -166,6 +173,21 @@ class ProcessDefinitionValidator(
                         )
                     )
                 }
+            } else if (node is BoundaryEvent) {
+                // Boundary events attach to activities, so they don't need incoming flows
+                if (node.getOutgoing().isEmpty()) {
+                    errors.add(
+                        ProcessDefinitionValidationError(
+                            elementId = node.id,
+                            elementType = node.elementType.typeName,
+                            elementName = node.name,
+                            reason = "Boundary event has no outgoing flow",
+                        )
+                    )
+                }
+            } else if (node is SubProcess && node.triggeredByEvent()) {
+                // Event sub-processes are triggered by events, not sequence flows
+                return@forEach
             } else {
                 if (node.getIncoming().isEmpty()) {
                     errors.add(
@@ -177,7 +199,8 @@ class ProcessDefinitionValidator(
                         )
                     )
                 }
-                if (node.getOutgoing().isEmpty()) {
+                // Activities with boundary events don't need outgoing flows
+                if (node.getOutgoing().isEmpty() && node.id !in activitiesWithBoundaryEvents) {
                     errors.add(
                         ProcessDefinitionValidationError(
                             elementId = node.id,
@@ -197,6 +220,8 @@ class ProcessDefinitionValidator(
     ) {
         val allFlowNodes = process.getChildElementsByType(FlowNode::class.java)
         val startEvents = process.getChildElementsByType(StartEvent::class.java)
+        val boundaryEventsByActivity = process.getChildElementsByType(BoundaryEvent::class.java)
+            .groupBy { it.attachedTo?.id }
 
         val visited = mutableSetOf<String>()
         val queue = ArrayDeque<FlowNode>()
@@ -206,14 +231,17 @@ class ProcessDefinitionValidator(
         while (queue.isNotEmpty()) {
             val current = queue.removeFirst()
             if (!visited.add(current.id)) continue
-            current.getOutgoing().forEach { flow ->
-                if (!visited.contains(flow.target.id)) {
-                    queue.add(flow.target)
+            getSuccessors(current, boundaryEventsByActivity).forEach { successor ->
+                if (!visited.contains(successor.id)) {
+                    queue.add(successor)
                 }
             }
         }
 
         allFlowNodes.forEach { node ->
+            // Event sub-processes are triggered by events, not sequence flows
+            if (node is SubProcess && node.triggeredByEvent()) return@forEach
+
             if (!visited.contains(node.id)) {
                 errors.add(
                     ProcessDefinitionValidationError(
@@ -226,6 +254,18 @@ class ProcessDefinitionValidator(
                 )
             }
         }
+    }
+
+    private fun getSuccessors(
+        node: FlowNode,
+        boundaryEventsByActivity: Map<String?, List<BoundaryEvent>>
+    ): List<FlowNode> {
+        val successors = mutableListOf<FlowNode>()
+        // Regular outgoing sequence flows
+        node.getOutgoing().forEach { successors.add(it.target) }
+        // Boundary events attached to this activity
+        boundaryEventsByActivity[node.id]?.forEach { successors.add(it) }
+        return successors
     }
 
     private fun validateSingleNoneStartEvent(
@@ -258,6 +298,9 @@ class ProcessDefinitionValidator(
         }
         if (hasTerminateEndEvent) return
 
+        val boundaryEventsByActivity = process.getChildElementsByType(BoundaryEvent::class.java)
+            .groupBy { it.attachedTo?.id }
+
         val startEvents = process.getChildElementsByType(StartEvent::class.java)
         for (startEvent in startEvents) {
             val visited = mutableSetOf<String>()
@@ -272,9 +315,9 @@ class ProcessDefinitionValidator(
                     reachesEndEvent = true
                     break
                 }
-                current.getOutgoing().forEach { flow ->
-                    if (!visited.contains(flow.target.id)) {
-                        queue.add(flow.target)
+                getSuccessors(current, boundaryEventsByActivity).forEach { successor ->
+                    if (!visited.contains(successor.id)) {
+                        queue.add(successor)
                     }
                 }
             }
@@ -726,9 +769,10 @@ class ProcessDefinitionValidator(
                     elementId = elementId,
                     elementType = elementType,
                     elementName = elementName,
-                    reason = "Bean '$beanName' not found in process beans",
+                    reason = "No bean named '$beanName' found. If using a process variable, ensure it exists at runtime.",
                     errorCode = ExpressionValidationErrorCode.BEAN_NOT_FOUND.name,
-                    expression = expression
+                    expression = expression,
+                    severity = ValidationSeverity.WARNING
                 )
             )
         }

--- a/backend/process-link/src/test/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidatorTest.kt
+++ b/backend/process-link/src/test/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidatorTest.kt
@@ -1,17 +1,19 @@
 /*
- * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
- * Licensed under EUPL, Version 1.2 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *  *
+ *  * Licensed under EUPL, Version 1.2 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
  *
- * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 package com.ritense.processlink.validation
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.operaton.bpm.model.bpmn.Bpmn
 import org.operaton.bpm.model.bpmn.BpmnModelInstance
+import org.operaton.bpm.model.bpmn.instance.BoundaryEvent
 import org.operaton.bpm.model.bpmn.instance.BusinessRuleTask
 import org.operaton.bpm.model.bpmn.instance.CallActivity
 import org.operaton.bpm.model.bpmn.instance.Condition
@@ -50,6 +53,7 @@ import org.operaton.bpm.model.bpmn.instance.ServiceTask
 import org.operaton.bpm.model.bpmn.instance.Signal
 import org.operaton.bpm.model.bpmn.instance.SignalEventDefinition
 import org.operaton.bpm.model.bpmn.instance.StartEvent
+import org.operaton.bpm.model.bpmn.instance.SubProcess
 import org.operaton.bpm.model.bpmn.instance.TerminateEventDefinition
 import org.operaton.bpm.model.bpmn.instance.TimeDuration
 import org.operaton.bpm.model.bpmn.instance.TimerEventDefinition
@@ -722,6 +726,108 @@ class ProcessDefinitionValidatorTest {
     }
 
     @Test
+    fun `should not report boundary event for missing incoming flow`() {
+        val model = Bpmn.createExecutableProcess("test-process")
+            .startEvent("start")
+            .serviceTask("my-task").operatonExpression("\${true}")
+            .boundaryEvent("boundary").timerWithDuration("PT1H")
+            .endEvent("boundary-end")
+            .moveToActivity("my-task")
+            .endEvent("end")
+            .done()
+
+        val result = validator.validate(model, emptyList())
+
+        assertThat(result.errors).noneMatch {
+            it.elementId == "boundary" && it.reason.contains("incoming flow")
+        }
+    }
+
+    @Test
+    fun `should report boundary event with no outgoing flow`() {
+        val model = Bpmn.createExecutableProcess("test-process")
+            .startEvent("start")
+            .serviceTask("my-task").operatonExpression("\${true}")
+            .endEvent("end")
+            .done()
+
+        val process = model.getModelElementsByType(Process::class.java).first()
+        val serviceTask = model.getModelElementById<ServiceTask>("my-task")
+
+        val boundaryEvent = model.newInstance(BoundaryEvent::class.java)
+        boundaryEvent.id = "orphan-boundary"
+        boundaryEvent.attachedTo = serviceTask
+        val timerDef = model.newInstance(TimerEventDefinition::class.java)
+        val timeDuration = model.newInstance(TimeDuration::class.java)
+        timeDuration.textContent = "PT1H"
+        timerDef.timeDuration = timeDuration
+        boundaryEvent.eventDefinitions.add(timerDef)
+        process.addChildElement(boundaryEvent)
+
+        val result = validator.validate(model, emptyList())
+
+        assertThat(result.errors).anyMatch {
+            it.elementId == "orphan-boundary" && it.reason == "Boundary event has no outgoing flow"
+        }
+    }
+
+    @Test
+    fun `should not report activity with boundary event for missing outgoing flow`() {
+        val model = Bpmn.createExecutableProcess("test-process")
+            .startEvent("start")
+            .serviceTask("my-task").operatonExpression("\${true}")
+            .done()
+
+        val process = model.getModelElementsByType(Process::class.java).first()
+        val serviceTask = model.getModelElementById<ServiceTask>("my-task")
+
+        val boundaryEvent = model.newInstance(BoundaryEvent::class.java)
+        boundaryEvent.id = "boundary"
+        boundaryEvent.attachedTo = serviceTask
+        val timerDef = model.newInstance(TimerEventDefinition::class.java)
+        val timeDuration = model.newInstance(TimeDuration::class.java)
+        timeDuration.textContent = "PT1H"
+        timerDef.timeDuration = timeDuration
+        boundaryEvent.eventDefinitions.add(timerDef)
+        process.addChildElement(boundaryEvent)
+
+        val endEvent = model.newInstance(EndEvent::class.java)
+        endEvent.id = "end"
+        process.addChildElement(endEvent)
+
+        val flow = model.newInstance(SequenceFlow::class.java)
+        flow.id = "boundary-to-end"
+        flow.source = boundaryEvent
+        flow.target = endEvent
+        process.addChildElement(flow)
+
+        val result = validator.validate(model, emptyList())
+
+        assertThat(result.errors).noneMatch {
+            it.elementId == "my-task" && it.reason == "Element has no outgoing flow"
+        }
+    }
+
+    @Test
+    fun `should consider boundary event as valid path to end event`() {
+        val model = Bpmn.createExecutableProcess("test-process")
+            .startEvent("start")
+            .serviceTask("my-task").operatonExpression("\${true}")
+            .boundaryEvent("boundary").timerWithDuration("PT1H")
+            .endEvent("end")
+            .done()
+
+        val result = validator.validate(model, emptyList())
+
+        assertThat(result.errors).noneMatch {
+            it.elementId == "start" && it.reason == "Start event has no path to an end event"
+        }
+        assertThat(result.errors).noneMatch {
+            it.elementId == "boundary" && it.reason.contains("not reachable")
+        }
+    }
+
+    @Test
     fun `should report unreachable element`() {
         val model = Bpmn.createExecutableProcess("test-process")
             .startEvent("start")
@@ -752,6 +858,47 @@ class ProcessDefinitionValidatorTest {
         }
         assertThat(result.errors).anyMatch {
             it.elementId == "isolated-end" && it.reason == "Element is not reachable from any start event"
+        }
+    }
+
+    @Test
+    fun `should not report event sub-process for flow or reachability errors`() {
+        val model = Bpmn.createExecutableProcess("test-process")
+            .startEvent("start")
+            .endEvent("end")
+            .done()
+
+        val process = model.getModelElementsByType(Process::class.java).first()
+
+        val eventSubProcess = model.newInstance(SubProcess::class.java)
+        eventSubProcess.id = "error-handler"
+        eventSubProcess.setTriggeredByEvent(true)
+        process.addChildElement(eventSubProcess)
+
+        val errorStartEvent = model.newInstance(StartEvent::class.java)
+        errorStartEvent.id = "error-start"
+        val errorDef = model.newInstance(ErrorEventDefinition::class.java)
+        errorStartEvent.eventDefinitions.add(errorDef)
+        eventSubProcess.addChildElement(errorStartEvent)
+
+        val errorEndEvent = model.newInstance(EndEvent::class.java)
+        errorEndEvent.id = "error-end"
+        eventSubProcess.addChildElement(errorEndEvent)
+
+        val flow = model.newInstance(SequenceFlow::class.java)
+        flow.id = "error-flow"
+        flow.source = errorStartEvent
+        flow.target = errorEndEvent
+        eventSubProcess.addChildElement(flow)
+
+        val result = validator.validate(model, emptyList())
+
+        assertThat(result.errors).noneMatch {
+            it.elementId == "error-handler" && (
+                it.reason.contains("not reachable") ||
+                it.reason.contains("incoming flow") ||
+                it.reason.contains("outgoing flow")
+            )
         }
     }
 
@@ -1332,8 +1479,9 @@ class ProcessDefinitionValidatorTest {
 
         val error = result.errors.find { it.elementId == "my-task" && it.errorCode == "BEAN_NOT_FOUND" }
         assertThat(error).isNotNull
-        assertThat(error!!.reason).contains("nonExistentBean")
+        assertThat(error!!.reason).contains("No bean named 'nonExistentBean' found")
         assertThat(error.expression).isEqualTo("\${nonExistentBean.doSomething()}")
+        assertThat(error.severity).isEqualTo(ValidationSeverity.WARNING)
     }
 
     @Test

--- a/backend/process-link/src/test/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidatorTest.kt
+++ b/backend/process-link/src/test/kotlin/com/ritense/processlink/validation/ProcessDefinitionValidatorTest.kt
@@ -1,19 +1,17 @@
 /*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
- *  * Copyright 2015-2026 Ritense BV, the Netherlands.
- *  *
- *  * Licensed under EUPL, Version 1.2 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" basis,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.ritense.processlink.validation

--- a/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/panel/valtimo-properties-provider.ts
+++ b/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/panel/valtimo-properties-provider.ts
@@ -1,19 +1,17 @@
 /*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
- *  * Copyright 2015-2026 Ritense BV, the Netherlands.
- *  *
- *  * Licensed under EUPL, Version 1.2 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" basis,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import {useService} from 'bpmn-js-properties-panel';

--- a/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/panel/valtimo-properties-provider.ts
+++ b/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/panel/valtimo-properties-provider.ts
@@ -1,17 +1,19 @@
 /*
- * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
- * Licensed under EUPL, Version 1.2 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *  *
+ *  * Licensed under EUPL, Version 1.2 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
  *
- * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 import {useService} from 'bpmn-js-properties-panel';
@@ -417,9 +419,9 @@ const ValidationErrorsElement = (props: {
   const getErrorMessage = (error: ProcessDefinitionValidationError): string => {
     if (error.errorCode) {
       const translationKey = `processManagement.expressionErrors.${error.errorCode}`;
-      const translated = props.translateService.instant(translationKey);
+      const translated = props.translateService.instant(translationKey, {expression: error.expression ? `'${error.expression}'` : ''});
       if (translated !== translationKey) {
-        return error.expression ? `${translated}: '${error.expression}'` : translated;
+        return translated;
       }
     }
     return error.reason;

--- a/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/process-management-builder.component.ts
+++ b/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/process-management-builder.component.ts
@@ -1,17 +1,19 @@
 /*
- * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
- * Licensed under EUPL, Version 1.2 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *  *
+ *  * Licensed under EUPL, Version 1.2 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
  *
- * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 import {CommonModule} from '@angular/common';
@@ -1229,9 +1231,11 @@ export class ProcessManagementBuilderComponent implements AfterViewInit, OnDestr
   }): string {
     if (error.errorCode) {
       const translationKey = `processManagement.expressionErrors.${error.errorCode}`;
-      const translated = this.translateService.instant(translationKey);
+      const translated = this.translateService.instant(translationKey, {
+        expression: error.expression ? `'${error.expression}'` : '',
+      });
       if (translated !== translationKey) {
-        return error.expression ? `${translated}: '${error.expression}'` : translated;
+        return translated;
       }
     }
     return error.reason;

--- a/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/process-management-builder.component.ts
+++ b/frontend/projects/valtimo/process-management/src/lib/components/process-management-builder/process-management-builder.component.ts
@@ -1,19 +1,17 @@
 /*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
- *  * Copyright 2015-2026 Ritense BV, the Netherlands.
- *  *
- *  * Licensed under EUPL, Version 1.2 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" basis,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import {CommonModule} from '@angular/common';

--- a/frontend/projects/valtimo/shared/assets/core/en.json
+++ b/frontend/projects/valtimo/shared/assets/core/en.json
@@ -1837,14 +1837,14 @@
     "canInitializeDocument": "Starts case",
     "startableByUser": "Startable by user",
     "expressionErrors": {
-      "MISSING_EL_MARKERS": "Expression must use ${...} or #{...} syntax",
-      "UNCLOSED_PARENTHESIS": "Expression has an unclosed parenthesis '('",
-      "UNCLOSED_BRACE": "Expression is missing a closing brace '}'",
-      "UNCLOSED_BRACKET": "Expression has an unclosed bracket '['",
-      "MISMATCHED_DELIMITER": "Expression has mismatched brackets or braces",
-      "INCOMPLETE_EXPRESSION": "Expression is incomplete",
-      "INVALID_SYNTAX": "Expression has invalid syntax",
-      "BEAN_NOT_FOUND": "Referenced bean does not exist"
+      "MISSING_EL_MARKERS": "Expression {{expression}} must use ${...} or #{...} syntax",
+      "UNCLOSED_PARENTHESIS": "Expression {{expression}} has an unclosed parenthesis '('",
+      "UNCLOSED_BRACE": "Expression {{expression}} is missing a closing brace '}'",
+      "UNCLOSED_BRACKET": "Expression {{expression}} has an unclosed bracket '['",
+      "MISMATCHED_DELIMITER": "Expression {{expression}} has mismatched brackets or braces",
+      "INCOMPLETE_EXPRESSION": "Expression {{expression}} is incomplete",
+      "INVALID_SYNTAX": "Expression {{expression}} has invalid syntax",
+      "BEAN_NOT_FOUND": "No bean found with this name: {{expression}}. If using a process variable, ensure it exists at runtime"
     },
     "warningConfirmation": {
       "title": "Process has warnings",

--- a/frontend/projects/valtimo/shared/assets/core/nl.json
+++ b/frontend/projects/valtimo/shared/assets/core/nl.json
@@ -1865,14 +1865,14 @@
     "canInitializeDocument": "Start een dossier",
     "startableByUser": "Door gebruiker te starten",
     "expressionErrors": {
-      "MISSING_EL_MARKERS": "Expressie moet ${...} of #{...} syntax gebruiken",
-      "UNCLOSED_PARENTHESIS": "Expressie heeft een niet-gesloten haakje '('",
-      "UNCLOSED_BRACE": "Expressie mist een sluitende accolade '}'",
-      "UNCLOSED_BRACKET": "Expressie heeft een niet-gesloten blokhaak '['",
-      "MISMATCHED_DELIMITER": "Expressie heeft niet-overeenkomende haakjes of accolades",
-      "INCOMPLETE_EXPRESSION": "Expressie is onvolledig",
-      "INVALID_SYNTAX": "Expressie heeft ongeldige syntax",
-      "BEAN_NOT_FOUND": "Gerefereerde bean bestaat niet"
+      "MISSING_EL_MARKERS": "Expressie {{expression}} moet ${...} of #{...} syntax gebruiken",
+      "UNCLOSED_PARENTHESIS": "Expressie {{expression}} heeft een niet-gesloten haakje '('",
+      "UNCLOSED_BRACE": "Expressie {{expression}} mist een sluitende accolade '}'",
+      "UNCLOSED_BRACKET": "Expressie {{expression}} heeft een niet-gesloten blokhaak '['",
+      "MISMATCHED_DELIMITER": "Expressie {{expression}} heeft niet-overeenkomende haakjes of accolades",
+      "INCOMPLETE_EXPRESSION": "Expressie {{expression}} is onvolledig",
+      "INVALID_SYNTAX": "Expressie {{expression}} heeft ongeldige syntax",
+      "BEAN_NOT_FOUND": "Geen bean gevonden met deze naam: {{expression}}. Als u een procesvariabele gebruikt, zorg dat deze tijdens runtime bestaat"
     },
     "warningConfirmation": {
       "title": "Proces bevat waarschuwingen",


### PR DESCRIPTION
Solves https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/535.

Test scenario:

  1. Bean/variable warning message
    - Open process builder
    - Add a sequence flow from exclusive gateway with condition ${someVariable.status == true}
    - Verify warning shows: "No bean found with this name: '${someVariable.status == true}'. If using a process variable, ensure it exists at runtime"
    - Verify it's a warning (yellow), not an error (red)
  2. Boundary event - no incoming flow error
    - Create a service task with a timer boundary event attached
    - Verify no "Element has no incoming flow" error on the boundary event
  3. Activity with boundary event - no outgoing flow error
    - Create a service task with only a boundary event (no regular outgoing flow)
    - The boundary event should lead to an end event
    - Verify no "Element has no outgoing flow" error on the service task
  4. Event sub-process - no errors
    - Create process with an error event sub-process (triggered by error event)
    - Verify no "Element has no incoming flow", "no outgoing flow", or "not reachable" errors on the event sub-process itself
  5. Path via boundary event counts
    - Create: start → service task (no outgoing) → boundary event → end
    - Verify no "Start event has no path to an end event" error