### PR TITLE
docs: add 12.4.3 security release notes

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -222,6 +222,7 @@
   * [12.5.0](release-notes/12.x.x/12.5.0.md)
   * [12.4.0](release-notes/12.x.x/12.4.0.md)
     * [12.4.1](release-notes/12.x.x/12.4.0/12.4.1.md)
+    * [12.4.3](release-notes/12.x.x/12.4.0/12.4.3.md)
   * [12.3.0](release-notes/12.x.x/12.3.0/README.md)
     * [12.3.1](release-notes/12.x.x/12.3.0/12.3.1.md)
   * [12.2.0](release-notes/12.x.x/12.2.0.md)

--- a/documentation/release-notes/12.x.x/12.4.0/12.4.3.md
+++ b/documentation/release-notes/12.x.x/12.4.0/12.4.3.md
@@ -1,0 +1,17 @@
+# 12.4.3
+
+## Security
+
+* **Case documents can no longer be downloaded from the wrong case**
+
+  When downloading or retrieving a case document, the application now checks that the document actually
+  belongs to the case in the request before returning it. Previously this check was only applied when
+  editing or deleting a document, so a signed-in user could retrieve a document from another case by
+  referencing it directly. The read and download paths now enforce the same check.
+
+* **Hardened expression evaluation in Form Flow**
+
+  Form Flow expressions are now evaluated in a restricted context, preventing expressions from reaching
+  arbitrary Java types and methods.
+
+* Updated several dependencies to address reported vulnerabilities.


### PR DESCRIPTION
Adds release notes for the 12.4.3 security backport.

## Security
- **Case documents can no longer be downloaded from the wrong case** — the zaken-api read/download paths now enforce the case↔document relation.
- **Hardened Form Flow expression evaluation** — SpEL now runs in a restricted (`SimpleEvaluationContext`) context.
- Dependency vulnerability updates (incl. `httpcore5` 5.4.3 for CVE-2026-54399 / CVE-2026-54428).

Mirrors the Security section added for 12.40.0 in #811. Old flat 12.4.x format; linked in `SUMMARY.md` under 12.4.0.

Corresponding code fixes are on `rc/12.4.3`.