### PR TITLE
Add release notes for 13.4.2

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -240,6 +240,7 @@
   * [13.5.0](release-notes/13.x.x/13.5.0/README.md)
   * [13.4.0](release-notes/13.x.x/13.4.0/README.md)
   * [13.4.1](release-notes/13.x.x/13.4.0/13.4.1.md)
+  * [13.4.2](release-notes/13.x.x/13.4.0/13.4.2.md)
   * [13.3.0](release-notes/13.x.x/13.3.0/README.md)
   * [13.2.0](release-notes/13.x.x/13.2.0/README.md)
   * [13.2.1](release-notes/13.x.x/13.2.1/README.md)

--- a/documentation/release-notes/13.x.x/13.4.0/13.4.2.md
+++ b/documentation/release-notes/13.x.x/13.4.0/13.4.2.md
@@ -1,0 +1,11 @@
+# 13.4.2
+
+{% hint style="info" %}
+**Release date 29-07-2026**
+{% endhint %}
+
+## Bugfixes
+
+* Fixed a security issue that could allow expressions to perform unintended actions. Expressions are now evaluated in a restricted context.
+* Fixed a security issue where a user could download a document that did not belong to the case they were viewing. Document downloads are now checked against the case.
+* Updated underlying libraries to address known security vulnerabilities.


### PR DESCRIPTION
Adds release notes for the 13.4.2 patch release. Covers the SpEL context fix (#793), the case-scoped document download fix (#800), and the httpcore5/logback CVE dependency overrides.

Don't squash!