### PR TITLE
Add default value support to environment placeholders

### DIFF
--- a/backend/changelog/src/main/kotlin/com/ritense/valtimo/changelog/service/ChangelogDeployer.kt
+++ b/backend/changelog/src/main/kotlin/com/ritense/valtimo/changelog/service/ChangelogDeployer.kt
@@ -87,8 +87,10 @@ class ChangelogDeployer(
             .map { it.groupValues }
             .forEach { (placeholder, placeholderValue) ->
                 try {
-                    val resolvedValue = environment.getProperty(placeholderValue)
-                    if (!resolvedValue.isNullOrBlank()) {
+                    val name = placeholderValue.substringBefore(':')
+                    val default = placeholderValue.substringAfter(':', missingDelimiterValue = "").takeIf { ':' in placeholderValue }
+                    val resolvedValue = environment.getProperty(name)?.takeIf { it.isNotBlank() } ?: default
+                    if (resolvedValue != null) {
                         resolvedContent = resolvedContent.replace(placeholder, resolvedValue)
                     }
                 } catch (e: Exception) {

--- a/backend/changelog/src/test/kotlin/com/ritense/valtimo/changelog/ChangelogDeployerIntTest.kt
+++ b/backend/changelog/src/test/kotlin/com/ritense/valtimo/changelog/ChangelogDeployerIntTest.kt
@@ -110,4 +110,45 @@ internal class ChangelogDeployerIntTest : BaseIntegrationTest() {
         assertThat(changeset.get().md5sum).isEqualTo("7b30a822ba6369cfb1d7bb2a1adf0f92")
         assertThat(changeset.get().checksumType).isEqualTo(ChangesetCheckSumType.FILE_HASH)
     }
+
+    @Test
+    fun `should use default value when property is not set`() {
+        val content = """{"url": "${'$'}{SOME_UNSET_CHANGELOG_PROPERTY:https://default.example.com}"}"""
+
+        val result = changelogDeployer.resolveProperties(content)
+
+        assertThat(result).isEqualTo("""{"url": "https://default.example.com"}""")
+    }
+
+    @Test
+    fun `should prefer set property over default value`() {
+        System.setProperty("MY_SET_CHANGELOG_PROPERTY", "actual-value")
+        try {
+            val content = """{"value": "${'$'}{MY_SET_CHANGELOG_PROPERTY:default-value}"}"""
+
+            val result = changelogDeployer.resolveProperties(content)
+
+            assertThat(result).isEqualTo("""{"value": "actual-value"}""")
+        } finally {
+            System.clearProperty("MY_SET_CHANGELOG_PROPERTY")
+        }
+    }
+
+    @Test
+    fun `should resolve empty default to empty string`() {
+        val content = """{"suffix": "value=${'$'}{SOME_UNSET_CHANGELOG_PROPERTY:}"}"""
+
+        val result = changelogDeployer.resolveProperties(content)
+
+        assertThat(result).isEqualTo("""{"suffix": "value="}""")
+    }
+
+    @Test
+    fun `should leave placeholder untouched when property not set and no default`() {
+        val content = """{"value": "${'$'}{SOME_UNSET_CHANGELOG_PROPERTY}"}"""
+
+        val result = changelogDeployer.resolveProperties(content)
+
+        assertThat(result).isEqualTo(content)
+    }
 }

--- a/backend/importer/src/main/kotlin/com/ritense/importer/ValtimoImportService.kt
+++ b/backend/importer/src/main/kotlin/com/ritense/importer/ValtimoImportService.kt
@@ -525,11 +525,15 @@ class ValtimoImportService(
             .map { it.groupValues }
             .forEach { (placeholder, placeholderValue) ->
                 try {
-                    whitelistedEnvironmentProperties.firstOrNull { it.matches(placeholderValue) }?.let {
-                        val resolvedValue = environment.getProperty(placeholderValue)
-                        if (!resolvedValue.isNullOrBlank()) {
-                            resolvedContent = resolvedContent.replace(placeholder, resolvedValue)
-                        }
+                    val name = placeholderValue.substringBefore(':')
+                    val default = placeholderValue.substringAfter(':', missingDelimiterValue = "").takeIf { ':' in placeholderValue }
+                    val resolvedValue = if (whitelistedEnvironmentProperties.any { it.matches(name) }) {
+                        environment.getProperty(name)?.takeIf { it.isNotBlank() } ?: default
+                    } else {
+                        default
+                    }
+                    if (resolvedValue != null) {
+                        resolvedContent = resolvedContent.replace(placeholder, resolvedValue)
                     }
                 } catch (e: Exception) {
                     // ignored

--- a/backend/importer/src/test/kotlin/com/ritense/importer/ValtimoImportServiceTest.kt
+++ b/backend/importer/src/test/kotlin/com/ritense/importer/ValtimoImportServiceTest.kt
@@ -33,6 +33,7 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.core.env.Environment
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -229,6 +230,64 @@ class ValtimoImportServiceTest {
 
         assertThat(String(received["config/test.json"]!!, Charsets.UTF_8))
             .isEqualTo(jsonText)
+    }
+
+    @Test
+    fun `should use default when whitelisted property is not set`() {
+        val environment = mock(Environment::class.java)
+        val service = ValtimoImportService(setOf(), environment, listOf(Regex("MY_PROP")), null)
+
+        val result = service.invokeResolveProperties("""{"url": "${'$'}{MY_PROP:https://default.example.com}"}""")
+
+        assertThat(result).isEqualTo("""{"url": "https://default.example.com"}""")
+    }
+
+    @Test
+    fun `should prefer whitelisted environment value over default`() {
+        val environment = mock(Environment::class.java)
+        whenever(environment.getProperty("MY_PROP")).thenReturn("https://actual.example.com")
+        val service = ValtimoImportService(setOf(), environment, listOf(Regex("MY_PROP")), null)
+
+        val result = service.invokeResolveProperties("""{"url": "${'$'}{MY_PROP:https://default.example.com}"}""")
+
+        assertThat(result).isEqualTo("""{"url": "https://actual.example.com"}""")
+    }
+
+    @Test
+    fun `should use default even when property is not whitelisted`() {
+        val environment = mock(Environment::class.java)
+        val service = ValtimoImportService(setOf(), environment, emptyList(), null)
+
+        val result = service.invokeResolveProperties("""{"url": "${'$'}{NOT_WHITELISTED:https://default.example.com}"}""")
+
+        assertThat(result).isEqualTo("""{"url": "https://default.example.com"}""")
+    }
+
+    @Test
+    fun `should resolve empty default to empty string`() {
+        val environment = mock(Environment::class.java)
+        val service = ValtimoImportService(setOf(), environment, listOf(Regex("MY_PROP")), null)
+
+        val result = service.invokeResolveProperties("""{"suffix": "value=${'$'}{MY_PROP:}"}""")
+
+        assertThat(result).isEqualTo("""{"suffix": "value="}""")
+    }
+
+    @Test
+    fun `should leave placeholder untouched when not whitelisted and no default`() {
+        val environment = mock(Environment::class.java)
+        val service = ValtimoImportService(setOf(), environment, emptyList(), null)
+        val content = """{"value": "${'$'}{NOT_WHITELISTED}"}"""
+
+        val result = service.invokeResolveProperties(content)
+
+        assertThat(result).isEqualTo(content)
+    }
+
+    private fun ValtimoImportService.invokeResolveProperties(content: String): String {
+        val method = ValtimoImportService::class.java.getDeclaredMethod("resolveProperties", String::class.java)
+        method.isAccessible = true
+        return method.invoke(this, content) as String
     }
 
     private fun createZipInputStream(size: Int = 5, skip: Int? = null, extraEntries: List<Pair<String, String>> = emptyList()): InputStream {

--- a/backend/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
+++ b/backend/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
@@ -236,10 +236,13 @@ class PluginService(
                 Regex("\\$\\{([^\\}]+)\\}").findAll(value)
                     .map { it.groupValues }
                     .forEach { (placeholder, placeholderValue) ->
-                        val resolvedValue = environment.getProperty(placeholderValue)
-                            ?: System.getenv(placeholderValue)
-                            ?: System.getProperty(placeholderValue)
-                            ?: throw IllegalStateException("Failed to find environment variable: '$placeholderValue'")
+                        val name = placeholderValue.substringBefore(':')
+                        val default = placeholderValue.substringAfter(':', missingDelimiterValue = "").takeIf { ':' in placeholderValue }
+                        val resolvedValue = environment.getProperty(name)
+                            ?: System.getenv(name)
+                            ?: System.getProperty(name)
+                            ?: default
+                            ?: throw IllegalStateException("Failed to find environment variable: '$name'")
                         value = value.replace(placeholder, resolvedValue)
                     }
                 return TextNode(value)

--- a/backend/plugin/src/test/kotlin/com/ritense/plugin/service/PluginServiceIT.kt
+++ b/backend/plugin/src/test/kotlin/com/ritense/plugin/service/PluginServiceIT.kt
@@ -461,6 +461,69 @@ internal class PluginServiceIT : BaseIntegrationTest() {
 
     @Test
     @Transactional
+    fun `should deploy plugin using default value for optional placeholder`() {
+        val pluginConfigurationId = UUID.randomUUID()
+        // MY_OPTIONAL_URL / MY_OPTIONAL_SUFFIX are deliberately never set, so the
+        // ${'$'}{NAME:default} default must be used instead of failing the deployment.
+        val properties = """
+            {
+                "property1": "${'$'}{MY_OPTIONAL_URL:https://default.example.com/}api/v1",
+                "property2": true,
+                "property3": 3,
+                "property4": [
+                    {
+                        "innerProperty": "value=${'$'}{MY_OPTIONAL_SUFFIX:}"
+                    }
+                ]
+            }"""
+
+        pluginService.deployPluginConfigurations(
+            PluginAutoDeploymentDto(
+                id = pluginConfigurationId,
+                title = "My optional-default plugin",
+                pluginDefinitionKey = "auto-deployment-test-plugin",
+                properties = objectMapper.readTree(properties) as ObjectNode
+            )
+        )
+
+        val pluginConfiguration = pluginService.createInstance<AutoDeploymentTestPlugin>(pluginConfigurationId)
+        assertEquals(URI("https://default.example.com/api/v1"), pluginConfiguration.property1)
+        // An empty default resolves to an empty string, keeping the variable optional and non-fatal.
+        assertEquals("value=", pluginConfiguration.property4.single().innerProperty)
+    }
+
+    @Test
+    @Transactional
+    fun `should prefer set variable over placeholder default`() {
+        val pluginConfigurationId = UUID.randomUUID()
+        System.setProperty("MY_SET_URL", "https://set.example.com/")
+        val properties = """
+            {
+                "property1": "${'$'}{MY_SET_URL:https://default.example.com/}api/v1",
+                "property2": true,
+                "property3": 3,
+                "property4": [
+                    {
+                        "innerProperty": "x"
+                    }
+                ]
+            }"""
+
+        pluginService.deployPluginConfigurations(
+            PluginAutoDeploymentDto(
+                id = pluginConfigurationId,
+                title = "My set-over-default plugin",
+                pluginDefinitionKey = "auto-deployment-test-plugin",
+                properties = objectMapper.readTree(properties) as ObjectNode
+            )
+        )
+
+        val pluginConfiguration = pluginService.createInstance<AutoDeploymentTestPlugin>(pluginConfigurationId)
+        assertEquals(URI("https://set.example.com/api/v1"), pluginConfiguration.property1)
+    }
+
+    @Test
+    @Transactional
     fun `should update plugin configuration id`() {
         val pluginProperties = objectMapper.readTree("""{ "property1": "updated" }""") as ObjectNode
         val newPluginConfigurationId = PluginConfigurationId(UUID.fromString("ec9c12f3-5617-4184-88cc-e314dd9f4de2"))

--- a/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/autodeployment/ObjectManagementDefinitionDeploymentService.kt
+++ b/backend/zgw/object-management/src/main/kotlin/com/ritense/objectmanagement/autodeployment/ObjectManagementDefinitionDeploymentService.kt
@@ -103,7 +103,13 @@ class ObjectManagementDefinitionDeploymentService(
 
     private fun getEnvVariableOrYamlPropertyOrDirectValue(value: String): String {
         return Regex("\\$\\{([^\\}]+)\\}").find(value)?.let { matchResult ->
-            System.getenv(matchResult.groupValues[1]) ?: System.getProperty(matchResult.groupValues[1]) ?: environment.getProperty(matchResult.groupValues[1])
+            val placeholderValue = matchResult.groupValues[1]
+            val name = placeholderValue.substringBefore(':')
+            val default = placeholderValue.substringAfter(':', missingDelimiterValue = "").takeIf { ':' in placeholderValue }
+            System.getenv(name)
+                ?: System.getProperty(name)
+                ?: environment.getProperty(name)
+                ?: default
         } ?: value
     }
 

--- a/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/autodeployment/ObjectManagementDefinitionDeploymentServiceIntTest.kt
+++ b/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/autodeployment/ObjectManagementDefinitionDeploymentServiceIntTest.kt
@@ -20,7 +20,10 @@ import com.ritense.objectmanagement.BaseIntegrationTest
 import com.ritense.objectmanagement.service.ObjectManagementService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.env.Environment
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
@@ -37,5 +40,54 @@ internal class ObjectManagementDefinitionDeploymentServiceIntTest: BaseIntegrati
         assertThat(objectManagement).isNotNull
         assertThat(objectManagement?.title).isEqualTo("My Object Management")
         assertThat(objectManagement?.id).isEqualTo(UUID.fromString("4f35c270-21f4-4e99-a8a1-6c4f9d5a6c5c"))
+    }
+
+    @Test
+    fun `should use default value when placeholder is not resolvable`() {
+        val service = deploymentService(mock())
+
+        val result = service.invokeResolvePlaceholder("${'$'}{SOME_UNSET_PROPERTY:https://default.example.com}")
+
+        assertThat(result).isEqualTo("https://default.example.com")
+    }
+
+    @Test
+    fun `should prefer resolved value over default`() {
+        val environment = mock<Environment>()
+        whenever(environment.getProperty("MY_OBJECT_PROP")).thenReturn("https://actual.example.com")
+        val service = deploymentService(environment)
+
+        val result = service.invokeResolvePlaceholder("${'$'}{MY_OBJECT_PROP:https://default.example.com}")
+
+        assertThat(result).isEqualTo("https://actual.example.com")
+    }
+
+    @Test
+    fun `should resolve empty default to empty string`() {
+        val service = deploymentService(mock())
+
+        val result = service.invokeResolvePlaceholder("${'$'}{SOME_UNSET_PROPERTY:}")
+
+        assertThat(result).isEqualTo("")
+    }
+
+    @Test
+    fun `should return original value when placeholder not resolvable and no default`() {
+        val service = deploymentService(mock())
+
+        val result = service.invokeResolvePlaceholder("${'$'}{SOME_UNSET_PROPERTY}")
+
+        assertThat(result).isEqualTo("${'$'}{SOME_UNSET_PROPERTY}")
+    }
+
+    private fun deploymentService(environment: Environment) = ObjectManagementDefinitionDeploymentService(
+        mock(), mock(), mock(), mock(), mock(), environment
+    )
+
+    private fun ObjectManagementDefinitionDeploymentService.invokeResolvePlaceholder(value: String): String {
+        val method = ObjectManagementDefinitionDeploymentService::class.java
+            .getDeclaredMethod("getEnvVariableOrYamlPropertyOrDirectValue", String::class.java)
+        method.isAccessible = true
+        return method.invoke(this, value) as String
     }
 }


### PR DESCRIPTION
Add support for a default value, like: `${NAME:default}`, in autodeploy/import json files