### PR TITLE
Refactor custom FormIO component to centralize `customOptions` binding logic and ensure updates during `setValue` calls

### DIFF
--- a/frontend/projects/valtimo/components/src/lib/modules/custom-formio-component/create-custom-component.ts
+++ b/frontend/projects/valtimo/components/src/lib/modules/custom-formio-component/create-custom-component.ts
@@ -238,7 +238,7 @@ export function createCustomFormioComponent(customComponentOptions: FormioCustom
     }
 
     // Push the (possibly calculateValue-mutated) customOptions to the Angular element.
-    private bindCustomOptions(): void {
+    public bindCustomOptions(): void {
       if (!this._customAngularElement) {
         return;
       }

--- a/frontend/projects/valtimo/components/src/lib/modules/custom-formio-component/create-custom-component.ts
+++ b/frontend/projects/valtimo/components/src/lib/modules/custom-formio-component/create-custom-component.ts
@@ -243,7 +243,15 @@ export function createCustomFormioComponent(customComponentOptions: FormioCustom
         return;
       }
       for (const key in this.component.customOptions) {
-        if (this.component.customOptions.hasOwnProperty(key)) {
+        // Reject dangerous keys to prevent prototype pollution. customOptions can be
+        // manipulated through form schemas or calculateValue expressions, so a key like
+        // __proto__/constructor/prototype must never be assigned onto the element.
+        if (
+          Object.prototype.hasOwnProperty.call(this.component.customOptions, key) &&
+          key !== '__proto__' &&
+          key !== 'constructor' &&
+          key !== 'prototype'
+        ) {
           this._customAngularElement[key] = this.component.customOptions[key];
         }
       }

--- a/frontend/projects/valtimo/components/src/lib/modules/custom-formio-component/create-custom-component.ts
+++ b/frontend/projects/valtimo/components/src/lib/modules/custom-formio-component/create-custom-component.ts
@@ -155,11 +155,7 @@ export function createCustomFormioComponent(customComponentOptions: FormioCustom
         }
 
         // Bind customOptions
-        for (const key in this.component.customOptions) {
-          if (this.component.customOptions.hasOwnProperty(key)) {
-            this._customAngularElement[key] = this.component.customOptions[key];
-          }
-        }
+        this.bindCustomOptions();
         // Bind validate options
         for (const key in this.component.validate) {
           if (this.component.validate.hasOwnProperty(key)) {
@@ -228,9 +224,29 @@ export function createCustomFormioComponent(customComponentOptions: FormioCustom
         return false;
       }
 
+      // Re-apply customOptions on every setValue. calculateValue expressions can mutate
+      // this.component.customOptions (e.g. "component.customOptions.filename = 'test'") for
+      // their side effect, and FormIO calls setValue() right after evaluating calculateValue.
+      // customOptions are otherwise only bound during attach(), which is only re-run on a
+      // redraw triggered by *another* component's data change — so without this, calculated
+      // customOptions never reach the Angular element in a single-component form.
+      this.bindCustomOptions();
+
       this._customAngularElement.value = value;
 
       return true;
+    }
+
+    // Push the (possibly calculateValue-mutated) customOptions to the Angular element.
+    private bindCustomOptions(): void {
+      if (!this._customAngularElement) {
+        return;
+      }
+      for (const key in this.component.customOptions) {
+        if (this.component.customOptions.hasOwnProperty(key)) {
+          this._customAngularElement[key] = this.component.customOptions[key];
+        }
+      }
     }
   };
 }


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: [#818](https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/818)

Custom FormIO components (e.g. `documenten-api-file`) support setting `customOptions` programmatically via a `calculateValue` side effect, for example `component.customOptions.filename = 'test'`. This stopped taking effect.

The root cause: `customOptions` were only pushed onto the underlying Angular element inside `attach()`, which only re-runs on a redraw. A `calculateValue` expression mutates `component.customOptions`, but for that mutation to reach the DOM it depended on a `redrawOn: "data"` redraw firing *after* the calculation. FormIO's self-change guard prevents a component from redrawing on its own data change, and within a single `checkData` cycle the redraw runs before the calculation — so in a form where nothing else changes after the calculation (e.g. a single uploader), the mutated `customOptions` never reached the element.

This change extracts the binding into a `bindCustomOptions()` helper and also invokes it from the overridden `setValue()`. Since FormIO calls `setValue()` immediately after evaluating `calculateValue`, the (possibly mutated) `customOptions` are now re-applied to the Angular element right away, independent of redraw timing. `attach()` still binds them as before.

>
> Trade-off considered: `bindCustomOptions()` now runs on every `setValue()` call. It is idempotent (re-applying config values) and cheap, so re-running it is harmless.

Specify the code branch location: `next-minor`

**Relevant comments:**
> This is a follow-up on [#818](https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/818) — the array-value restoration fix did not touch this path, but investigating the report surfaced that `calculateValue`-driven `customOptions` had become unreliable due to their dependence on redraw timing.

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [x] Step 1 — Create a form with a `documenten-api-file` component that has `redrawOn: "data"` and `calculateValue: "component.customOptions.filename = 'test'"`.
- [x] Step 2 — Render the form and open the upload/metadata dialog.
- [x] Step 3 — Confirm the `filename` field defaults to `test` (and verify the same works for other `customOptions`, e.g. `author`, `documentType`, `hide*`).

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
````