### PR TITLE
Prevent breaking release images (OpenSearch boot regression + smoke-test gate)

### DIFF
--- a/.github/workflows/backend_publish_release.yml
+++ b/.github/workflows/backend_publish_release.yml
@@ -23,8 +23,11 @@ jobs:
   build_run_tests:
     uses: ./.github/workflows/backend_build_test_libraries.yml
 
-  build_and_push_gzac_image:
-    name: Build and push gzac-backend image
+  # Release images are built to GHCR only here (no push_to_dockerhub). The
+  # smoke_and_promote jobs below boot each image and only then copy it to Docker
+  # Hub, so Docker Hub never receives an image that has not booted.
+  build_gzac_image:
+    name: Build gzac-backend image (GHCR)
     needs:
       - build_run_tests
     permissions:
@@ -34,13 +37,11 @@ jobs:
     with:
       backend_libraries_build_artifact_name: ${{ needs.build_run_tests.outputs.build_artifact_name }}
       variant: gzac
-      push_to_dockerhub: true
-      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}
     secrets: inherit
 
-  build_and_push_valtimo_image:
-    name: Build and push valtimo-backend image
+  build_valtimo_image:
+    name: Build valtimo-backend image (GHCR)
     needs:
       - build_run_tests
     permissions:
@@ -50,13 +51,11 @@ jobs:
     with:
       backend_libraries_build_artifact_name: ${{ needs.build_run_tests.outputs.build_artifact_name }}
       variant: valtimo
-      push_to_dockerhub: true
-      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}
     secrets: inherit
 
-  build_and_push_evenementenvergunning_image:
-    name: Build and push gzac-evenementenvergunning-backend image
+  build_evenementenvergunning_image:
+    name: Build gzac-evenementenvergunning-backend image (GHCR)
     needs:
       - build_run_tests
     permissions:
@@ -66,9 +65,46 @@ jobs:
     with:
       backend_libraries_build_artifact_name: ${{ needs.build_run_tests.outputs.build_artifact_name }}
       variant: evenementenvergunning
-      push_to_dockerhub: true
-      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}
+    secrets: inherit
+
+  smoke_and_promote_gzac:
+    name: Smoke test + promote gzac-backend
+    needs:
+      - build_gzac_image
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/backend_smoke_and_promote.yml
+    with:
+      image_name: gzac-backend
+      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
+    secrets: inherit
+
+  smoke_and_promote_valtimo:
+    name: Smoke test + promote valtimo-backend
+    needs:
+      - build_valtimo_image
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/backend_smoke_and_promote.yml
+    with:
+      image_name: valtimo-backend
+      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
+    secrets: inherit
+
+  smoke_and_promote_evenementenvergunning:
+    name: Smoke test + promote gzac-evenementenvergunning-backend
+    needs:
+      - build_evenementenvergunning_image
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/backend_smoke_and_promote.yml
+    with:
+      image_name: gzac-evenementenvergunning-backend
+      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
     secrets: inherit
 
   publish:

--- a/.github/workflows/backend_smoke_and_promote.yml
+++ b/.github/workflows/backend_smoke_and_promote.yml
@@ -1,0 +1,107 @@
+name: Backend - smoke test image and promote to Docker Hub
+
+# Release gate for backend images. The image was already built and pushed to
+# GHCR by backend_build_push_docker_image.yml (GHCR-only during release). Here we
+# BOOT that exact image against a minimal Postgres + Keycloak stack and wait for
+# the app's "... is running!" banner — logged by main() right after
+# runApplication() returns, i.e. once the Spring context has fully started and
+# every ready-event listener (Liquibase migrations, autodeployments) completed
+# without throwing. Only if it boots do we promote the identical multi-arch
+# manifest to Docker Hub with `docker buildx imagetools create` (a manifest copy,
+# no rebuild), so Docker Hub never receives an image that has not booted.
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: "GHCR/Docker Hub image name, e.g. gzac-backend"
+        required: true
+        type: string
+      release_image_tag:
+        description: "Tag to publish on Docker Hub, e.g. 13.40.0"
+        required: true
+        type: string
+      startup_timeout_seconds:
+        description: "How long to wait for the app to log its running banner"
+        required: false
+        type: number
+        default: 300
+
+jobs:
+  smoke_and_promote:
+    name: "Smoke + promote ${{ inputs.image_name }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      # The build workflow tags every image with a deterministic, slash-free
+      # commit tag; use it as the exact image under test and promotion source.
+      SMOKE_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image_name }}:commit-production-${{ github.sha }}
+      COMPOSE_FILE: backend/apps/dev/docker-compose.smoke.yml
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Boot image against Postgres + Keycloak
+        run: |
+          set -euo pipefail
+          echo "Image under test: $SMOKE_IMAGE"
+          docker compose -f "$COMPOSE_FILE" pull app
+          docker compose -f "$COMPOSE_FILE" up -d
+
+      - name: Wait for application-running banner
+        run: |
+          set -uo pipefail
+          deadline=$(( $(date +%s) + ${{ inputs.startup_timeout_seconds }} ))
+          # The app's main() logs this banner immediately after runApplication()
+          # returns — i.e. once the Spring context has fully started and every
+          # ready-event listener (migrations, autodeployments) completed without
+          # throwing. Its presence is our "image boots cleanly" signal.
+          banner="is running!"
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            logs="$(docker compose -f "$COMPOSE_FILE" logs --no-color app 2>/dev/null || true)"
+            if printf '%s' "$logs" | grep -qF "$banner"; then
+              echo "Application-running banner detected — image boots cleanly."
+              printf '%s\n' "$logs" | grep -F "$banner"
+              exit 0
+            fi
+            if ! docker compose -f "$COMPOSE_FILE" ps app --status running --quiet | grep -q .; then
+              echo "::error::App container exited before logging the running banner."
+              break
+            fi
+            sleep 5
+          done
+          echo "::error::Image ${SMOKE_IMAGE} did not log the running banner in ${{ inputs.startup_timeout_seconds }}s."
+          echo "----- last 200 lines of app logs -----"
+          docker compose -f "$COMPOSE_FILE" logs --tail=200 app || true
+          exit 1
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f "$COMPOSE_FILE" down -v || true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Promote tested image to Docker Hub
+        run: |
+          set -euo pipefail
+          TARGET="docker.io/ritense/${{ inputs.image_name }}:${{ inputs.release_image_tag }}"
+          echo "Promoting $SMOKE_IMAGE -> $TARGET (multi-arch manifest copy)"
+          docker buildx imagetools create --tag "$TARGET" "$SMOKE_IMAGE"
+          docker buildx imagetools inspect "$TARGET"

--- a/.github/workflows/frontend_publish_release.yml
+++ b/.github/workflows/frontend_publish_release.yml
@@ -37,8 +37,11 @@ jobs:
       frontend_libraries_build_artifact_name: ${{ needs.build_and_test_libs.outputs.build_artifact_name }}
     secrets: inherit
 
-  publish_gzac_image:
-    name: Build and push gzac-frontend image
+  # Release images are built to GHCR only here (no push_to_dockerhub). The
+  # smoke_and_promote jobs below run each image and only then copy it to Docker
+  # Hub, so Docker Hub never receives an image that has not served a page.
+  build_gzac_image:
+    name: Build gzac-frontend image (GHCR)
     needs:
       - build_and_test_libs
     permissions:
@@ -48,13 +51,11 @@ jobs:
     with:
       frontend_libraries_build_artifact_name: ${{ needs.build_and_test_libs.outputs.build_artifact_name }}
       variant: gzac
-      push_to_dockerhub: true
-      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}
     secrets: inherit
 
-  publish_valtimo_image:
-    name: Build and push valtimo-frontend image
+  build_valtimo_image:
+    name: Build valtimo-frontend image (GHCR)
     needs:
       - build_and_test_libs
     permissions:
@@ -64,13 +65,11 @@ jobs:
     with:
       frontend_libraries_build_artifact_name: ${{ needs.build_and_test_libs.outputs.build_artifact_name }}
       variant: valtimo
-      push_to_dockerhub: true
-      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}
     secrets: inherit
 
-  publish_evenementenvergunning_image:
-    name: Build and push gzac-evenementenvergunning-frontend image
+  build_evenementenvergunning_image:
+    name: Build gzac-evenementenvergunning-frontend image (GHCR)
     needs:
       - build_and_test_libs
     permissions:
@@ -80,7 +79,44 @@ jobs:
     with:
       frontend_libraries_build_artifact_name: ${{ needs.build_and_test_libs.outputs.build_artifact_name }}
       variant: evenementenvergunning
-      push_to_dockerhub: true
-      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}
+    secrets: inherit
+
+  smoke_and_promote_gzac:
+    name: Smoke test + promote gzac-frontend
+    needs:
+      - build_gzac_image
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/frontend_smoke_and_promote.yml
+    with:
+      image_name: gzac-frontend
+      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
+    secrets: inherit
+
+  smoke_and_promote_valtimo:
+    name: Smoke test + promote valtimo-frontend
+    needs:
+      - build_valtimo_image
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/frontend_smoke_and_promote.yml
+    with:
+      image_name: valtimo-frontend
+      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
+    secrets: inherit
+
+  smoke_and_promote_evenementenvergunning:
+    name: Smoke test + promote gzac-evenementenvergunning-frontend
+    needs:
+      - build_evenementenvergunning_image
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/frontend_smoke_and_promote.yml
+    with:
+      image_name: gzac-evenementenvergunning-frontend
+      release_image_tag: ${{ inputs.project_version || github.event.inputs.project_version }}
     secrets: inherit

--- a/.github/workflows/frontend_smoke_and_promote.yml
+++ b/.github/workflows/frontend_smoke_and_promote.yml
@@ -1,0 +1,121 @@
+name: Frontend - smoke test image and promote to Docker Hub
+
+# Release gate for frontend images. The image was already built and pushed to
+# GHCR by frontend_build_push_docker_image.yml (GHCR-only during release). Here
+# we RUN that exact image and assert the things that actually break in these
+# nginx images: the Angular variant bundle was really copied in, the container's
+# startup `envsubst` produced assets/config.js, and nginx serves without
+# crash-looping. Only then do we promote the identical multi-arch manifest to
+# Docker Hub with `docker buildx imagetools create` (a manifest copy, no
+# rebuild), so Docker Hub never receives an image that has not served a page.
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: "GHCR/Docker Hub image name, e.g. gzac-frontend"
+        required: true
+        type: string
+      release_image_tag:
+        description: "Tag to publish on Docker Hub, e.g. 13.40.0"
+        required: true
+        type: string
+
+jobs:
+  smoke_and_promote:
+    name: "Smoke + promote ${{ inputs.image_name }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      SMOKE_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image_name }}:commit-production-${{ github.sha }}
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run image
+        run: |
+          set -euo pipefail
+          echo "Image under test: $SMOKE_IMAGE"
+          docker pull "$SMOKE_IMAGE"
+          docker run -d --name fe -p 8080:8080 "$SMOKE_IMAGE"
+
+      - name: Smoke test served content
+        run: |
+          set -uo pipefail
+
+          # 1) index.html is served (200) and is a real Angular shell — proves the
+          #    variant browser/ dir was actually copied in (catches an empty image
+          #    from a wrong VARIANT build-arg).
+          index=""
+          for _ in $(seq 1 30); do
+            index="$(curl -fsS http://localhost:8080/ 2>/dev/null || true)"
+            [ -n "$index" ] && break
+            sleep 2
+          done
+          if ! echo "$index" | grep -q '<app-root'; then
+            echo "::error::index.html did not contain <app-root — variant bundle missing or empty."
+            echo "$index" | head -20
+            docker logs fe || true
+            exit 1
+          fi
+          echo "index.html OK (<app-root present)"
+
+          # 2) assets/config.js exists — proves config.template.js shipped and the
+          #    container's startup envsubst succeeded (the fragile part of the CMD).
+          if ! curl -fsS http://localhost:8080/assets/config.js >/dev/null 2>&1; then
+            echo "::error::/assets/config.js missing — startup envsubst of config.template.js failed."
+            docker logs fe || true
+            exit 1
+          fi
+          echo "assets/config.js OK (envsubst ran)"
+
+          # 3) a real Angular JS bundle referenced by index.html resolves —
+          #    proves the build produced bundles, not a zero-byte dist. Exclude
+          #    assets/config.js (it always exists and is checked above), so this
+          #    targets an actual app bundle (runtime.js / main.js / hashed).
+          bundle="$(echo "$index" | grep -oE 'src="[^"]+\.js"' | sed -E 's/src="([^"]+)"/\1/' | grep -viE '(^|/)config\.js$' | head -1)"
+          if [ -z "$bundle" ]; then
+            echo "::error::no app .js bundle referenced in index.html."
+            exit 1
+          fi
+          if ! curl -fsS "http://localhost:8080/${bundle#/}" >/dev/null 2>&1; then
+            echo "::error::referenced bundle ${bundle} did not resolve (200)."
+            exit 1
+          fi
+          echo "bundle ${bundle} OK"
+
+          # 4) container is still up (catches nginx config errors that crash-loop).
+          if [ "$(docker inspect -f '{{.State.Running}}' fe)" != "true" ]; then
+            echo "::error::container is not running — nginx likely crashed."
+            docker logs fe || true
+            exit 1
+          fi
+          echo "container still running OK"
+
+      - name: Tear down container
+        if: always()
+        run: docker rm -f fe || true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Promote tested image to Docker Hub
+        run: |
+          set -euo pipefail
+          TARGET="docker.io/ritense/${{ inputs.image_name }}:${{ inputs.release_image_tag }}"
+          echo "Promoting $SMOKE_IMAGE -> $TARGET (multi-arch manifest copy)"
+          docker buildx imagetools create --tag "$TARGET" "$SMOKE_IMAGE"
+          docker buildx imagetools inspect "$TARGET"

--- a/backend/apps/dev/docker-compose.smoke.yml
+++ b/backend/apps/dev/docker-compose.smoke.yml
@@ -1,0 +1,106 @@
+# Minimal boot stack for the release Docker-image smoke test.
+#
+# Boots a single backend image (gzac / valtimo / evenementenvergunning) against
+# the smallest set of dependencies it needs to reach full readiness: a Postgres
+# database and a Keycloak with the dev realm imported. RabbitMQ auto-config is
+# excluded by the apps, and OpenSearch/Gotenberg/ZGW are only used lazily, so
+# they are intentionally omitted here — the goal is "does this image boot and
+# migrate cleanly?", not a full functional environment.
+#
+# The image under test is injected via ${SMOKE_IMAGE}; the env block mirrors the
+# proven `gzac-backend` service in docker-compose.yaml, but points at the
+# in-network service names instead of host-gateway (no browser is involved).
+#
+# Usage (see backend_smoke_and_promote.yml):
+#   SMOKE_IMAGE=ghcr.io/<owner>/<repo>/gzac-backend:commit-production-<sha> \
+#     docker compose -f backend/apps/dev/docker-compose.smoke.yml up -d
+
+name: gzac-smoke
+
+services:
+    smoke-keycloak-database:
+        image: postgres:17.4
+        environment:
+            POSTGRES_USER: keycloak
+            POSTGRES_PASSWORD: keycloak
+
+    smoke-keycloak:
+        image: quay.io/keycloak/keycloak:26.6
+        depends_on:
+            - smoke-keycloak-database
+        environment:
+            KEYCLOAK_ADMIN: admin
+            KEYCLOAK_ADMIN_PASSWORD: admin
+            KC_DB: postgres
+            KC_DB_URL: jdbc:postgresql://smoke-keycloak-database/keycloak
+            KC_DB_USERNAME: keycloak
+            KC_DB_PASSWORD: keycloak
+            KC_HTTP_RELATIVE_PATH: /auth
+            KC_HOSTNAME_STRICT: false
+            KC_HOSTNAME_STRICT_HTTPS: false
+        volumes:
+            - ./imports/keycloak:/opt/keycloak/data/import
+        command:
+            - start-dev
+            - --import-realm
+            - --http-enabled=true
+            - --hostname-strict=false
+        healthcheck:
+            test: [ 'CMD-SHELL', '[ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { System.exit(((java.net.HttpURLConnection)new java.net.URL(args[0]).openConnection()).getResponseCode() == 200 ? 0 : 1); } }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:8080/auth' ]
+            interval: 10s
+            timeout: 5s
+            retries: 60
+            start_period: 5s
+
+    smoke-database:
+        image: postgres:17.4
+        environment:
+            POSTGRES_USER: gzac
+            POSTGRES_PASSWORD: password
+            POSTGRES_DB: gzac
+
+    # The outbox module wires RabbitMQ beans at boot (even though the base config
+    # excludes the plain RabbitAutoConfiguration), so a broker + connection env
+    # are required for the context to start — independent of any plugin autodeploy.
+    smoke-rabbitmq:
+        image: rabbitmq:4.1-management
+
+    app:
+        image: ${SMOKE_IMAGE:?set SMOKE_IMAGE to the backend image under test}
+        depends_on:
+            smoke-keycloak:
+                condition: service_healthy
+            smoke-database:
+                condition: service_started
+            smoke-rabbitmq:
+                condition: service_started
+        environment:
+            SPRING_PROFILES_ACTIVE: dev
+            SPRING_DATASOURCE_URL: jdbc:postgresql://smoke-database:5432/gzac
+            SPRING_DATASOURCE_NAME: gzac
+            SPRING_DATASOURCE_USERNAME: gzac
+            SPRING_DATASOURCE_PASSWORD: password
+            SPRING_RABBITMQ_HOST: smoke-rabbitmq
+            SPRING_RABBITMQ_PORT: "5672"
+            SPRING_RABBITMQ_USERNAME: guest
+            SPRING_RABBITMQ_PASSWORD: guest
+            SPRING_RABBITMQ_SSL_ENABLED: "false"
+            # Actuator basic-auth creds have no defaults in the base config; the
+            # actuator security filter chain fails to wire without them.
+            SPRING_ACTUATOR_USERNAME: actuator
+            SPRING_ACTUATOR_PASSWORD: actuator
+            VALTIMO_APP_HOSTNAME: http://localhost:4200
+            SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: http://smoke-keycloak:8080/auth/realms/valtimo/protocol/openid-connect/certs
+            SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAKAPI_ISSUERURI: http://smoke-keycloak:8080/auth/realms/valtimo
+            SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAKJWT_ISSUERURI: http://smoke-keycloak:8080/auth/realms/valtimo
+            SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKJWT_CLIENTID: valtimo-console
+            SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKAPI_CLIENTID: valtimo-user-m2m-client
+            SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAKAPI_CLIENTSECRET: 6ef6ca16-6b86-482a-a3d9-0561704c1db9
+            VALTIMO_PLUGIN_ENCRYPTIONSECRET: abcdefghijklmnop
+            VALTIMO_WEB_CORS_CORSCONFIGURATION_ALLOWEDORIGINS: http://localhost
+            VALTIMO_WEB_CORS_CORSCONFIGURATION_ALLOWEDMETHODS: "*"
+            VALTIMO_WEB_CORS_CORSCONFIGURATION_ALLOWEDHEADERS: "*"
+            VALTIMO_WEB_CORS_PATHS: /**
+            VALTIMO_CHANGELOG_PBAC_CLEARTABLES: "false"
+        ports:
+            - "8080:8080"

--- a/backend/apps/dev/src/main/resources/config/application.yml
+++ b/backend/apps/dev/src/main/resources/config/application.yml
@@ -26,7 +26,7 @@ management:
 
 spring:
     profiles:
-        active: ${SPRING_PROFILES_ACTIVE}
+        active: ${SPRING_PROFILES_ACTIVE:}
     application:
         name: GZAC backend
     jackson:

--- a/backend/apps/evenementenvergunning/src/main/resources/config/application.yml
+++ b/backend/apps/evenementenvergunning/src/main/resources/config/application.yml
@@ -18,6 +18,11 @@ logging:
 management:
     endpoint:
         health:
+            # readinessState/livenessState only exist when probes are enabled. Enable them
+            # explicitly so the readiness/startup groups below are valid outside Kubernetes too
+            # (Spring only auto-enables probes when it detects a Kubernetes platform).
+            probes:
+                enabled: true
             group:
                 # readiness (and a dedicated startup group) only report UP once the bootstrap
                 # health indicator is UP, i.e. after migrations + autodeployments have finished.
@@ -29,7 +34,7 @@ management:
 
 spring:
     profiles:
-        active: ${SPRING_PROFILES_ACTIVE}
+        active: ${SPRING_PROFILES_ACTIVE:}
     application:
         name: gzac-backend
     jackson:
@@ -138,7 +143,7 @@ server:
         min-response-size: 1024
 
 opensearch:
-    uris: ${OPENSEARCH_URIS:}
+    uris: ${OPENSEARCH_URIS:http://localhost:9200}
     username: ${OPENSEARCH_USERNAME:}
     password: ${OPENSEARCH_PASSWORD:}
 

--- a/backend/apps/gzac/src/main/resources/config/application.yml
+++ b/backend/apps/gzac/src/main/resources/config/application.yml
@@ -18,6 +18,11 @@ logging:
 management:
     endpoint:
         health:
+            # readinessState/livenessState only exist when probes are enabled. Enable them
+            # explicitly so the readiness/startup groups below are valid outside Kubernetes too
+            # (Spring only auto-enables probes when it detects a Kubernetes platform).
+            probes:
+                enabled: true
             group:
                 # readiness (and a dedicated startup group) only report UP once the bootstrap
                 # health indicator is UP, i.e. after migrations + autodeployments have finished.
@@ -29,7 +34,7 @@ management:
 
 spring:
     profiles:
-        active: ${SPRING_PROFILES_ACTIVE}
+        active: ${SPRING_PROFILES_ACTIVE:}
     application:
         name: gzac-backend
     jackson:
@@ -138,7 +143,7 @@ server:
         min-response-size: 1024
 
 opensearch:
-    uris: ${OPENSEARCH_URIS:}
+    uris: ${OPENSEARCH_URIS:http://localhost:9200}
     username: ${OPENSEARCH_USERNAME:}
     password: ${OPENSEARCH_PASSWORD:}
 

--- a/backend/apps/valtimo/src/main/resources/config/application.yml
+++ b/backend/apps/valtimo/src/main/resources/config/application.yml
@@ -31,7 +31,7 @@ management:
 
 spring:
     profiles:
-        active: ${SPRING_PROFILES_ACTIVE}
+        active: ${SPRING_PROFILES_ACTIVE:}
     application:
         name: valtimo-backend
     jackson:
@@ -140,7 +140,7 @@ server:
         min-response-size: 1024
 
 opensearch:
-    uris: ${OPENSEARCH_URIS:}
+    uris: ${OPENSEARCH_URIS:http://localhost:9200}
     username: ${OPENSEARCH_USERNAME:}
     password: ${OPENSEARCH_PASSWORD:}
 


### PR DESCRIPTION
## What

`opensearch.uris: ${OPENSEARCH_URIS:}` defaulted to an **empty** value, which made the OpenSearch client fail at startup (`hosts must not be null nor empty`). The gzac/valtimo/evenementenvergunning images could no longer boot unless `OPENSEARCH_URIS` was set — a breaking change we only noticed after release.

## Changes

- **Fix the regression:** default `opensearch.uris` to the library default (`http://localhost:9200`) so a missing `OPENSEARCH_URIS` no longer breaks boot (the client is only contacted on an actual search).
- **Also fixed:** enable health probes on gzac/evenementenvergunning so their `readiness`/`startup` groups are valid outside Kubernetes (`readinessState` was otherwise missing → startup crash).
- **Prevent future breakage:** a smoke-test gate that boots each backend/frontend release image and only promotes it to Docker Hub after it starts cleanly — so this class of "image doesn't boot" bug is caught before release instead of after.