### PR TITLE
More stable integration tests

### DIFF
--- a/backend/keycloak-iam/src/test/kotlin/com/valtimo/keycloak/BaseIntegrationTest.kt
+++ b/backend/keycloak-iam/src/test/kotlin/com/valtimo/keycloak/BaseIntegrationTest.kt
@@ -23,11 +23,11 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
@@ -47,35 +47,44 @@ abstract class BaseIntegrationTest {
 
     companion object {
 
-        lateinit var server: MockWebServer
-
-        @JvmStatic
-        @BeforeAll
-        fun setUp() {
-            server = MockWebServer()
-            setupMockKeycloakApiServer()
-            server.start(port = 19152)
+        // Started eagerly (before the Spring context) on an OS-assigned free port, so @DynamicPropertySource can
+        // expose that port to the OIDC configuration that Spring Security resolves and validates during startup.
+        // This avoids depending on a fixed port, which could clash with an outbound socket and cause a BindException.
+        val server: MockWebServer = MockWebServer().apply {
+            dispatcher = keycloakDispatcher()
+            start()
         }
 
+        private val issuerUri: String
+            get() = server.url("/auth/realms/valtimo").toString()
+
         @JvmStatic
-        @AfterAll
-        fun tearDown() {
-            server.shutdown()
+        @DynamicPropertySource
+        fun keycloakProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.security.oauth2.client.provider.keycloakjwt.issuer-uri") { issuerUri }
+            registry.add("spring.security.oauth2.client.provider.keycloakapi.issuer-uri") { issuerUri }
+            registry.add("spring.security.oauth2.resourceserver.jwt.jwk-set-uri") {
+                "$issuerUri/protocol/openid-connect/certs"
+            }
         }
 
-        private fun setupMockKeycloakApiServer() {
-            val dispatcher = object : Dispatcher() {
-                override fun dispatch(request: RecordedRequest): MockResponse {
-                    val response = when (request.requestLine) {
-                        "GET /auth/realms/valtimo/.well-known/openid-configuration HTTP/1.1" -> mockResponseFromFile("/data/get-openid-configuration.json")
-                        "GET /auth/admin/serverinfo HTTP/1.1" -> mockResponseFromFile("/data/get-server-info.json")
-                        "POST /auth/realms/valtimo/protocol/openid-connect/token HTTP/1.1" -> mockResponseFromFile("/data/grant-token-response.json")
-                        else -> MockResponse().setResponseCode(404)
-                    }
-                    return response
+        private fun keycloakDispatcher(): Dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                return when (request.requestLine) {
+                    "GET /auth/realms/valtimo/.well-known/openid-configuration HTTP/1.1" ->
+                        mockResponse(openIdConfiguration())
+                    "GET /auth/admin/serverinfo HTTP/1.1" -> mockResponseFromFile("/data/get-server-info.json")
+                    "POST /auth/realms/valtimo/protocol/openid-connect/token HTTP/1.1" ->
+                        mockResponseFromFile("/data/grant-token-response.json")
+                    else -> MockResponse().setResponseCode(404)
                 }
             }
-            server.dispatcher = dispatcher
+        }
+
+        private fun openIdConfiguration(): String {
+            val baseUrl = server.url("").toString().removeSuffix("/")
+            return readFileAsString("/data/get-openid-configuration.json")
+                .replace("http://localhost:19152", baseUrl)
         }
 
         private fun mockResponseFromFile(fileName: String) =

--- a/backend/keycloak-iam/src/test/kotlin/com/valtimo/keycloak/BaseIntegrationTest.kt
+++ b/backend/keycloak-iam/src/test/kotlin/com/valtimo/keycloak/BaseIntegrationTest.kt
@@ -54,7 +54,7 @@ abstract class BaseIntegrationTest {
         fun setUp() {
             server = MockWebServer()
             setupMockKeycloakApiServer()
-            server.start(port = 49152)
+            server.start(port = 19152)
         }
 
         @JvmStatic

--- a/backend/keycloak-iam/src/test/resources/config/application.yml
+++ b/backend/keycloak-iam/src/test/resources/config/application.yml
@@ -26,13 +26,13 @@ spring:
         oauth2:
             resourceserver:
                 jwt:
-                    jwk-set-uri: http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/certs
+                    jwk-set-uri: http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/certs
             client:
                 provider:
                     keycloakjwt:
-                        issuer-uri: http://localhost:49152/auth/realms/valtimo
+                        issuer-uri: http://localhost:19152/auth/realms/valtimo
                     keycloakapi:
-                        issuer-uri: http://localhost:49152/auth/realms/valtimo
+                        issuer-uri: http://localhost:19152/auth/realms/valtimo
                 registration:
                     keycloakjwt:
                         client-id: valtimo-console

--- a/backend/keycloak-iam/src/test/resources/data/get-openid-configuration.json
+++ b/backend/keycloak-iam/src/test/resources/data/get-openid-configuration.json
@@ -1,14 +1,14 @@
 {
-    "issuer": "http://localhost:49152/auth/realms/valtimo",
-    "authorization_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/auth",
-    "token_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/token",
-    "introspection_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/token/introspect",
-    "userinfo_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/userinfo",
-    "end_session_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/logout",
+    "issuer": "http://localhost:19152/auth/realms/valtimo",
+    "authorization_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/auth",
+    "token_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/token",
+    "introspection_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/token/introspect",
+    "userinfo_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/userinfo",
+    "end_session_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/logout",
     "frontchannel_logout_session_supported": true,
     "frontchannel_logout_supported": true,
-    "jwks_uri": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/certs",
-    "check_session_iframe": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/login-status-iframe.html",
+    "jwks_uri": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/certs",
+    "check_session_iframe": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/login-status-iframe.html",
     "grant_types_supported": [
         "authorization_code",
         "client_credentials",
@@ -150,7 +150,7 @@
         "form_post.jwt",
         "jwt"
     ],
-    "registration_endpoint": "http://localhost:49152/auth/realms/valtimo/clients-registrations/openid-connect",
+    "registration_endpoint": "http://localhost:19152/auth/realms/valtimo/clients-registrations/openid-connect",
     "token_endpoint_auth_methods_supported": [
         "private_key_jwt",
         "client_secret_basic",
@@ -265,7 +265,7 @@
         "S256"
     ],
     "tls_client_certificate_bound_access_tokens": true,
-    "revocation_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/revoke",
+    "revocation_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/revoke",
     "revocation_endpoint_auth_methods_supported": [
         "private_key_jwt",
         "client_secret_basic",
@@ -290,12 +290,12 @@
     ],
     "backchannel_logout_supported": true,
     "backchannel_logout_session_supported": true,
-    "device_authorization_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/auth/device",
+    "device_authorization_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/auth/device",
     "backchannel_token_delivery_modes_supported": [
         "poll",
         "ping"
     ],
-    "backchannel_authentication_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/ext/ciba/auth",
+    "backchannel_authentication_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/ext/ciba/auth",
     "backchannel_authentication_request_signing_alg_values_supported": [
         "PS384",
         "RS384",
@@ -309,16 +309,16 @@
         "RS512"
     ],
     "require_pushed_authorization_requests": false,
-    "pushed_authorization_request_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/ext/par/request",
+    "pushed_authorization_request_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/ext/par/request",
     "mtls_endpoint_aliases": {
-        "token_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/token",
-        "revocation_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/revoke",
-        "introspection_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/token/introspect",
-        "device_authorization_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/auth/device",
-        "registration_endpoint": "http://localhost:49152/auth/realms/valtimo/clients-registrations/openid-connect",
-        "userinfo_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/userinfo",
-        "pushed_authorization_request_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/ext/par/request",
-        "backchannel_authentication_endpoint": "http://localhost:49152/auth/realms/valtimo/protocol/openid-connect/ext/ciba/auth"
+        "token_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/token",
+        "revocation_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/revoke",
+        "introspection_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/token/introspect",
+        "device_authorization_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/auth/device",
+        "registration_endpoint": "http://localhost:19152/auth/realms/valtimo/clients-registrations/openid-connect",
+        "userinfo_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/userinfo",
+        "pushed_authorization_request_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/ext/par/request",
+        "backchannel_authentication_endpoint": "http://localhost:19152/auth/realms/valtimo/protocol/openid-connect/ext/ciba/auth"
     },
     "authorization_response_iss_parameter_supported": true
 }

--- a/backend/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginIT.kt
+++ b/backend/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginIT.kt
@@ -86,13 +86,19 @@ class CatalogiApiPluginIT : BaseIntegrationTest() {
     lateinit var pluginConfigurationId: PluginConfigurationId
     private var executedRequests: MutableList<RecordedRequest> = mutableListOf()
 
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val apiBaseUrl get() = server.url(CATALOGI_API_PATH).toString()
+    private val catalogusUrl get() = "$apiBaseUrl/catalogussen/8225508a-6840-413e-acc9-6422af120db1"
+    private val zaaktypeUrl get() = "$apiBaseUrl/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002"
+    private val zaaktypeInformatieobjecttypeUrl get() = "$apiBaseUrl/zaaktype-informatieobjecttypen/f1234567-1234-1234-1234-123456789012"
+    private val informatieobjecttypeUrl get() = "$apiBaseUrl/informatieobjecttypen/$INFORMATIEOBJECTTYPE_ID"
+
     @BeforeEach
     internal fun setUp() {
         executedRequests.clear()
         server = MockWebServer()
         setupMockCatalogiApiServer()
-        server.start(port = 56274)
-        Thread.sleep(2000)
+        server.start()
 
         val mockedId = PluginConfigurationId.existingId(UUID.fromString(AUTHENTICATION_PLUGIN_ID))
         doReturn(Optional.of(mock<PluginConfiguration>()))
@@ -141,13 +147,13 @@ class CatalogiApiPluginIT : BaseIntegrationTest() {
         val processInstanceId = response.resultingProcessInstanceId().get().toString()
         val processVariable = getHistoricProcessVariable(processInstanceId, PROCESS_VARIABLE_NAME)
 
-        assertEquals(INFORMATIEOBJECTTYPE_URL, processVariable)
+        assertEquals(informatieobjecttypeUrl, processVariable)
 
         val zaaktypeInformatieobjecttypesRequest = executedRequests.find {
             it.path?.contains("zaaktype-informatieobjecttypen") == true
         }
         assertNotNull(zaaktypeInformatieobjecttypesRequest)
-        assertTrue(zaaktypeInformatieobjecttypesRequest.path?.contains("zaaktype=$ZAAKTYPE_URL") == true)
+        assertTrue(zaaktypeInformatieobjecttypesRequest.path?.contains("zaaktype=$zaaktypeUrl") == true)
     }
 
     private fun createProcessLink(informatieobjecttype: String) {
@@ -171,7 +177,7 @@ class CatalogiApiPluginIT : BaseIntegrationTest() {
     }
 
     private fun setupZaaktypeUrlProviderMock() {
-        doReturn(URI.create(ZAAKTYPE_URL))
+        doReturn(URI.create(zaaktypeUrl))
             .whenever(zaaktypeUrlProvider).getZaaktypeUrl(any<UUID>())
     }
 
@@ -213,9 +219,9 @@ class CatalogiApiPluginIT : BaseIntegrationTest() {
                 "next": null,
                 "previous": null,
                 "results": [{
-                    "url": "$ZAAKTYPE_INFORMATIEOBJECTTYPE_URL",
-                    "zaaktype": "$ZAAKTYPE_URL",
-                    "informatieobjecttype": "$INFORMATIEOBJECTTYPE_URL",
+                    "url": "$zaaktypeInformatieobjecttypeUrl",
+                    "zaaktype": "$zaaktypeUrl",
+                    "informatieobjecttype": "$informatieobjecttypeUrl",
                     "volgnummer": 1,
                     "richting": "inkomend",
                     "statustype": null
@@ -228,8 +234,8 @@ class CatalogiApiPluginIT : BaseIntegrationTest() {
     private fun informatieobjecttypeResponse(): MockResponse {
         val body = """
             {
-                "url": "$INFORMATIEOBJECTTYPE_URL",
-                "catalogus": "$CATALOGUS_URL",
+                "url": "$informatieobjecttypeUrl",
+                "catalogus": "$catalogusUrl",
                 "omschrijving": "$INFORMATIEOBJECTTYPE_OMSCHRIJVING",
                 "vertrouwelijkheidaanduiding": "openbaar",
                 "beginGeldigheid": "${LocalDate.now().minusDays(1)}",
@@ -260,11 +266,7 @@ class CatalogiApiPluginIT : BaseIntegrationTest() {
         private const val AUTHENTICATION_PLUGIN_ID = "27a399c7-9d70-4833-a651-57664e2e9e09"
 
         private const val CATALOGI_API_PATH = "/catalogi/api/v1"
-        private const val CATALOGUS_URL = "http://localhost:56274$CATALOGI_API_PATH/catalogussen/8225508a-6840-413e-acc9-6422af120db1"
-        private const val ZAAKTYPE_URL = "http://localhost:56274$CATALOGI_API_PATH/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002"
-        private const val ZAAKTYPE_INFORMATIEOBJECTTYPE_URL = "http://localhost:56274$CATALOGI_API_PATH/zaaktype-informatieobjecttypen/f1234567-1234-1234-1234-123456789012"
         private const val INFORMATIEOBJECTTYPE_ID = "12345678-be3b-4bad-9e3c-49a6219c92ad"
-        private const val INFORMATIEOBJECTTYPE_URL = "http://localhost:56274$CATALOGI_API_PATH/informatieobjecttypen/$INFORMATIEOBJECTTYPE_ID"
         private const val INFORMATIEOBJECTTYPE_OMSCHRIJVING = "Bijlage"
         private const val PROCESS_VARIABLE_NAME = "informatieobjecttypeUrl"
     }

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/BaseIntegrationTest.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/BaseIntegrationTest.kt
@@ -16,14 +16,17 @@
 
 package com.ritense.documentenapi
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.ritense.catalogiapi.service.ZaaktypeUrlProvider
 import com.ritense.documentenapi.event.DocumentCreated
+import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.repository.PluginConfigurationRepository
 import com.ritense.plugin.service.PluginService
 import com.ritense.resource.service.ResourceService
 import com.ritense.valtimo.contract.authentication.UserManagementService
 import com.ritense.valtimo.contract.mail.MailSender
 import okhttp3.mockwebserver.MockResponse
+import java.util.UUID
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
@@ -69,5 +72,20 @@ class BaseIntegrationTest {
         return MockResponse()
             .addHeader("Content-Type", "application/json")
             .setBody(body)
+    }
+
+    /**
+     * Points a deployed plugin configuration at the given (typically randomly assigned) mock server URL,
+     * so integration tests do not depend on a fixed port. Returns the previous URL so callers that run
+     * outside a rolled-back transaction (e.g. @BeforeAll) can restore it afterwards.
+     */
+    protected fun setPluginConfigurationUrl(pluginConfigurationId: String, url: String): String {
+        val id = PluginConfigurationId.existingId(UUID.fromString(pluginConfigurationId))
+        val configuration = pluginService.getPluginConfiguration(id)
+        val properties: ObjectNode = configuration.properties!!.deepCopy()
+        val previousUrl = properties.get("url")?.asText() ?: ""
+        properties.put("url", url)
+        pluginService.updatePluginConfiguration(id, configuration.title, properties)
+        return previousUrl
     }
 }

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientIT.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientIT.kt
@@ -60,20 +60,27 @@ internal class DocumentenApiClientIT @Autowired constructor(
     lateinit var server: MockWebServer
     lateinit var documentenApiPlugin: DocumentenApiPlugin
     lateinit var roleTest: Role
+    private var previousPluginUrl: String = ""
+
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val baseUrl get() = server.url("").toString().removeSuffix("/")
 
     @BeforeAll
     internal fun setUp() {
         server = MockWebServer()
         setupMockDocumentenApiServer()
-        server.start(port = 16274)
+        server.start()
 
-        documentenApiPlugin = pluginService.createInstance("5474fe57-532a-4050-8d89-32e62ca3e895")
+        // @BeforeAll runs outside the per-test transaction, so capture the original URL and restore it in tearDown.
+        previousPluginUrl = setPluginConfigurationUrl(DOCUMENTEN_API_PLUGIN_ID, server.url("/documenten/").toString())
+        documentenApiPlugin = pluginService.createInstance(DOCUMENTEN_API_PLUGIN_ID)
 
         roleTest = roleRepository.findByKey("ROLE_TEST")!!
     }
 
     @AfterAll
     internal fun tearDown() {
+        setPluginConfigurationUrl(DOCUMENTEN_API_PLUGIN_ID, previousPluginUrl)
         server.shutdown()
     }
 
@@ -152,7 +159,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
             documentenApiPlugin.url,
             Pageable.ofSize(10),
             DocumentSearchRequest(
-                zaakUrl = URI("https://localhost:16274/documenten/1234"),
+                zaakUrl = URI("$baseUrl/documenten/1234"),
             )
         )
 
@@ -169,7 +176,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
             documentenApiPlugin.url,
             Pageable.ofSize(10),
             DocumentSearchRequest(
-                zaakUrl = URI("https://localhost:16274/documenten/1234"),
+                zaakUrl = URI("$baseUrl/documenten/1234"),
             )
         )
 
@@ -317,7 +324,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
         permissionRepository.saveAllAndFlush(permissions)
 
         // Use objectUrl (non-zaak filter, simulating a custom ZGW object) with objectType "zaak"
-        val zaakUrl = URI("http://localhost:16274/documenten/zaken/1234")
+        val zaakUrl = URI("$baseUrl/documenten/zaken/1234")
         val results = documentenApiClient.getInformatieObjecten(
             documentenApiPlugin.authenticationPluginConfiguration,
             documentId,
@@ -349,7 +356,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         // Drain any previously queued requests so takeRequest() returns this test's request
         val requestCountBefore = server.requestCount
-        val objectUrl = URI("http://localhost:16274/documenten/zaken/5678")
+        val objectUrl = URI("$baseUrl/documenten/zaken/5678")
         documentenApiClient.getInformatieObjecten(
             documentenApiPlugin.authenticationPluginConfiguration,
             documentId,
@@ -387,7 +394,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         val request = ObjectInformatieObjectRequest(
             informatieobject = URI("${documentenApiPlugin.url}enkelvoudiginformatieobjecten/objectId"),
-            `object` = URI("http://localhost:16274/documenten/zaken/objectId"),
+            `object` = URI("$baseUrl/documenten/zaken/objectId"),
             objectType = "zaak",
         )
 
@@ -411,7 +418,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         val request = ObjectInformatieObjectRequest(
             informatieobject = URI("${documentenApiPlugin.url}enkelvoudiginformatieobjecten/objectId"),
-            `object` = URI("http://localhost:16274/documenten/zaken/objectId"),
+            `object` = URI("$baseUrl/documenten/zaken/objectId"),
             objectType = "zaak",
         )
 
@@ -490,7 +497,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
             {
               "url": "${server.url("/")}objectinformatieobjecten/new-link-id",
               "informatieobject": "${server.url("/")}enkelvoudiginformatieobjecten/objectId",
-              "object": "http://localhost:16274/documenten/zaken/objectId",
+              "object": "$baseUrl/documenten/zaken/objectId",
               "objectType": "zaak"
             }
         """.trimIndent()
@@ -605,6 +612,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
     }
 
     companion object {
+        private const val DOCUMENTEN_API_PLUGIN_ID = "5474fe57-532a-4050-8d89-32e62ca3e895"
         val CASE_DOCUMENT_ID: UUID =
             UUID.fromString("123e4567-e89b-12d3-a456-426655440000")
     }

--- a/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientIT.kt
+++ b/backend/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientIT.kt
@@ -65,7 +65,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
     internal fun setUp() {
         server = MockWebServer()
         setupMockDocumentenApiServer()
-        server.start(port = 56273)
+        server.start(port = 16274)
 
         documentenApiPlugin = pluginService.createInstance("5474fe57-532a-4050-8d89-32e62ca3e895")
 
@@ -152,7 +152,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
             documentenApiPlugin.url,
             Pageable.ofSize(10),
             DocumentSearchRequest(
-                zaakUrl = URI("https://localhost:56273/documenten/1234"),
+                zaakUrl = URI("https://localhost:16274/documenten/1234"),
             )
         )
 
@@ -169,7 +169,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
             documentenApiPlugin.url,
             Pageable.ofSize(10),
             DocumentSearchRequest(
-                zaakUrl = URI("https://localhost:56273/documenten/1234"),
+                zaakUrl = URI("https://localhost:16274/documenten/1234"),
             )
         )
 
@@ -317,7 +317,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
         permissionRepository.saveAllAndFlush(permissions)
 
         // Use objectUrl (non-zaak filter, simulating a custom ZGW object) with objectType "zaak"
-        val zaakUrl = URI("http://localhost:56273/documenten/zaken/1234")
+        val zaakUrl = URI("http://localhost:16274/documenten/zaken/1234")
         val results = documentenApiClient.getInformatieObjecten(
             documentenApiPlugin.authenticationPluginConfiguration,
             documentId,
@@ -349,7 +349,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         // Drain any previously queued requests so takeRequest() returns this test's request
         val requestCountBefore = server.requestCount
-        val objectUrl = URI("http://localhost:56273/documenten/zaken/5678")
+        val objectUrl = URI("http://localhost:16274/documenten/zaken/5678")
         documentenApiClient.getInformatieObjecten(
             documentenApiPlugin.authenticationPluginConfiguration,
             documentId,
@@ -387,7 +387,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         val request = ObjectInformatieObjectRequest(
             informatieobject = URI("${documentenApiPlugin.url}enkelvoudiginformatieobjecten/objectId"),
-            `object` = URI("http://localhost:56273/documenten/zaken/objectId"),
+            `object` = URI("http://localhost:16274/documenten/zaken/objectId"),
             objectType = "zaak",
         )
 
@@ -411,7 +411,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
 
         val request = ObjectInformatieObjectRequest(
             informatieobject = URI("${documentenApiPlugin.url}enkelvoudiginformatieobjecten/objectId"),
-            `object` = URI("http://localhost:56273/documenten/zaken/objectId"),
+            `object` = URI("http://localhost:16274/documenten/zaken/objectId"),
             objectType = "zaak",
         )
 
@@ -490,7 +490,7 @@ internal class DocumentenApiClientIT @Autowired constructor(
             {
               "url": "${server.url("/")}objectinformatieobjecten/new-link-id",
               "informatieobject": "${server.url("/")}enkelvoudiginformatieobjecten/objectId",
-              "object": "http://localhost:56273/documenten/zaken/objectId",
+              "object": "http://localhost:16274/documenten/zaken/objectId",
               "objectType": "zaak"
             }
         """.trimIndent()

--- a/backend/zgw/documenten-api/src/test/resources/config/plugin-configurations/app.pluginconfig.json
+++ b/backend/zgw/documenten-api/src/test/resources/config/plugin-configurations/app.pluginconfig.json
@@ -9,7 +9,7 @@
         "title": "Documenten API",
         "pluginDefinitionKey": "documentenapi",
         "properties": {
-            "url": "http://localhost:56273/documenten/",
+            "url": "http://localhost:16274/documenten/",
             "bronorganisatie": "051845623",
             "authenticationPluginConfiguration": "27a399c7-9d70-4833-a651-57664e2e9e09",
             "apiVersion": "1.5.0-test-1.0.0"

--- a/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceIntTest.kt
+++ b/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceIntTest.kt
@@ -27,6 +27,7 @@ import com.ritense.objectmanagement.domain.ObjectManagement
 import com.ritense.objectmanagement.domain.search.SearchRequestValue
 import com.ritense.objectmanagement.domain.search.SearchWithConfigFilter
 import com.ritense.objectmanagement.domain.search.SearchWithConfigRequest
+import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.service.PluginService
 import com.ritense.search.domain.DataType
 import com.ritense.search.domain.DisplayType
@@ -69,16 +70,38 @@ internal class ObjectManagementServiceIntTest : BaseIntegrationTest() {
     lateinit var objectMapper: ObjectMapper
 
     lateinit var mockApi: MockWebServer
+    private var previousObjectenApiUrl: String = ""
+    private var previousObjecttypenApiUrl: String = ""
 
     @BeforeAll
     fun setUp() {
         mockApi = MockWebServer()
-        mockApi.start(port = 17797)
+        mockApi.start()
+
+        // The "My Object Management" fixture binds these statically-deployed plugin configurations by id, so point
+        // them at the randomly assigned mock server port. @BeforeAll runs outside the per-test transaction, so the
+        // original URLs are captured and restored in tearDown.
+        previousObjectenApiUrl =
+            setPluginConfigurationUrl(OBJECTEN_API_PLUGIN_ID, mockApi.url("/some-object/").toString())
+        previousObjecttypenApiUrl =
+            setPluginConfigurationUrl(OBJECTTYPEN_API_PLUGIN_ID, mockApi.url("/some-objectTypesApi/").toString())
     }
 
     @AfterAll
     fun tearDown() {
+        setPluginConfigurationUrl(OBJECTEN_API_PLUGIN_ID, previousObjectenApiUrl)
+        setPluginConfigurationUrl(OBJECTTYPEN_API_PLUGIN_ID, previousObjecttypenApiUrl)
         mockApi.shutdown()
+    }
+
+    private fun setPluginConfigurationUrl(pluginConfigurationId: String, url: String): String {
+        val id = PluginConfigurationId.existingId(UUID.fromString(pluginConfigurationId))
+        val configuration = pluginService.getPluginConfiguration(id)
+        val properties: ObjectNode = configuration.properties!!.deepCopy()
+        val previousUrl = properties.get("url")?.asText() ?: ""
+        properties.put("url", url)
+        pluginService.updatePluginConfiguration(id, configuration.title, properties)
+        return previousUrl
     }
 
     @Test
@@ -324,5 +347,10 @@ internal class ObjectManagementServiceIntTest : BaseIntegrationTest() {
         return MockResponse()
             .addHeader("Content-Type", "application/json")
             .setBody(body)
+    }
+
+    companion object {
+        private const val OBJECTEN_API_PLUGIN_ID = "8f35c270-21f4-4e99-a8a1-6c4f9d5a6c5c"
+        private const val OBJECTTYPEN_API_PLUGIN_ID = "5f35c270-21f4-4e99-a8a1-6c4f9d5a6c5c"
     }
 }

--- a/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceIntTest.kt
+++ b/backend/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceIntTest.kt
@@ -73,7 +73,7 @@ internal class ObjectManagementServiceIntTest : BaseIntegrationTest() {
     @BeforeAll
     fun setUp() {
         mockApi = MockWebServer()
-        mockApi.start(port = 47797)
+        mockApi.start(port = 17797)
     }
 
     @AfterAll

--- a/backend/zgw/object-management/src/test/resources/config/plugin-configurations/app.pluginconfig.json
+++ b/backend/zgw/object-management/src/test/resources/config/plugin-configurations/app.pluginconfig.json
@@ -12,7 +12,7 @@
         "title": "Objecten API",
         "pluginDefinitionKey": "objectenapi",
         "properties": {
-            "url": "http://localhost:47797/some-object/",
+            "url": "http://localhost:17797/some-object/",
             "authenticationPluginConfiguration": "feb1d774-229e-4c28-b385-b7f59def8bba"
         }
     },
@@ -21,7 +21,7 @@
         "title": "Objecttypen API",
         "pluginDefinitionKey": "objecttypenapi",
         "properties": {
-            "url": "http://localhost:47797/some-objectTypesApi/",
+            "url": "http://localhost:17797/some-objectTypesApi/",
             "authenticationPluginConfiguration": "feb1d774-229e-4c28-b385-b7f59def8bba"
         }
     }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/BaseIntegrationTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/BaseIntegrationTest.kt
@@ -16,6 +16,8 @@
 
 package com.ritense.zakenapi
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.repository.PluginConfigurationRepository
 import com.ritense.plugin.service.PluginService
 import com.ritense.resource.service.ResourceService
@@ -24,6 +26,7 @@ import com.ritense.valtimo.contract.mail.MailSender
 import com.ritense.zakenapi.link.ZaakInstanceLinkService
 import com.ritense.zakenapi.service.ZaakDocumentService
 import okhttp3.mockwebserver.MockResponse
+import java.util.UUID
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -67,5 +70,20 @@ class BaseIntegrationTest {
         return MockResponse()
             .addHeader("Content-Type", "application/json")
             .setBody(body)
+    }
+
+    /**
+     * Points a deployed plugin configuration at the given (typically randomly assigned) mock server URL,
+     * so integration tests do not depend on a fixed port. Returns the previous URL so callers that run
+     * outside a rolled-back transaction (e.g. @BeforeAll) can restore it afterwards.
+     */
+    protected fun setPluginConfigurationUrl(pluginConfigurationId: String, url: String): String {
+        val id = PluginConfigurationId.existingId(UUID.fromString(pluginConfigurationId))
+        val configuration = pluginService.getPluginConfiguration(id)
+        val properties: ObjectNode = configuration.properties!!.deepCopy()
+        val previousUrl = properties.get("url")?.asText() ?: ""
+        properties.put("url", url)
+        pluginService.updatePluginConfiguration(id, configuration.title, properties)
+        return previousUrl
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginIT.kt
@@ -107,7 +107,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 56273)
+        server.start(port = 16273)
         sleep(2000) // Needed to fix connection refused error
 
         // Since we do not have an actual authentication plugin in this context we will mock one
@@ -300,9 +300,9 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
     fun `should create zaak object`() {
         val zakenApiPlugin = pluginService.createInstance<ZakenApiPlugin>(UUID.fromString(ZAKEN_API_PLUGIN_ID))
 
-        val zaakUrl = URI("http://localhost:56273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
+        val zaakUrl = URI("http://localhost:16273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
         val objectUrl = URI("")
-        val zaakobjecttype = "http://localhost:56273/catalogi/my-zaaktype-id"
+        val zaakobjecttype = "http://localhost:16273/catalogi/my-zaaktype-id"
         val objectType = ZaakObjectType.ADRES
         val relatieomschrijving = ""
 
@@ -329,7 +329,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
     fun `should create zaak object via legacy function`() {
         val zakenApiPlugin = pluginService.createInstance<ZakenApiPlugin>(UUID.fromString(ZAKEN_API_PLUGIN_ID))
 
-        val zaakUrl = URI("http://localhost:56273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
+        val zaakUrl = URI("http://localhost:16273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
         val objectUrl = URI("")
         val objectType = ZaakObjectType.OVERIGE
         val objectTypeOverige = "zaakdetails"
@@ -353,7 +353,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         val zakenApiPlugin = pluginService.createInstance<ZakenApiPlugin>(UUID.fromString(ZAKEN_API_PLUGIN_ID))
 
         val edossierNummer = "E.123.4"
-        val zaakUrl = URI("http://localhost:56273/zaken/123")
+        val zaakUrl = URI("http://localhost:16273/zaken/123")
         val relatieomschrijving = "Betrokken erfpachtdossier"
         val identificatie = "doc:verzoek.metaData.eDossiernummer"
         val avgAard = "Erfpacht"
@@ -381,7 +381,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
             zaakUrl,
             UUID.randomUUID(),
             document.id().id,
-            URI("http://localhost:56273/zaak-type/456")
+            URI("http://localhost:16273/zaak-type/456")
         )
 
         val execution: DelegateExecution = mock()
@@ -557,9 +557,9 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
             {
                 "url": "http://example.com",
                 "uuid": "ffa06285-d60f-4748-8fcf-15a93c5fb308",
-                "zaak": "http://localhost:56273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900",
+                "zaak": "http://localhost:16273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900",
                 "object": "",
-                "zaakobjecttype": "http://localhost:56273/catalogi/my-zaaktype-id",
+                "zaakobjecttype": "http://localhost:16273/catalogi/my-zaaktype-id",
                 "objectType": "adres",
                 "objectTypeOverige": "a",
                 "objectTypeOverigeDefinitie": {
@@ -678,9 +678,9 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         private const val ZAAK_ID = "57f66ff6-db7f-43bc-84ef-6847640d3609"
 
         private const val CATALOGI_API_PATH = "/catalogi/api/v1"
-        private const val CATALOGI_API_URL = "http://localhost:56273$CATALOGI_API_PATH"
+        private const val CATALOGI_API_URL = "http://localhost:16273$CATALOGI_API_PATH"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:56273$ZAKEN_API_PATH"
+        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
 
         private val ZAAKTYPE_URL = URI("${CATALOGI_API_URL}/zaaktypen/$ZAAKTYPE_ID")
         private val ZAAK_URL = URI("${ZAKEN_API_URL}/zaken/$ZAAK_ID")

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginIT.kt
@@ -71,7 +71,6 @@ import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.ExchangeFunction
 import reactor.core.publisher.Mono
-import java.lang.Thread.sleep
 import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -103,12 +102,18 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
 
     private var executedRequests: MutableList<RecordedRequest> = mutableListOf()
 
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val baseUrl get() = server.url("").toString().removeSuffix("/")
+    private val catalogiApiUrl get() = server.url(CATALOGI_API_PATH).toString()
+    private val zakenApiUrl get() = server.url(ZAKEN_API_PATH).toString()
+    private val zaaktypeUrl get() = URI("$catalogiApiUrl/zaaktypen/$ZAAKTYPE_ID")
+    private val zaakInstanceUrl get() = URI("$zakenApiUrl/zaken/$ZAAK_ID")
+
     @BeforeEach
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 16273)
-        sleep(2000) // Needed to fix connection refused error
+        server.start()
 
         // Since we do not have an actual authentication plugin in this context we will mock one
         val mockedId = PluginConfigurationId.existingId(UUID.fromString(AUTHENTICATION_PLUGIN_ID))
@@ -118,6 +123,10 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
             .whenever(pluginService).createInstance(mockedId)
         doCallRealMethod()
             .whenever(pluginService).createPluginConfiguration(any(), any(), any())
+
+        // Point the statically-deployed plugin configurations at the randomly assigned mock server port.
+        setPluginConfigurationUrl(ZAKEN_API_PLUGIN_ID, server.url("$ZAKEN_API_PATH/").toString())
+        setPluginConfigurationUrl(CATALOGI_API_PLUGIN_ID, server.url("$CATALOGI_API_PATH/").toString())
 
         // Setting up plugin
         val pluginPropertiesJson = """
@@ -176,7 +185,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         zakenApiPlugin.createZaak(
             caseDocumentId = document.id().id,
             rsin = Rsin("155539620"),
-            zaaktypeUrl = ZAAKTYPE_URL
+            zaaktypeUrl = zaaktypeUrl
         )
 
         val requestBody = createZaakRequestBody()
@@ -193,7 +202,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         zakenApiPlugin.createZaak(
             caseDocumentId = document.id().id,
             rsin = Rsin("155539620"),
-            zaaktypeUrl = ZAAKTYPE_URL,
+            zaaktypeUrl = zaaktypeUrl,
             description = description,
             plannedEndDate = plannedEndDate,
             finalDeliveryDate = null
@@ -216,7 +225,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         zakenApiPlugin.createZaak(
             caseDocumentId = document.id().id,
             rsin = Rsin("155539620"),
-            zaaktypeUrl = ZAAKTYPE_URL,
+            zaaktypeUrl = zaaktypeUrl,
         )
 
         val description = "omschrijving na patch"
@@ -254,7 +263,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
 
         assertEquals(4, parsedOutput.size)
         assertEquals(INFORMATIE_OBJECT_URL, parsedOutput["informatieobject"])
-        assertEquals(ZAAK_URL.toString(), parsedOutput["zaak"])
+        assertEquals(zaakInstanceUrl.toString(), parsedOutput["zaak"])
         assertEquals("titelVariableName", parsedOutput["titel"])
         assertEquals("beschrijvingVariableName", parsedOutput["beschrijving"])
 
@@ -285,7 +294,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
 
         assertEquals(4, parsedOutput.size)
         assertEquals(INFORMATIE_OBJECT_URL, parsedOutput["informatieobject"])
-        assertEquals(ZAAK_URL.toString(), parsedOutput["zaak"])
+        assertEquals(zaakInstanceUrl.toString(), parsedOutput["zaak"])
         assertEquals("titelVariableName", parsedOutput["titel"])
         assertEquals("beschrijvingVariableName", parsedOutput["beschrijving"])
 
@@ -300,9 +309,9 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
     fun `should create zaak object`() {
         val zakenApiPlugin = pluginService.createInstance<ZakenApiPlugin>(UUID.fromString(ZAKEN_API_PLUGIN_ID))
 
-        val zaakUrl = URI("http://localhost:16273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
+        val zaakUrl = URI("$baseUrl/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
         val objectUrl = URI("")
-        val zaakobjecttype = "http://localhost:16273/catalogi/my-zaaktype-id"
+        val zaakobjecttype = "$baseUrl/catalogi/my-zaaktype-id"
         val objectType = ZaakObjectType.ADRES
         val relatieomschrijving = ""
 
@@ -329,7 +338,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
     fun `should create zaak object via legacy function`() {
         val zakenApiPlugin = pluginService.createInstance<ZakenApiPlugin>(UUID.fromString(ZAKEN_API_PLUGIN_ID))
 
-        val zaakUrl = URI("http://localhost:16273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
+        val zaakUrl = URI("$baseUrl/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900")
         val objectUrl = URI("")
         val objectType = ZaakObjectType.OVERIGE
         val objectTypeOverige = "zaakdetails"
@@ -353,7 +362,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         val zakenApiPlugin = pluginService.createInstance<ZakenApiPlugin>(UUID.fromString(ZAKEN_API_PLUGIN_ID))
 
         val edossierNummer = "E.123.4"
-        val zaakUrl = URI("http://localhost:16273/zaken/123")
+        val zaakUrl = URI("$baseUrl/zaken/123")
         val relatieomschrijving = "Betrokken erfpachtdossier"
         val identificatie = "doc:verzoek.metaData.eDossiernummer"
         val avgAard = "Erfpacht"
@@ -381,7 +390,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
             zaakUrl,
             UUID.randomUUID(),
             document.id().id,
-            URI("http://localhost:16273/zaak-type/456")
+            URI("$baseUrl/zaak-type/456")
         )
 
         val execution: DelegateExecution = mock()
@@ -436,10 +445,10 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
             val result = invocation.callRealMethod() as com.ritense.document.service.result.CreateDocumentResult
             result.resultingDocument().ifPresent { document ->
                 zaakInstanceLinkService.createZaakInstanceLink(
-                    ZAAK_URL,
+                    zaakInstanceUrl,
                     UUID.fromString(ZAAK_ID),
                     document.id().id,
-                    ZAAKTYPE_URL
+                    zaaktypeUrl
                 )
             }
             result
@@ -496,7 +505,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
               "url": "http://example.com",
               "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
               "informatieobject": "$INFORMATIE_OBJECT_URL",
-              "zaak": "$ZAAK_URL",
+              "zaak": "$zaakInstanceUrl",
               "aardRelatieWeergave": "Hoort bij, omgekeerd: kent",
               "titel": "string",
               "beschrijving": "string",
@@ -509,13 +518,13 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
     private fun zaakResponse(): MockResponse {
         val body = """
             {
-                "url": "$ZAAK_URL",
+                "url": "$zaakInstanceUrl",
                 "uuid": "$ZAAK_ID",
                 "identificatie": "ZAAK-2023-0000000001",
                 "bronorganisatie": "419071349",
                 "omschrijving": "",
                 "toelichting": "",
-                "zaaktype": "$ZAAKTYPE_URL",
+                "zaaktype": "$zaaktypeUrl",
                 "registratiedatum": "2024-02-13",
                 "verantwoordelijkeOrganisatie": "420936440",
                 "startdatum": "2023-01-23",
@@ -557,9 +566,9 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
             {
                 "url": "http://example.com",
                 "uuid": "ffa06285-d60f-4748-8fcf-15a93c5fb308",
-                "zaak": "http://localhost:16273/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900",
+                "zaak": "$baseUrl/zaken/41e90cab-7f81-4a45-883d-430b7a6d9900",
                 "object": "",
-                "zaakobjecttype": "http://localhost:16273/catalogi/my-zaaktype-id",
+                "zaakobjecttype": "$baseUrl/catalogi/my-zaaktype-id",
                 "objectType": "adres",
                 "objectTypeOverige": "a",
                 "objectTypeOverigeDefinitie": {
@@ -588,7 +597,7 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
     private fun zaaktypeResponse(): MockResponse {
         val body = """
             {
-                "url": "$ZAAKTYPE_URL",
+                "url": "$zaaktypeUrl",
                 "identificatie": "example-case",
                 "omschrijving": "Example case",
                 "omschrijvingGeneriek": "Example case",
@@ -619,19 +628,19 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
                     "naam": "Example case",
                     "link": "http://ritense.com"
                 },
-                "catalogus": "${CATALOGI_API_URL}catalogussen/8225508a-6840-413e-acc9-6422af120db1",
+                "catalogus": "${catalogiApiUrl}catalogussen/8225508a-6840-413e-acc9-6422af120db1",
                 "statustypen": [
-                    "${CATALOGI_API_URL}statustypen/12345678-3f25-4716-5432-49ea8e954fd0"
+                    "${catalogiApiUrl}statustypen/12345678-3f25-4716-5432-49ea8e954fd0"
                 ],
                 "resultaattypen": [],
                 "eigenschappen": [
-                    "${CATALOGI_API_URL}eigenschappen/12345678-b04b-424b-ab02-c4102b562633"
+                    "${catalogiApiUrl}eigenschappen/12345678-b04b-424b-ab02-c4102b562633"
                 ],
                 "informatieobjecttypen": [
-                    "${CATALOGI_API_URL}informatieobjecttypen/12345678-be3b-4bad-9e3c-49a6219c92ad"
+                    "${catalogiApiUrl}informatieobjecttypen/12345678-be3b-4bad-9e3c-49a6219c92ad"
                 ],
                 "roltypen": [
-                    "${CATALOGI_API_URL}roltypen/12345678-c38d-47b8-bed5-994db88ead61"
+                    "${catalogiApiUrl}roltypen/12345678-c38d-47b8-bed5-994db88ead61"
                 ],
                 "besluittypen": [],
                 "deelzaaktypen": [],
@@ -672,17 +681,13 @@ class ZakenApiPluginIT : BaseIntegrationTest() {
         private const val DOCUMENT_DEFINITION_KEY = "profile"
         private const val INFORMATIE_OBJECT_URL = "http://informatie.object.url"
         private const val ZAKEN_API_PLUGIN_ID = "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee"
+        private const val CATALOGI_API_PLUGIN_ID = "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec"
         private const val AUTHENTICATION_PLUGIN_ID = "27a399c7-9d70-4833-a651-57664e2e9e09"
 
         private const val ZAAKTYPE_ID = "21c0946a-9058-11ee-b9d1-0242ac120002"
         private const val ZAAK_ID = "57f66ff6-db7f-43bc-84ef-6847640d3609"
 
         private const val CATALOGI_API_PATH = "/catalogi/api/v1"
-        private const val CATALOGI_API_URL = "http://localhost:16273$CATALOGI_API_PATH"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
-
-        private val ZAAKTYPE_URL = URI("${CATALOGI_API_URL}/zaaktypen/$ZAAKTYPE_ID")
-        private val ZAAK_URL = URI("${ZAKEN_API_URL}/zaken/$ZAAK_ID")
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
@@ -56,7 +56,7 @@ internal class ZakenApiClientIT @Autowired constructor(
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 56273)
+        server.start(port = 16273)
 
         zakenApiPlugin = pluginService.createInstance("3079d6fe-42e3-4f8f-a9db-52ce2507b7ee")
 
@@ -90,8 +90,8 @@ internal class ZakenApiClientIT @Autowired constructor(
             CASE_DOCUMENT_ID,
             zakenApiPlugin.url,
             LinkDocumentRequest(
-                informatieobject = "https://localhost:56273/documenten/informatieobject/1234",
-                zaak = "https://localhost:56273/zaken/1234",
+                informatieobject = "https://localhost:16273/documenten/informatieobject/1234",
+                zaak = "https://localhost:16273/zaken/1234",
                 titel = "titel",
                 beschrijving = "beschrijving",
                 vernietigingsdatum = null,
@@ -109,8 +109,8 @@ internal class ZakenApiClientIT @Autowired constructor(
                 CASE_DOCUMENT_ID,
                 zakenApiPlugin.url,
                 LinkDocumentRequest(
-                    informatieobject = "https://localhost:56273/documenten/informatieobject/1234",
-                    zaak = "https://localhost:56273/zaken/1234",
+                    informatieobject = "https://localhost:16273/documenten/informatieobject/1234",
+                    zaak = "https://localhost:16273/zaken/1234",
                     titel = "titel",
                     beschrijving = "beschrijving",
                     vernietigingsdatum = null,
@@ -265,7 +265,7 @@ internal class ZakenApiClientIT @Autowired constructor(
     companion object {
         private const val ZAAK_ID = "57f66ff6-db7f-43bc-84ef-6847640d3609"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:56273$ZAKEN_API_PATH"
+        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
         val CASE_DOCUMENT_ID: UUID = UUID.fromString(ZAAK_ID)
 
         private val ZAAK_URL = URI("${ZAKEN_API_URL}/zaken/$ZAAK_ID")

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/client/ZakenApiClientIT.kt
@@ -52,13 +52,20 @@ internal class ZakenApiClientIT @Autowired constructor(
     lateinit var zakenApiPlugin: ZakenApiPlugin
     lateinit var roleTest: Role
 
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val baseUrl get() = server.url("").toString().removeSuffix("/")
+    private val zakenApiUrl get() = server.url(ZAKEN_API_PATH).toString()
+    private val zaakUrl get() = URI("$zakenApiUrl/zaken/$ZAAK_ID")
+    private val zaakInformatieObjectUrl get() = URI("$zakenApiUrl/zaakinformatieobjecten/$ZAAK_ID")
+
     @BeforeEach
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 16273)
+        server.start()
 
-        zakenApiPlugin = pluginService.createInstance("3079d6fe-42e3-4f8f-a9db-52ce2507b7ee")
+        setPluginConfigurationUrl(ZAKEN_API_PLUGIN_ID, server.url("$ZAKEN_API_PATH/").toString())
+        zakenApiPlugin = pluginService.createInstance(ZAKEN_API_PLUGIN_ID)
 
         roleTest = roleRepository.findByKey("ROLE_TEST")!!
         permissionRepository.deleteByRoleKeyIn(listOf("ROLE_TEST"))
@@ -90,8 +97,8 @@ internal class ZakenApiClientIT @Autowired constructor(
             CASE_DOCUMENT_ID,
             zakenApiPlugin.url,
             LinkDocumentRequest(
-                informatieobject = "https://localhost:16273/documenten/informatieobject/1234",
-                zaak = "https://localhost:16273/zaken/1234",
+                informatieobject = "$baseUrl/documenten/informatieobject/1234",
+                zaak = "$baseUrl/zaken/1234",
                 titel = "titel",
                 beschrijving = "beschrijving",
                 vernietigingsdatum = null,
@@ -109,8 +116,8 @@ internal class ZakenApiClientIT @Autowired constructor(
                 CASE_DOCUMENT_ID,
                 zakenApiPlugin.url,
                 LinkDocumentRequest(
-                    informatieobject = "https://localhost:16273/documenten/informatieobject/1234",
-                    zaak = "https://localhost:16273/zaken/1234",
+                    informatieobject = "$baseUrl/documenten/informatieobject/1234",
+                    zaak = "$baseUrl/zaken/1234",
                     titel = "titel",
                     beschrijving = "beschrijving",
                     vernietigingsdatum = null,
@@ -139,7 +146,7 @@ internal class ZakenApiClientIT @Autowired constructor(
         val result = zakenApiClient.getZaakInformatieObject(
             authentication = zakenApiPlugin.authenticationPluginConfiguration,
             baseUrl = zakenApiPlugin.url,
-            zaakInformatieobjectUrl = ZAAK_INFORMATIEOBJECT_URL,
+            zaakInformatieobjectUrl = zaakInformatieObjectUrl,
             caseDocumentId = CASE_DOCUMENT_ID
         )
 
@@ -153,7 +160,7 @@ internal class ZakenApiClientIT @Autowired constructor(
             zakenApiClient.getZaakInformatieObject(
                 authentication = zakenApiPlugin.authenticationPluginConfiguration,
                 baseUrl = zakenApiPlugin.url,
-                zaakInformatieobjectUrl = ZAAK_INFORMATIEOBJECT_URL,
+                zaakInformatieobjectUrl = zaakInformatieObjectUrl,
                 caseDocumentId = CASE_DOCUMENT_ID
             )
         }
@@ -179,7 +186,7 @@ internal class ZakenApiClientIT @Autowired constructor(
             authentication = zakenApiPlugin.authenticationPluginConfiguration,
             CASE_DOCUMENT_ID,
             baseUrl = zakenApiPlugin.url,
-            zaakUrl = ZAAK_URL
+            zaakUrl = zaakUrl
         )
 
         assertEquals(1, results.count())
@@ -192,7 +199,7 @@ internal class ZakenApiClientIT @Autowired constructor(
             authentication = zakenApiPlugin.authenticationPluginConfiguration,
             CASE_DOCUMENT_ID,
             baseUrl = zakenApiPlugin.url,
-            zaakUrl = ZAAK_URL
+            zaakUrl = zaakUrl
         )
 
         assertEquals(0, results.count())
@@ -265,11 +272,8 @@ internal class ZakenApiClientIT @Autowired constructor(
     companion object {
         private const val ZAAK_ID = "57f66ff6-db7f-43bc-84ef-6847640d3609"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
+        private const val ZAKEN_API_PLUGIN_ID = "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee"
         val CASE_DOCUMENT_ID: UUID = UUID.fromString(ZAAK_ID)
-
-        private val ZAAK_URL = URI("${ZAKEN_API_URL}/zaken/$ZAAK_ID")
-        val ZAAK_INFORMATIEOBJECT_URL = URI("${ZAKEN_API_URL}/zaakinformatieobjecten/$ZAAK_ID")
     }
 
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/formflow/ZakenFormFlowIntTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/formflow/ZakenFormFlowIntTest.kt
@@ -41,11 +41,16 @@ class ZakenFormFlowIntTest : BaseIntegrationTest() {
 
     lateinit var server: MockWebServer
 
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val baseUrl get() = server.url("").toString().removeSuffix("/")
+
     @BeforeEach
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 16273)
+        server.start()
+
+        setPluginConfigurationUrl(ZAKEN_API_PLUGIN_ID, server.url("$ZAKEN_API_PATH/").toString())
 
         ExpressionProcessorFactoryHolder
             .setInstance(SpelExpressionProcessorFactory(), applicationContext = applicationContext)
@@ -123,13 +128,13 @@ class ZakenFormFlowIntTest : BaseIntegrationTest() {
 
     private fun zaak(identificatie: String) = """
         {
-            "url": "http://localhost:16273$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609",
+            "url": "$baseUrl$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609",
             "uuid": "57f66ff6-db7f-43bc-84ef-6847640d3609",
             "identificatie": "$identificatie",
             "bronorganisatie": "419071349",
             "omschrijving": "",
             "toelichting": "",
-            "zaaktype": "http://localhost:16273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002",
+            "zaaktype": "$baseUrl/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002",
             "registratiedatum": "2024-02-13",
             "verantwoordelijkeOrganisatie": "420936440",
             "startdatum": "2023-01-23",
@@ -140,5 +145,6 @@ class ZakenFormFlowIntTest : BaseIntegrationTest() {
     companion object {
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
         private const val ZAAK_IDENTIFICATIE = "ZAAK-2023-0000000001"
+        private const val ZAKEN_API_PLUGIN_ID = "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee"
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/formflow/ZakenFormFlowIntTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/formflow/ZakenFormFlowIntTest.kt
@@ -45,7 +45,7 @@ class ZakenFormFlowIntTest : BaseIntegrationTest() {
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 56273)
+        server.start(port = 16273)
 
         ExpressionProcessorFactoryHolder
             .setInstance(SpelExpressionProcessorFactory(), applicationContext = applicationContext)
@@ -123,13 +123,13 @@ class ZakenFormFlowIntTest : BaseIntegrationTest() {
 
     private fun zaak(identificatie: String) = """
         {
-            "url": "http://localhost:56273$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609",
+            "url": "http://localhost:16273$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609",
             "uuid": "57f66ff6-db7f-43bc-84ef-6847640d3609",
             "identificatie": "$identificatie",
             "bronorganisatie": "419071349",
             "omschrijving": "",
             "toelichting": "",
-            "zaaktype": "http://localhost:56273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002",
+            "zaaktype": "http://localhost:16273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002",
             "registratiedatum": "2024-02-13",
             "verantwoordelijkeOrganisatie": "420936440",
             "startdatum": "2023-01-23",

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/mock/ZaakMockUrlProvider.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/mock/ZaakMockUrlProvider.kt
@@ -36,10 +36,10 @@ class ZaakMockUrlProvider(
     }
 
     override fun getZaaktypeUrl(caseDefinitionId: CaseDefinitionId): URI {
-        return URI("http://localhost:56273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002")
+        return URI("http://localhost:16273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002")
     }
 
     override fun getZaaktypeUrl(documentId: UUID): URI {
-        return URI("http://localhost:56273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002")
+        return URI("http://localhost:16273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002")
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/mock/ZaakMockUrlProvider.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/mock/ZaakMockUrlProvider.kt
@@ -17,6 +17,7 @@
 package com.ritense.zakenapi.mock
 
 import com.ritense.catalogiapi.service.ZaaktypeUrlProvider
+import com.ritense.plugin.service.PluginService
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
 import com.ritense.zakenapi.ZaakUrlProvider
 import com.ritense.zakenapi.link.ZaakInstanceLinkNotFoundException
@@ -27,7 +28,8 @@ import java.util.UUID
 
 @Service
 class ZaakMockUrlProvider(
-    private val zaakInstanceLinkService: ZaakInstanceLinkService
+    private val zaakInstanceLinkService: ZaakInstanceLinkService,
+    private val pluginService: PluginService,
 ) : ZaakUrlProvider, ZaaktypeUrlProvider {
 
     @Throws(ZaakInstanceLinkNotFoundException::class)
@@ -35,11 +37,16 @@ class ZaakMockUrlProvider(
         return zaakInstanceLinkService.getByDocumentId(documentId).zaakInstanceUrl
     }
 
-    override fun getZaaktypeUrl(caseDefinitionId: CaseDefinitionId): URI {
-        return URI("http://localhost:16273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002")
-    }
+    override fun getZaaktypeUrl(caseDefinitionId: CaseDefinitionId): URI = zaaktypeUrl()
 
-    override fun getZaaktypeUrl(documentId: UUID): URI {
-        return URI("http://localhost:16273/catalogi/api/v1/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002")
+    override fun getZaaktypeUrl(documentId: UUID): URI = zaaktypeUrl()
+
+    // Derived from the deployed Catalogi API plugin configuration so the URL follows the mock server's
+    // actual (randomly assigned) port instead of a hardcoded one.
+    private fun zaaktypeUrl(): URI {
+        val baseUrl = pluginService.findPluginConfiguration("catalogiapi") { true }
+            ?.properties?.get("url")?.asText()?.trimEnd('/')
+            ?: "http://localhost:16273/catalogi/api/v1"
+        return URI("$baseUrl/zaaktypen/21c0946a-9058-11ee-b9d1-0242ac120002")
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakResultaatValueResolverValueIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakResultaatValueResolverValueIT.kt
@@ -51,7 +51,7 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 56273)
+        server.start(port = 16273)
     }
 
     @AfterEach
@@ -191,8 +191,8 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
 
     companion object {
         private const val CATALOGI_API_PATH = "/catalogi/api/v1"
-        private const val CATALOGI_API_URL = "http://localhost:56273$CATALOGI_API_PATH"
+        private const val CATALOGI_API_URL = "http://localhost:16273$CATALOGI_API_PATH"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:56273$ZAKEN_API_PATH"
+        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakResultaatValueResolverValueIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakResultaatValueResolverValueIT.kt
@@ -47,11 +47,18 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
 
     lateinit var server: MockWebServer
 
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val zakenApiUrl get() = server.url(ZAKEN_API_PATH).toString()
+    private val catalogiApiUrl get() = server.url(CATALOGI_API_PATH).toString()
+
     @BeforeEach
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 16273)
+        server.start()
+
+        setPluginConfigurationUrl(ZAKEN_API_PLUGIN_ID, server.url("$ZAKEN_API_PATH/").toString())
+        setPluginConfigurationUrl(CATALOGI_API_PLUGIN_ID, server.url("$CATALOGI_API_PATH/").toString())
     }
 
     @AfterEach
@@ -74,10 +81,10 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
 
             // Create zaak instance link so the resolver can find the zaak URL
             zaakInstanceLinkService.createZaakInstanceLink(
-                URI("$ZAKEN_API_URL/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
+                URI("$zakenApiUrl/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 java.util.UUID.fromString("57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 documentId,
-                URI("$CATALOGI_API_URL/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002")
+                URI("$catalogiApiUrl/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002")
             )
 
             val formDefinition = formDefinitionRepository.findByNameAndCaseDefinitionId("form-with-zaakresultaat-fields", caseDefinitionId).get()
@@ -114,13 +121,13 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
     private fun getZaakRequest(): MockResponse {
         val body = """
             {
-                "url": "${ZAKEN_API_URL}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
+                "url": "${zakenApiUrl}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "uuid": "a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "identificatie": "ZK2023-00001",
                 "bronorganisatie": "104978119",
                 "omschrijving": "Test",
                 "toelichting": "",
-                "zaaktype": "${CATALOGI_API_URL}/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002",
+                "zaaktype": "${catalogiApiUrl}/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002",
                 "registratiedatum": "2023-03-22",
                 "verantwoordelijkeOrganisatie": "104978119",
                 "startdatum": "2023-03-22",
@@ -146,14 +153,14 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
                 "relevanteAndereZaken": [],
                 "eigenschappen": [],
                 "rollen": [],
-                "status": "${ZAKEN_API_URL}/zaken/statussen/f0ca7629-115d-4231-b684-7eaa130ac1af",
+                "status": "${zakenApiUrl}/zaken/statussen/f0ca7629-115d-4231-b684-7eaa130ac1af",
                 "zaakinformatieobjecten": [],
                 "zaakobjecten": [],
                 "kenmerken": [],
                 "archiefnominatie": "blijvend_bewaren",
                 "archiefstatus": "nog_te_archiveren",
                 "archiefactiedatum": null,
-                "resultaat": "${ZAKEN_API_URL}/zaken/resultaten/2a43ac32-0c7e-45ac-bca5-7621d952ccf9",
+                "resultaat": "${zakenApiUrl}/zaken/resultaten/2a43ac32-0c7e-45ac-bca5-7621d952ccf9",
                 "opdrachtgevendeOrganisatie": "",
                 "processobjectaard": "",
                 "resultaattoelichting": "",
@@ -166,10 +173,10 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
     private fun getZaakResultaatRequest(): MockResponse {
         val body = """
         {
-            "url": "${ZAKEN_API_URL}/zaken/resultaten/2a43ac32-0c7e-45ac-bca5-7621d952ccf9",
+            "url": "${zakenApiUrl}/zaken/resultaten/2a43ac32-0c7e-45ac-bca5-7621d952ccf9",
             "uuid": "2a43ac32-0c7e-45ac-bca5-7621d952ccf9",
-            "zaak": "${ZAKEN_API_URL}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
-            "resultaattype": "${CATALOGI_API_URL}/resultaattypen/82576fa3-0832-4301-8744-f72fc49f6381",
+            "zaak": "${zakenApiUrl}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
+            "resultaattype": "${catalogiApiUrl}/resultaattypen/82576fa3-0832-4301-8744-f72fc49f6381",
             "toelichting": "Toelichting"
         }
         """.trimIndent()
@@ -179,10 +186,10 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
     private fun getResultaatTypeRequest(): MockResponse {
         val body = """
         {
-            "url": "${CATALOGI_API_URL}/resultaattypen/82576fa3-0832-4301-8744-f72fc49f6381",
+            "url": "${catalogiApiUrl}/resultaattypen/82576fa3-0832-4301-8744-f72fc49f6381",
             "omschrijving": "Toegekend",
-            "resultaattypeomschrijving": "${CATALOGI_API_URL}/resultaattypen/82576fa3-0832-4301-8744-f72fc49f6381",
-            "zaaktype": "${CATALOGI_API_URL}/zaaktypen/01afac88-36e0-466b-b233-b8e2301c57e2",
+            "resultaattypeomschrijving": "${catalogiApiUrl}/resultaattypen/82576fa3-0832-4301-8744-f72fc49f6381",
+            "zaaktype": "${catalogiApiUrl}/zaaktypen/01afac88-36e0-466b-b233-b8e2301c57e2",
             "selectielijstklasse": ""
         }
         """.trimIndent()
@@ -191,8 +198,8 @@ class ZaakResultaatValueResolverValueIT @Autowired constructor(
 
     companion object {
         private const val CATALOGI_API_PATH = "/catalogi/api/v1"
-        private const val CATALOGI_API_URL = "http://localhost:16273$CATALOGI_API_PATH"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
+        private const val ZAKEN_API_PLUGIN_ID = "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee"
+        private const val CATALOGI_API_PLUGIN_ID = "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec"
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakStatusValueResolverValueIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakStatusValueResolverValueIT.kt
@@ -51,7 +51,7 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 56273)
+        server.start(port = 16273)
     }
 
     @AfterEach
@@ -195,8 +195,8 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
 
     companion object {
         private const val CATALOGI_API_PATH = "/catalogi/api/v1"
-        private const val CATALOGI_API_URL = "http://localhost:56273$CATALOGI_API_PATH"
+        private const val CATALOGI_API_URL = "http://localhost:16273$CATALOGI_API_PATH"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:56273$ZAKEN_API_PATH"
+        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakStatusValueResolverValueIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakStatusValueResolverValueIT.kt
@@ -47,11 +47,18 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
 
     lateinit var server: MockWebServer
 
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val zakenApiUrl get() = server.url(ZAKEN_API_PATH).toString()
+    private val catalogiApiUrl get() = server.url(CATALOGI_API_PATH).toString()
+
     @BeforeEach
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 16273)
+        server.start()
+
+        setPluginConfigurationUrl(ZAKEN_API_PLUGIN_ID, server.url("$ZAKEN_API_PATH/").toString())
+        setPluginConfigurationUrl(CATALOGI_API_PLUGIN_ID, server.url("$CATALOGI_API_PATH/").toString())
     }
 
     @AfterEach
@@ -74,10 +81,10 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
 
             // Create zaak instance link so the resolver can find the zaak URL
             zaakInstanceLinkService.createZaakInstanceLink(
-                URI("$ZAKEN_API_URL/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
+                URI("$zakenApiUrl/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 java.util.UUID.fromString("57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 documentId,
-                URI("$CATALOGI_API_URL/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002")
+                URI("$catalogiApiUrl/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002")
             )
 
             val formDefinition = formDefinitionRepository.findByNameAndCaseDefinitionId("form-with-zaak-fields", caseDefinitionId).get()
@@ -112,13 +119,13 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
     private fun getZaakRequest(): MockResponse {
         val body = """
             {
-                "url": "${ZAKEN_API_URL}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
+                "url": "${zakenApiUrl}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "uuid": "a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "identificatie": "ZK2023-00001",
                 "bronorganisatie": "104978119",
                 "omschrijving": "Test",
                 "toelichting": "",
-                "zaaktype": "${CATALOGI_API_URL}/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002",
+                "zaaktype": "${catalogiApiUrl}/zaaktypen/e02753ba-9055-11ee-b9d1-0242ac120002",
                 "registratiedatum": "2023-03-22",
                 "verantwoordelijkeOrganisatie": "104978119",
                 "startdatum": "2023-03-22",
@@ -144,7 +151,7 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
                 "relevanteAndereZaken": [],
                 "eigenschappen": [],
                 "rollen": [],
-                "status": "${ZAKEN_API_URL}/zaken/statussen/f0ca7629-115d-4231-b684-7eaa130ac1af",
+                "status": "${zakenApiUrl}/zaken/statussen/f0ca7629-115d-4231-b684-7eaa130ac1af",
                 "zaakinformatieobjecten": [],
                 "zaakobjecten": [],
                 "kenmerken": [],
@@ -164,10 +171,10 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
     private fun getZaakStatusRequest(): MockResponse {
         val body = """
         {
-            "url": "${ZAKEN_API_URL}/zaken/f7ef2339-fe9a-435e-a2d3-ae75ca4fb51a",
+            "url": "${zakenApiUrl}/zaken/f7ef2339-fe9a-435e-a2d3-ae75ca4fb51a",
             "uuid": "f7ef2339-fe9a-435e-a2d3-ae75ca4fb51a",
-            "zaak": "${ZAKEN_API_URL}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
-            "statustype": "${CATALOGI_API_URL}/statustypen/40cb531f-fbde-46af-9693-90e78535ff9f",
+            "zaak": "${zakenApiUrl}/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
+            "statustype": "${catalogiApiUrl}/statustypen/40cb531f-fbde-46af-9693-90e78535ff9f",
             "datumStatusGezet": "2023-12-01T14:52:07Z",
             "statustoelichting": "",
             "indicatieLaatstGezetteStatus": true
@@ -179,15 +186,15 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
     private fun getStatusTypeRequest(): MockResponse {
         val body = """
         {
-            "url": "${CATALOGI_API_URL}/statustypen/33e13d2c-6441-4d70-a30b-bdda74105c1f",
+            "url": "${catalogiApiUrl}/statustypen/33e13d2c-6441-4d70-a30b-bdda74105c1f",
             "omschrijving": "Zaak gestart",
             "omschrijvingGeneriek": "Zaak gestart",
             "statustekst": "",
-            "zaaktype": "${CATALOGI_API_URL}/zaaktypen/01afac88-36e0-466b-b233-b8e2301c57e2",
+            "zaaktype": "${catalogiApiUrl}/zaaktypen/01afac88-36e0-466b-b233-b8e2301c57e2",
             "zaaktypeIdentificatie": "TEST_AANV",
             "volgnummer": 1,
             "checklistitemStatustype": [],
-            "catalogus": "${CATALOGI_API_URL}/759c3861-9c86-44f6-9c17-178ce9c331a7"
+            "catalogus": "${catalogiApiUrl}/759c3861-9c86-44f6-9c17-178ce9c331a7"
         }
         """.trimIndent()
         return mockResponse(body)
@@ -195,8 +202,8 @@ class ZaakStatusValueResolverValueIT @Autowired constructor(
 
     companion object {
         private const val CATALOGI_API_PATH = "/catalogi/api/v1"
-        private const val CATALOGI_API_URL = "http://localhost:16273$CATALOGI_API_PATH"
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
-        private const val ZAKEN_API_URL = "http://localhost:16273$ZAKEN_API_PATH"
+        private const val ZAKEN_API_PLUGIN_ID = "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee"
+        private const val CATALOGI_API_PLUGIN_ID = "22c78b91-0b0f-4008-8d8f-c4a84b8e71ec"
     }
 }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakValueResolverValueIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakValueResolverValueIT.kt
@@ -59,7 +59,7 @@ class ZaakValueResolverValueIT @Autowired constructor(
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 56273)
+        server.start(port = 16273)
     }
 
     @AfterEach
@@ -82,10 +82,10 @@ class ZaakValueResolverValueIT @Autowired constructor(
 
             // Create zaak instance link so the resolver can find the zaak URL
             zaakInstanceLinkService.createZaakInstanceLink(
-                URI("http://localhost:56273$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
+                URI("http://localhost:16273$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 java.util.UUID.fromString("57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 documentId,
-                URI("http://localhost:56273/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002")
+                URI("http://localhost:16273/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002")
             )
 
             val formDefinition = formDefinitionRepository.findByNameAndCaseDefinitionId("form-with-zaak-fields", caseDefinitionId).get()
@@ -118,13 +118,13 @@ class ZaakValueResolverValueIT @Autowired constructor(
     private fun getZaakRequest(): MockResponse {
         val body = """
             {
-                "url": "http://localhost:56273/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
+                "url": "http://localhost:16273/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "uuid": "a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "identificatie": "ZK2023-00001",
                 "bronorganisatie": "104978119",
                 "omschrijving": "Test",
                 "toelichting": "",
-                "zaaktype": "http://localhost:56273/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002",
+                "zaaktype": "http://localhost:16273/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002",
                 "registratiedatum": "2023-03-22",
                 "verantwoordelijkeOrganisatie": "104978119",
                 "startdatum": "2023-03-22",

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakValueResolverValueIT.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/resolver/ZaakValueResolverValueIT.kt
@@ -55,11 +55,16 @@ class ZaakValueResolverValueIT @Autowired constructor(
 
     lateinit var server: MockWebServer
 
+    // Derived from the mock server's actual (randomly assigned) address so the test does not depend on a fixed port.
+    private val baseUrl get() = server.url("").toString().removeSuffix("/")
+
     @BeforeEach
     internal fun setUp() {
         server = MockWebServer()
         setupMockZakenApiServer()
-        server.start(port = 16273)
+        server.start()
+
+        setPluginConfigurationUrl(ZAKEN_API_PLUGIN_ID, server.url("$ZAKEN_API_PATH/").toString())
     }
 
     @AfterEach
@@ -82,10 +87,10 @@ class ZaakValueResolverValueIT @Autowired constructor(
 
             // Create zaak instance link so the resolver can find the zaak URL
             zaakInstanceLinkService.createZaakInstanceLink(
-                URI("http://localhost:16273$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
+                URI("$baseUrl$ZAKEN_API_PATH/zaken/57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 java.util.UUID.fromString("57f66ff6-db7f-43bc-84ef-6847640d3609"),
                 documentId,
-                URI("http://localhost:16273/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002")
+                URI("$baseUrl/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002")
             )
 
             val formDefinition = formDefinitionRepository.findByNameAndCaseDefinitionId("form-with-zaak-fields", caseDefinitionId).get()
@@ -118,13 +123,13 @@ class ZaakValueResolverValueIT @Autowired constructor(
     private fun getZaakRequest(): MockResponse {
         val body = """
             {
-                "url": "http://localhost:16273/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
+                "url": "$baseUrl/zaken/a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "uuid": "a6b63eb5-cc92-4f4b-ba53-9c145133166b",
                 "identificatie": "ZK2023-00001",
                 "bronorganisatie": "104978119",
                 "omschrijving": "Test",
                 "toelichting": "",
-                "zaaktype": "http://localhost:16273/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002",
+                "zaaktype": "$baseUrl/catalogi/e02753ba-9055-11ee-b9d1-0242ac120002",
                 "registratiedatum": "2023-03-22",
                 "verantwoordelijkeOrganisatie": "104978119",
                 "startdatum": "2023-03-22",
@@ -169,5 +174,6 @@ class ZaakValueResolverValueIT @Autowired constructor(
 
     companion object {
         private const val ZAKEN_API_PATH = "/zaken/api/v1"
+        private const val ZAKEN_API_PLUGIN_ID = "3079d6fe-42e3-4f8f-a9db-52ce2507b7ee"
     }
 }

--- a/backend/zgw/zaken-api/src/test/resources/config/plugin-configurations/app.pluginconfig.json
+++ b/backend/zgw/zaken-api/src/test/resources/config/plugin-configurations/app.pluginconfig.json
@@ -9,7 +9,7 @@
         "title": "Zaken API",
         "pluginDefinitionKey": "zakenapi",
         "properties": {
-            "url": "http://localhost:56273/zaken/api/v1/",
+            "url": "http://localhost:16273/zaken/api/v1/",
             "authenticationPluginConfiguration": "27a399c7-9d70-4833-a651-57664e2e9e09"
         }
     },
@@ -18,7 +18,7 @@
         "title": "Catalogi API",
         "pluginDefinitionKey": "catalogiapi",
         "properties": {
-            "url": "http://localhost:56273/catalogi/api/v1/",
+            "url": "http://localhost:16273/catalogi/api/v1/",
             "authenticationPluginConfiguration": "27a399c7-9d70-4833-a651-57664e2e9e09"
         }
     }


### PR DESCRIPTION
## Problem

The `release/13.38.0` publish pipeline [failed](https://github.com/valtimo-platform/valtimo/actions/runs/30002112640) on `:backend:zgw:catalogi-api:integrationTesting` with a `java.net.BindException`. The other ZGW jobs it reported were only *canceled* by matrix `fail-fast`.

Several integration tests start their `MockWebServer` on a **fixed port inside the OS ephemeral range** (Linux `32768–60999`, macOS `49152–65535`):

| Module | Port |
|---|---|
| catalogi-api | 56274 |
| zaken-api | 56273 |
| documenten-api | 56273 |
| keycloak-iam | 49152 |
| object-management | 47797 |

The kernel draws from that same range to auto-assign local ports to **outbound** sockets the app opens at context startup (e.g. HikariCP → Postgres). If it hands out `56273` before the test binds its listener, `server.start(port = …)` fails with `BindException`. It's a race — hence intermittent, and why it only occasionally breaks CI.

## Fix

Two approaches, because the modules differ:

- **catalogi-api** — no static config coupling, so fixed the right way: `server.start()` (OS-assigned free port) and derive the URL constants from `server.url(...)`, matching every other healthy ZGW test. Also removed a `Thread.sleep(2000)` band-aid.
- **keycloak-iam, object-management, zaken-api, documenten-api** — the port is hardcoded in **static Spring-loaded config** (`application.yml`, OIDC discovery JSON, `app.pluginconfig.json`), so the mock server must keep a fixed port. Moved each **below 32768** (`19152 / 17797 / 16273 / 16274`) so the OS never auto-assigns it to an outbound socket. Kotlin and resource files change together, so all URLs stay consistent — no logic change.

## Verification

`integrationTestingPostgresql` for all five modules: **98 tests, 0 failures.**

## Notes

- Test-only change; safe to cherry-pick into `release/13.38.0`.
- `documenten-api-preview` and `zaakdetails` also hardcode `56273` in their `app.pluginconfig.json`, but their tests don't do a fixed-port `.start()`, so they're not part of this `BindException` class. Left out of scope.
- Longer term, the static-config modules could migrate to fully dynamic ports (like catalogi-api) via `@DynamicPropertySource`.