### PR TITLE
fix: Skip documents missing in the Documenten API when listing case documents

### DIFF
--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
@@ -52,10 +52,13 @@ import com.ritense.zakenapi.ZakenApiPlugin
 import com.ritense.zakenapi.domain.ZaakInformatieObject
 import com.ritense.zakenapi.domain.ZaakResponse
 import com.ritense.zakenapi.link.ZaakInstanceLinkNotFoundException
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.transaction.annotation.Transactional
 import java.io.InputStream
 import java.net.URI
@@ -89,7 +92,7 @@ class ZaakDocumentService(
         val (viewPermissions, modifyPermissions, deletePermissions) = prefetchDocumentPermissions()
 
         return zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakUri)
-            .map { getRelatedFiles(it, caseDocumentId, viewPermissions, modifyPermissions, deletePermissions) }
+            .mapNotNull { getRelatedFiles(it, caseDocumentId, viewPermissions, modifyPermissions, deletePermissions) }
     }
 
     fun getInformatieObjectenAsRelatedFilesPage(
@@ -136,7 +139,7 @@ class ZaakDocumentService(
         } else {
             val zakenApiPlugin = getZakenApiPlugin(zaakUri)
             val documenten = zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakUri)
-                .map { mapDocumentenApiDocument(it, version, caseDocumentId, viewPermissions, modifyPermissions, deletePermissions) }
+                .mapNotNull { mapDocumentenApiDocument(it, version, caseDocumentId, viewPermissions, modifyPermissions, deletePermissions) }
             toPage(documenten, pageable)
         }
     }
@@ -189,10 +192,10 @@ class ZaakDocumentService(
         viewPermissions: List<Permission>,
         modifyPermissions: List<Permission>,
         deletePermissions: List<Permission>,
-    ): RelatedFileDto {
+    ): RelatedFileDto? {
         val pluginConfiguration = getDocumentenApiPluginByInformatieobjectUrl(zaakInformatieObject.informatieobject)
         val plugin = pluginService.createInstance(pluginConfiguration) as DocumentenApiPlugin
-        val informatieObject = plugin.getInformatieObject(zaakInformatieObject.informatieobject, caseDocumentId)
+        val informatieObject = getInformatieObjectOrNull(plugin, zaakInformatieObject, caseDocumentId) ?: return null
         return mapRelatedFile(informatieObject, pluginConfiguration, caseDocumentId, viewPermissions, modifyPermissions, deletePermissions)
     }
 
@@ -282,10 +285,10 @@ class ZaakDocumentService(
         viewPermissions: List<Permission>,
         modifyPermissions: List<Permission>,
         deletePermissions: List<Permission>,
-    ): DocumentenApiDocumentDto {
+    ): DocumentenApiDocumentDto? {
         val pluginConfiguration = getDocumentenApiPluginByInformatieobjectUrl(zaakInformatieObject.informatieobject)
         val plugin = pluginService.createInstance(pluginConfiguration) as DocumentenApiPlugin
-        val informatieObject = plugin.getInformatieObject(zaakInformatieObject.informatieobject, caseDocumentId)
+        val informatieObject = getInformatieObjectOrNull(plugin, zaakInformatieObject, caseDocumentId) ?: return null
         val trefwoorden = if (version.supportsTrefwoorden) {
             informatieObject.trefwoorden
         } else {
@@ -317,6 +320,26 @@ class ZaakDocumentService(
             canModify = evaluatePermission(zgwDocument, ZgwDocumentActionProvider.MODIFY, modifyPermissions),
             canDelete = evaluatePermission(zgwDocument, ZgwDocumentActionProvider.DELETE, deletePermissions),
         )
+    }
+
+    private fun getInformatieObjectOrNull(
+        plugin: DocumentenApiPlugin,
+        zaakInformatieObject: ZaakInformatieObject,
+        caseDocumentId: UUID,
+    ): DocumentInformatieObject? {
+        return try {
+            plugin.getInformatieObject(zaakInformatieObject.informatieobject, caseDocumentId)
+        } catch (e: HttpClientErrorException) {
+            if (e.statusCode == HttpStatus.NOT_FOUND) {
+                logger.warn(e) {
+                    "Skipping zaakinformatieobject '${zaakInformatieObject.url}' of case '$caseDocumentId': " +
+                        "informatieobject '${zaakInformatieObject.informatieobject}' was not found in the Documenten API"
+                }
+                null
+            } else {
+                throw e
+            }
+        }
     }
 
     private fun prefetchDocumentPermissions(): Triple<List<Permission>, List<Permission>, List<Permission>> {
@@ -469,5 +492,9 @@ class ZaakDocumentService(
     fun getInformatieObject(pluginConfigurationId: String, caseDocumentId: UUID, documentId: String): DocumentInformatieObject {
         getVerifiedInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
         return documentenApiService.getInformatieObject(pluginConfigurationId, caseDocumentId, documentId)
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
     }
 }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
@@ -161,10 +161,24 @@ class ZaakDocumentService(
                     zaakInformatieobject.informatieobject
                 ).size == 1
             ) {
-                documentenApiService.deleteInformatieObject(
-                    zaakInformatieobject.informatieobject,
-                    caseDocumentId
-                )
+                try {
+                    // Call the plugin directly instead of DocumentenApiService: an exception that
+                    // crossed the service's @Transactional proxy would have marked the transaction
+                    // rollback-only, so catching it here would no longer save the case deletion.
+                    val pluginConfiguration =
+                        getDocumentenApiPluginByInformatieobjectUrl(zaakInformatieobject.informatieobject)
+                    val plugin = pluginService.createInstance(pluginConfiguration) as DocumentenApiPlugin
+                    plugin.deleteInformatieObject(caseDocumentId, zaakInformatieobject.informatieobject)
+                } catch (e: HttpClientErrorException) {
+                    if (e.statusCode == HttpStatus.NOT_FOUND) {
+                        logger.warn(e) {
+                            "Skipping deletion of informatieobject '${zaakInformatieobject.informatieobject}' " +
+                                "of case '$caseDocumentId': it was not found in the Documenten API"
+                        }
+                    } else {
+                        throw e
+                    }
+                }
             } else {
                 zakenApiPlugin.deleteZaakInformatieobject(zaakInformatieobject.url, caseDocumentId)
             }
@@ -181,7 +195,9 @@ class ZaakDocumentService(
     }
 
     private fun <T> toPage(list: List<T>, pageable: Pageable): Page<T> {
-        val startIndex = pageable.offset.toInt()
+        // The offset can point past the end of the list, e.g. when documents that are missing
+        // in the Documenten API were filtered out. Clamp to avoid an out-of-bounds subList.
+        val startIndex = min(pageable.offset.toInt(), list.size)
         val endIndex = min(startIndex + pageable.pageSize, list.size)
         return PageImpl(list.subList(startIndex, endIndex), pageable, list.size.toLong())
     }

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
@@ -51,6 +51,8 @@ import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
 import java.io.ByteArrayInputStream
 import java.net.URI
 import java.time.LocalDate
@@ -123,6 +125,74 @@ class ZaakDocumentServiceTest {
             assertEquals(UUID.fromString("b059092c-9557-431a-9118-97f147903270"), relatedFile.fileId)
             assertEquals(documentenApiPluginConfiguration.id.id, relatedFile.pluginConfigurationId)
             assertEquals("http://localhost/informatieobjecttype", relatedFile.informatieobjecttype)
+        }
+    }
+
+    @Test
+    fun `should skip informatieobjecten that no longer exist in the Documenten API`() {
+        val caseId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/$caseId")
+        whenever(zaakUrlProvider.getZaakUrl(caseId)).thenReturn(zaakUrl)
+
+        val zakenApiPlugin = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .doReturn(zakenApiPlugin)
+
+        val zaakInformatieObjects = createZaakInformatieObjecten(zaakUrl)
+        whenever(zakenApiPlugin.getZaakInformatieObjecten(caseId, zaakUrl)).thenReturn(
+            zaakInformatieObjects
+        )
+
+        val documentenApiPluginConfiguration = mock<PluginConfiguration>()
+        val documentenApiPlugin = mock<DocumentenApiPlugin>()
+        whenever(pluginService.findPluginConfiguration(eq(DocumentenApiPlugin::class.java), any()))
+            .doReturn(documentenApiPluginConfiguration)
+        whenever(documentenApiPluginConfiguration.id)
+            .doReturn(PluginConfigurationId(UUID.randomUUID()))
+        whenever(pluginService.createInstance(eq(documentenApiPluginConfiguration)))
+            .doReturn(documentenApiPlugin)
+        val missingInformatieobjectUrl = zaakInformatieObjects[2].informatieobject
+        whenever(documentenApiPlugin.getInformatieObject(any<URI>(), any())).doAnswer { answer ->
+            val uri = answer.getArgument(0) as URI
+            if (uri == missingInformatieobjectUrl) {
+                throw HttpClientErrorException(HttpStatus.NOT_FOUND, "Not Found")
+            }
+            createDocumentInformatieObject(uri)
+        }
+
+        val relatedFiles = service.getInformatieObjectenAsRelatedFiles(caseId)
+
+        assertEquals(4, relatedFiles.size)
+    }
+
+    @Test
+    fun `should throw when the Documenten API fails with an error other than not found`() {
+        val caseId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/$caseId")
+        whenever(zaakUrlProvider.getZaakUrl(caseId)).thenReturn(zaakUrl)
+
+        val zakenApiPlugin = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .doReturn(zakenApiPlugin)
+
+        val zaakInformatieObjects = createZaakInformatieObjecten(zaakUrl)
+        whenever(zakenApiPlugin.getZaakInformatieObjecten(caseId, zaakUrl)).thenReturn(
+            zaakInformatieObjects
+        )
+
+        val documentenApiPluginConfiguration = mock<PluginConfiguration>()
+        val documentenApiPlugin = mock<DocumentenApiPlugin>()
+        whenever(pluginService.findPluginConfiguration(eq(DocumentenApiPlugin::class.java), any()))
+            .doReturn(documentenApiPluginConfiguration)
+        whenever(documentenApiPluginConfiguration.id)
+            .doReturn(PluginConfigurationId(UUID.randomUUID()))
+        whenever(pluginService.createInstance(eq(documentenApiPluginConfiguration)))
+            .doReturn(documentenApiPlugin)
+        whenever(documentenApiPlugin.getInformatieObject(any<URI>(), any()))
+            .doAnswer { throw HttpClientErrorException(HttpStatus.FORBIDDEN, "Forbidden") }
+
+        assertThrows<HttpClientErrorException> {
+            service.getInformatieObjectenAsRelatedFiles(caseId)
         }
     }
 

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
@@ -43,6 +43,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -197,6 +198,59 @@ class ZaakDocumentServiceTest {
     }
 
     @Test
+    fun `should page correctly when missing documents shrink the result set below the page offset`() {
+        val caseId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/$caseId")
+        whenever(zaakUrlProvider.getZaakUrl(caseId)).thenReturn(zaakUrl)
+        whenever(documentenApiVersionService.getVersionByDocumentId(caseId)).thenReturn(MINIMUM_VERSION)
+        whenever(authorizationService.hasPermission<Any>(any())).thenReturn(true)
+
+        val zakenApiPlugin = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .doReturn(zakenApiPlugin)
+
+        val zaakInformatieObjects = createZaakInformatieObjecten(zaakUrl, count = 10)
+        whenever(zakenApiPlugin.getZaakInformatieObjecten(caseId, zaakUrl)).thenReturn(
+            zaakInformatieObjects
+        )
+
+        val documentenApiPluginConfiguration = mock<PluginConfiguration>()
+        val documentenApiPlugin = mock<DocumentenApiPlugin>()
+        whenever(pluginService.findPluginConfiguration(eq(DocumentenApiPlugin::class.java), any()))
+            .doReturn(documentenApiPluginConfiguration)
+        whenever(documentenApiPluginConfiguration.id)
+            .doReturn(PluginConfigurationId(UUID.randomUUID()))
+        whenever(pluginService.createInstance(eq(documentenApiPluginConfiguration)))
+            .doReturn(documentenApiPlugin)
+        val missingInformatieobjectUrl = zaakInformatieObjects[2].informatieobject
+        whenever(documentenApiPlugin.getInformatieObject(any<URI>(), any())).doAnswer { answer ->
+            val uri = answer.getArgument(0) as URI
+            if (uri == missingInformatieobjectUrl) {
+                throw HttpClientErrorException(HttpStatus.NOT_FOUND, "Not Found")
+            }
+            createDocumentInformatieObject(uri)
+        }
+
+        val firstPage = service.getInformatieObjectenAsRelatedFilesPage(
+            caseId,
+            DocumentSearchRequest(),
+            PageRequest.of(0, 10)
+        )
+        assertEquals(9, firstPage.content.size)
+        assertEquals(9, firstPage.totalElements)
+
+        // 10 zaakinformatieobjecten with 1 missing document leaves 9 results, so the offset of
+        // page 2 (10) points past the result set. This used to throw an IllegalArgumentException.
+        val secondPage = service.getInformatieObjectenAsRelatedFilesPage(
+            caseId,
+            DocumentSearchRequest(),
+            PageRequest.of(1, 10)
+        )
+        assertEquals(0, secondPage.content.size)
+        assertEquals(9, secondPage.totalElements)
+    }
+
+    @Test
     fun `should get zaak by document id`() {
         val caseDocumentId = UUID.randomUUID()
         val zaakId = UUID.randomUUID()
@@ -333,10 +387,12 @@ class ZaakDocumentServiceTest {
         whenever(zaakApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId, URI("http://localhost/doc/2")))
             .thenReturn(listOf(doc2))
 
+        val documentenApiPlugin = mockDocumentenApiPlugin()
+
         service.deleteRelatedInformatieObjecten(caseDocumentId, documentUrl)
 
         val zaakDocumentCaptor = argumentCaptor<URI>()
-        verify(documentenApiService, times(2)).deleteInformatieObject(zaakDocumentCaptor.capture(), any())
+        verify(documentenApiPlugin, times(2)).deleteInformatieObject(eq(caseDocumentId), zaakDocumentCaptor.capture())
 
         assertEquals(URI("http://localhost/doc/1"), zaakDocumentCaptor.firstValue)
         assertEquals(URI("http://localhost/doc/2"), zaakDocumentCaptor.secondValue)
@@ -367,6 +423,73 @@ class ZaakDocumentServiceTest {
 
         verify(documentenApiService, times(0)).deleteInformatieObject(any(), any())
         verify(zaakApiPlugin).deleteZaakInformatieobject(relationUrl, caseDocumentId)
+    }
+
+    @Test
+    fun `should continue deleting when an informatieobject no longer exists in the Documenten API`() {
+        val caseDocumentId = UUID.randomUUID()
+        val documentUrl = URI("http://localhost/zaak/$caseDocumentId")
+        val zaakApiPlugin = mock<ZakenApiPlugin>()
+
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .thenReturn(zaakApiPlugin)
+        val doc1 = mock<ZaakInformatieObject>()
+        val doc2 = mock<ZaakInformatieObject>()
+
+        whenever(zaakApiPlugin.getZaakInformatieObjecten(caseDocumentId, documentUrl)).thenReturn(listOf(doc1, doc2))
+
+        whenever(doc1.informatieobject).thenReturn(URI("http://localhost/doc/1"))
+        whenever(doc2.informatieobject).thenReturn(URI("http://localhost/doc/2"))
+
+        whenever(zaakApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId, URI("http://localhost/doc/1")))
+            .thenReturn(listOf(doc1))
+        whenever(zaakApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId, URI("http://localhost/doc/2")))
+            .thenReturn(listOf(doc2))
+
+        val documentenApiPlugin = mockDocumentenApiPlugin()
+        doThrow(HttpClientErrorException(HttpStatus.NOT_FOUND, "Not Found"))
+            .whenever(documentenApiPlugin).deleteInformatieObject(caseDocumentId, URI("http://localhost/doc/1"))
+
+        service.deleteRelatedInformatieObjecten(caseDocumentId, documentUrl)
+
+        verify(documentenApiPlugin).deleteInformatieObject(caseDocumentId, URI("http://localhost/doc/1"))
+        verify(documentenApiPlugin).deleteInformatieObject(caseDocumentId, URI("http://localhost/doc/2"))
+    }
+
+    @Test
+    fun `should throw when deleting an informatieobject fails with an error other than not found`() {
+        val caseDocumentId = UUID.randomUUID()
+        val documentUrl = URI("http://localhost/zaak/$caseDocumentId")
+        val zaakApiPlugin = mock<ZakenApiPlugin>()
+
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .thenReturn(zaakApiPlugin)
+        val doc1 = mock<ZaakInformatieObject>()
+
+        whenever(zaakApiPlugin.getZaakInformatieObjecten(caseDocumentId, documentUrl)).thenReturn(listOf(doc1))
+
+        whenever(doc1.informatieobject).thenReturn(URI("http://localhost/doc/1"))
+
+        whenever(zaakApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(caseDocumentId, URI("http://localhost/doc/1")))
+            .thenReturn(listOf(doc1))
+
+        val documentenApiPlugin = mockDocumentenApiPlugin()
+        doThrow(HttpClientErrorException(HttpStatus.FORBIDDEN, "Forbidden"))
+            .whenever(documentenApiPlugin).deleteInformatieObject(caseDocumentId, URI("http://localhost/doc/1"))
+
+        assertThrows<HttpClientErrorException> {
+            service.deleteRelatedInformatieObjecten(caseDocumentId, documentUrl)
+        }
+    }
+
+    private fun mockDocumentenApiPlugin(): DocumentenApiPlugin {
+        val documentenApiPluginConfiguration = mock<PluginConfiguration>()
+        val documentenApiPlugin = mock<DocumentenApiPlugin>()
+        whenever(pluginService.findPluginConfiguration(eq(DocumentenApiPlugin::class.java), any()))
+            .doReturn(documentenApiPluginConfiguration)
+        whenever(pluginService.createInstance(eq(documentenApiPluginConfiguration)))
+            .doReturn(documentenApiPlugin)
+        return documentenApiPlugin
     }
 
     private fun createZaakInformatieObjecten(zaakUrl: URI, count: Int = 5): List<ZaakInformatieObject> {

--- a/documentation/release-notes/13.x.x/13.39.0/README.md
+++ b/documentation/release-notes/13.x.x/13.39.0/README.md
@@ -51,7 +51,9 @@
 
   Documents that are still linked to the zaak but no longer exist in the Documenten API are
   now skipped (with a warning in the log), so the remaining documents of the case are still
-  shown instead of an error.
+  shown instead of an error. Pagination of the documents tab also no longer fails when
+  skipped documents leave a page beyond the end of the result set, and deleting a case no
+  longer fails when one of its linked documents is missing in the Documenten API.
 
 * **Tooltips no longer stay on screen when the hovered element is removed**
 

--- a/documentation/release-notes/13.x.x/13.39.0/README.md
+++ b/documentation/release-notes/13.x.x/13.39.0/README.md
@@ -47,6 +47,12 @@
   before producing a file. A user without an applicable `export` permission for the case definition now receives a
   403 (Forbidden) response instead of an empty CSV.
 
+* **Documents tab no longer fails when a linked document is missing in the Documenten API**
+
+  Documents that are still linked to the zaak but no longer exist in the Documenten API are
+  now skipped (with a warning in the log), so the remaining documents of the case are still
+  shown instead of an error.
+
 * **Tooltips no longer stay on screen when the hovered element is removed**
 
   A tooltip shown for an element that was removed or re-rendered while hovered (for example on pages that


### PR DESCRIPTION
For 13. closes https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/799 - original , the new one for V13: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/568