### PR TITLE
 Fix modal directive freeze and align e2e tests with renamed labels

### DIFF
--- a/e2e/tests/access-control/access-control.spec.ts
+++ b/e2e/tests/access-control/access-control.spec.ts
@@ -50,9 +50,8 @@ test.describe('Access Control Management', () => {
     // Keep open-modal → fill → submit in one test: the beforeEach re-navigates to
     // the list before every test, so a split modal would be lost between blocks.
     test('Add a new role', async () => {
-      // Act
-      await accessControlPage.addRoleButton.click();
-      await expect(accessControlPage.roleNameInput).toBeVisible();
+      // Act — the modal opens in "choose from list" mode; switch it to manual entry first
+      await accessControlPage.openAddRoleModal();
       await accessControlPage.roleNameInput.fill(roleTestData.key);
       await accessControlPage.createRoleButton.click();
 

--- a/e2e/tests/access-control/page.ts
+++ b/e2e/tests/access-control/page.ts
@@ -59,13 +59,19 @@ export class AccessControlPage {
     return this.page.getByLabel('Table action bar').getByRole('button', {name: 'Add new role'});
   }
 
-  // Role metadata modal: cds-label wrapping "Role name" input, no data-test-ids
+  // Role metadata modal: plain <input formControlName="key">, no data-test-ids.
+  // It is only rendered in manual mode — see openAddRoleModal().
   get roleNameInput() {
-    return this.page
-      .locator('cds-modal')
-      .locator('cds-label')
-      .filter({hasText: 'Role name'})
-      .locator('input');
+    return this.page.locator('cds-modal input[formcontrolname="key"]');
+  }
+
+  /**
+   * The modal defaults to a "choose from list" v-select of existing role keys; the free
+   * text input only appears after switching to manual mode. The same button switches back
+   * ("Choose from list"), so only click it while it still offers manual entry.
+   */
+  get manualEntryButton() {
+    return this.page.locator('cds-modal').getByRole('button', {name: 'Enter manually'});
   }
 
   get createRoleButton() {
@@ -86,8 +92,16 @@ export class AccessControlPage {
 
   // ─── Actions ──────────────────────────────────────────────────────
 
-  async addRole(roleKey: string) {
+  /** Opens the add-role modal and switches it to manual key entry. */
+  async openAddRoleModal() {
     await this.addRoleButton.click();
+    await expect(this.manualEntryButton).toBeVisible();
+    await this.manualEntryButton.click();
+    await expect(this.roleNameInput).toBeVisible();
+  }
+
+  async addRole(roleKey: string) {
+    await this.openAddRoleModal();
     await this.roleNameInput.fill(roleKey);
     await this.createRoleButton.click();
   }

--- a/e2e/tests/case-details-management-form-flows/page.ts
+++ b/e2e/tests/case-details-management-form-flows/page.ts
@@ -53,9 +53,12 @@ export class CaseDetailsManagementFormFlowsPage {
   }
 
   get addFormFlowButton() {
-    // Two "Add new form flow" buttons exist when list is empty: toolbar + no-results panel.
+    // Two "Create new form flow" buttons exist when list is empty: toolbar + no-results panel.
     // Scope to toolbar to avoid strict mode violation.
-    return this.page.getByLabel('Table action bar').getByRole('button', {name: 'Add new form flow'});
+    // Label was renamed "Add new form flow" → "Create new form flow"; accept both.
+    return this.page
+      .getByLabel('Table action bar')
+      .getByRole('button', {name: /^(Create|Add) new form flow$/i});
   }
 
   // Create modal: only a key field, no data-test-ids

--- a/e2e/tests/case-details-management-tabs/page.ts
+++ b/e2e/tests/case-details-management-tabs/page.ts
@@ -36,8 +36,10 @@ export class CaseDetailsManagementTabsPage {
   }
 
   get addTabButton() {
-    // Toolbar button inside the tabs panel
-    return this.tabsPanel.getByRole('button', {name: /Add tab/i});
+    // Toolbar button inside the tabs panel.
+    // Label was renamed "Add tab" → "Create tab"; accept both so the test does not
+    // break while a target environment still runs an older frontend build.
+    return this.tabsPanel.getByRole('button', {name: /(Create|Add) tab/i});
   }
 
   get tabNameInput() {
@@ -49,8 +51,11 @@ export class CaseDetailsManagementTabsPage {
   }
 
   get addTabConfirmButton() {
-    // Primary "Add tab" button in the modal footer (only visible after a type is selected)
-    return this.page.locator('cds-modal-footer .valtimo-add-tab-modal__actions').getByRole('button', {name: /Add tab/i});
+    // Primary confirm button in the modal footer (only rendered after a type is selected).
+    // Label comes from `interface.create` ("Create"); older builds used "Add tab".
+    return this.page
+      .locator('cds-modal-footer .valtimo-add-tab-modal__actions')
+      .getByRole('button', {name: /^(Create|Add tab)$/i});
   }
 
   get modalCancelButton() {
@@ -69,6 +74,9 @@ export class CaseDetailsManagementTabsPage {
   async switchToCaseDetailsTabs() {
     await this.page.getByRole('tab', {name: 'Case details'}).click();
     await this.page.getByRole('tab', {name: 'Tabs'}).click();
+    // Confirm we landed: a late redirect from the version switch can throw the page back to
+    // /general, and every test in this file then runs against the wrong panel.
+    await expect(this.tabsList).toBeVisible();
   }
 
   async ensureDraftVersionSelected(): Promise<string> {

--- a/e2e/tests/case-details-management-tasks/page.ts
+++ b/e2e/tests/case-details-management-tasks/page.ts
@@ -19,6 +19,8 @@ import {CarbonList, CarbonListRow} from '../../shared/carbon-list/carbon-list.ut
 import {VALUE_PATH_SELECTOR_TEST_IDS} from '../../constants';
 import * as ApiUtils from '../../utils/api.utils';
 import {ensureDraftVersionSelected} from '../../utils/version.utils';
+import {fillValuePathManually} from '../../utils/value-path-selector.utils';
+import {fillStable} from '../../utils/ui.utils';
 
 export class CaseDetailsManagementTasksPage {
   constructor(
@@ -72,9 +74,13 @@ export class CaseDetailsManagementTasksPage {
   // No data-test-ids in column modal — use cds-label + hasText
 
   get addColumnButton() {
-    // Two "Add column" buttons exist when list is empty: toolbar + no-results panel.
+    // Two "Create column" buttons exist when list is empty: toolbar + no-results panel.
     // Scope to toolbar to avoid strict mode violation.
-    return this.page.getByLabel('Table action bar').getByRole('button', {name: 'Add column'});
+    // Label was renamed "Add column" → "Create column"; accept both so the test does not
+    // break while a target environment still runs an older frontend build.
+    return this.page
+      .getByLabel('Table action bar')
+      .getByRole('button', {name: /^(Create|Add) column$/i});
   }
 
   get columnTitleInput() {
@@ -85,22 +91,14 @@ export class CaseDetailsManagementTasksPage {
     return this.page.locator('cds-modal').locator('cds-label').filter({hasText: 'Key'}).locator('input');
   }
 
-  // Path uses valtimo-value-path-selector, which defaults to dropdown mode.
-  // The manual text input (where an arbitrary path can be typed) only renders
-  // after toggling to manual mode.
-  get columnPathToggle() {
-    return this.page
-      .locator('cds-modal')
-      .locator('valtimo-value-path-selector')
-      .getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.toggle)
-      .locator('.cds--toggle__switch');
+  // Path uses valtimo-value-path-selector. Whether it starts in dropdown or manual
+  // mode depends on the configuration, so use the shared helper to force manual mode.
+  get columnPathSelector() {
+    return this.page.locator('cds-modal').locator('valtimo-value-path-selector');
   }
 
   get columnPathInput() {
-    return this.page
-      .locator('cds-modal')
-      .locator('valtimo-value-path-selector')
-      .getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.input);
+    return this.columnPathSelector.getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.input);
   }
 
   get columnDisplayTypeDropdown() {
@@ -112,16 +110,22 @@ export class CaseDetailsManagementTasksPage {
   }
 
   get columnSaveButton() {
-    return this.page.locator('cds-modal-footer').getByRole('button', {name: 'Save column'});
+    // The primary button reads "Create" while adding and "Save column" while editing.
+    return this.page
+      .locator('cds-modal-footer')
+      .getByRole('button', {name: /^(Create|Save column)$/i});
   }
 
   // ─── Search Field Modal Elements ──────────────────────────────────
   // Search field modal uses data-testid attributes
 
   get addSearchFieldButton() {
-    // Two "Add search field" buttons exist when list is empty: toolbar + no-results panel.
+    // Two "Create search field" buttons exist when list is empty: toolbar + no-results panel.
     // Scope to toolbar to avoid strict mode violation.
-    return this.page.getByLabel('Table action bar').getByRole('button', {name: 'Add search field'});
+    // Label was renamed "Add search field" → "Create search field"; accept both.
+    return this.page
+      .getByLabel('Table action bar')
+      .getByRole('button', {name: /^(Create|Add) search field$/i});
   }
 
   get searchFieldKeyInput() {
@@ -153,20 +157,6 @@ export class CaseDetailsManagementTasksPage {
     await expect(dropdownLocator).toContainText(itemText);
   }
 
-  // The value-path-selector toggles to manual mode and runs a setTimeout(detectChanges, 1)
-  // before the manual <input> is wired to the parent form. Filling immediately can land the
-  // value before the CVA subscription is active, so the required `path` control never commits
-  // and the Save button stays disabled. Re-fill until the input actually holds the value.
-  private async fillValuePathManually(toggle: Locator, input: Locator, path: string) {
-    await toggle.click();
-    await expect(input).toBeVisible();
-    await expect(async () => {
-      await input.fill(path);
-      await input.blur();
-      await expect(input).toHaveValue(path);
-    }).toPass({timeout: 10_000});
-  }
-
   // ─── Cleanup ───────────────────────────────────────────────────────
 
   async cleanupStaleColumns() {
@@ -190,27 +180,23 @@ export class CaseDetailsManagementTasksPage {
     await this.addColumnButton.click();
     await expect(this.columnKeyInput).toBeVisible();
 
+    // The modal resets its form shortly after opening, so fill until the values stick.
     if (column.title) {
-      await this.columnTitleInput.fill(column.title);
+      await fillStable(this.columnTitleInput, column.title);
     }
-    await this.columnKeyInput.fill(column.key);
-    await this.fillValuePathManually(this.columnPathToggle, this.columnPathInput, column.path);
+    await fillStable(this.columnKeyInput, column.key);
+    await fillValuePathManually(this.columnPathSelector, column.path);
     await this.selectDropdownItem(this.columnDisplayTypeDropdown, column.displayType);
     await expect(this.columnSaveButton).toBeEnabled();
     await this.columnSaveButton.click();
   }
 
-  get searchFieldPathToggle() {
-    return this.page
-      .locator('valtimo-value-path-selector')
-      .getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.toggle)
-      .locator('.cds--toggle__switch');
+  get searchFieldPathSelector() {
+    return this.page.locator('valtimo-value-path-selector');
   }
 
   get searchFieldPathInput() {
-    return this.page
-      .locator('valtimo-value-path-selector')
-      .getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.input);
+    return this.searchFieldPathSelector.getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.input);
   }
 
   async addSearchField(field: {title: string; key: string; path: string; dataType: string; matchType?: string; fieldType: string}) {
@@ -218,7 +204,7 @@ export class CaseDetailsManagementTasksPage {
     await expect(this.searchFieldKeyInput).toBeVisible();
     await this.page.locator('[data-testid="task-management-search-title"]').fill(field.title);
     await this.searchFieldKeyInput.fill(field.key);
-    await this.fillValuePathManually(this.searchFieldPathToggle, this.searchFieldPathInput, field.path);
+    await fillValuePathManually(this.searchFieldPathSelector, field.path);
     await this.selectDropdownItem(this.searchFieldDataTypeDropdown, field.dataType);
     if (field.matchType) {
       const matchTypeVisible = await this.searchFieldMatchTypeDropdown.isVisible();

--- a/e2e/tests/case-details-management-widgets/case-details-management-widgets.ts
+++ b/e2e/tests/case-details-management-widgets/case-details-management-widgets.ts
@@ -25,7 +25,9 @@ export function createWidgetTestData() {
     tabKey: `e2e-widget-tab-${id}`,
     widgetTitle: `E2e Test Widget ${id}`,
     fieldTitle: 'Test Field',
-    valuePath: 'case:definitionId.name',
+    // `case:definitionId.name` no longer exists: the case definition id is exposed as
+    // key + versionTag since case definition versioning was introduced.
+    valuePath: 'case:definitionId.key',
   };
 }
 

--- a/e2e/tests/case-details-management-widgets/page.ts
+++ b/e2e/tests/case-details-management-widgets/page.ts
@@ -121,7 +121,9 @@ export class CaseDetailsManagementWidgetsPage {
   async selectValuePath(pathText: string) {
     const selector = this.page.getByTestId(WIDGET_CONTENT_FIELDS_TEST_IDS.valuePathSelector);
     await selector.getByRole('combobox').click();
-    await this.page.getByText(pathText).click();
+    // Match the option exactly: several paths share a prefix (e.g. `case:definitionId.key`
+    // and `case:definitionId.versionTag`), so a substring match is ambiguous.
+    await this.page.getByRole('option', {name: pathText, exact: true}).click();
   }
 
   /**

--- a/e2e/tests/case-details-management-zgw-keywords/case-details-management-zgw-keywords.spec.ts
+++ b/e2e/tests/case-details-management-zgw-keywords/case-details-management-zgw-keywords.spec.ts
@@ -35,6 +35,9 @@ test.describe('Case details management — ZGW Keywords (6S)', () => {
   const createdKeywords: string[] = [];
 
   test.beforeAll(async ({browser, baseURL}) => {
+    // Navigating to the case, selecting the draft version and loading the ZGW tab does not
+    // fit in the default 30s budget on a slower environment.
+    test.setTimeout(60_000);
     context = await browser.newContext({baseURL});
     page = await context.newPage();
     request = context.request;

--- a/e2e/tests/case-details-management-zgw-keywords/page.ts
+++ b/e2e/tests/case-details-management-zgw-keywords/page.ts
@@ -82,6 +82,10 @@ export class CaseDetailsManagementZgwKeywordsPage {
 
   async openKeywordsTab() {
     await this.zgwTab.click();
+    // The ZGW sub-tabs render only once the ZGW section has loaded, which can lag on a
+    // slower environment. Wait for the sub-tab explicitly so the click cannot block until
+    // the hook times out.
+    await expect(this.keywordsTab).toBeVisible({timeout: 20_000});
     await this.keywordsTab.click();
     await this.list.waitForLoaded();
   }

--- a/e2e/tests/case-details-management/case-details-management.spec.ts
+++ b/e2e/tests/case-details-management/case-details-management.spec.ts
@@ -124,12 +124,23 @@ test.describe('Case management', () => {
           const canHaveHandlerSwitch = caseDetailsManagementPage.caseHandlerCanHaveHandler.getByRole('switch');
           const autoAssignSwitch = caseDetailsManagementPage.caseHandlerAutomaticallyAssign.getByRole('switch');
 
-          if (await canHaveHandlerSwitch.isChecked()) {
-            await caseDetailsManagementPage.caseHandlerCanHaveHandlerToggle.click();
-          }
+          // The toggle can briefly re-disable while the handler section (re)binds after a
+          // reload, which swallows a single click. Retry each transition until the switch
+          // actually reaches the wanted state (same pattern as the sibling tests).
+          const setCanHaveHandler = async (checked: boolean) => {
+            await expect(async () => {
+              if ((await canHaveHandlerSwitch.isChecked()) !== checked) {
+                await expect(canHaveHandlerSwitch).toBeEnabled();
+                await caseDetailsManagementPage.caseHandlerCanHaveHandlerToggle.click();
+              }
+              await expect(canHaveHandlerSwitch).toBeChecked({checked, timeout: 2_000});
+            }).toPass({timeout: 15_000});
+          };
+
+          await setCanHaveHandler(false);
 
           //Act
-          await caseDetailsManagementPage.caseHandlerCanHaveHandlerToggle.click();
+          await setCanHaveHandler(true);
 
           // Assert
           await expect(canHaveHandlerSwitch).toBeChecked();

--- a/e2e/tests/choice-field-management/page.ts
+++ b/e2e/tests/choice-field-management/page.ts
@@ -126,6 +126,10 @@ export class ChoiceFieldManagementPage {
   // ─── Choice Field Value Actions ───────────────────────────────────
 
   async createChoiceFieldValue(name: string, value: string, sortOrder: string) {
+    // The toolbar button renders with the value list. Waiting for it explicitly turns a slow
+    // render into a clear assertion instead of a click that silently blocks until the test
+    // times out (which is how this failed on the nightly environment).
+    await expect(this.createValueButton).toBeVisible({timeout: 15_000});
     await this.createValueButton.click();
     await expect(this.nameInput).toBeVisible();
 

--- a/e2e/tests/iko/iko-search-action/page.ts
+++ b/e2e/tests/iko/iko-search-action/page.ts
@@ -23,6 +23,7 @@ import {
   IKO_SEARCH_ACTIONS_TEST_IDS,
 } from '../../../constants';
 import {apiDelete, apiGet, apiPost} from '../../../utils/api.utils';
+import {settleModalReset} from '../../../shared/modal/modal.utils';
 
 interface IkoSearchActionResponse {
   key: string;
@@ -85,8 +86,14 @@ export class IkoSearchActionPage {
   async closeAnyOpenModal(): Promise<void> {
     for (const heading of [this.addModalHeading, this.editModalHeading]) {
       if (await heading.isVisible().catch(() => false)) {
-        await this.cancelButton.click().catch(() => undefined);
-        await heading.waitFor({state: 'hidden', timeout: 5_000}).catch(() => undefined);
+        // Bounded: an unbounded click in a cleanup hook blocks until the test times out.
+        await this.cancelButton.click({timeout: 3_000}).catch(() => undefined);
+        await heading.waitFor({state: 'hidden', timeout: 3_000}).catch(() => undefined);
+
+        if (await heading.isVisible().catch(() => false)) {
+          await this.page.keyboard.press('Escape').catch(() => undefined);
+          await heading.waitFor({state: 'hidden', timeout: 3_000}).catch(() => undefined);
+        }
       }
     }
   }
@@ -112,16 +119,22 @@ export class IkoSearchActionPage {
   async openAddModal(): Promise<void> {
     await this.addActionButton.click();
     await expect(this.addModalHeading).toBeVisible();
+    // Let the deferred form reset fire before filling — otherwise it can wipe the form
+    // after it was filled and leave Save permanently disabled.
+    await settleModalReset(this.page);
   }
 
   async openEditModal(title: string): Promise<void> {
     await this.list.row(title).clickAction('Edit');
     await expect(this.editModalHeading).toBeVisible();
+    await settleModalReset(this.page);
   }
 
   async save(): Promise<void> {
-    await expect(this.saveButton).toBeEnabled();
-    await this.saveButton.click();
+    // A late form reset can disable Save again between filling and saving, so allow it to
+    // recover rather than clicking a disabled button until the test times out.
+    await expect(this.saveButton).toBeEnabled({timeout: 15_000});
+    await this.saveButton.click({timeout: 10_000});
     // Both add and edit modals close on save.
     await expect(this.addModalHeading).toBeHidden();
     await expect(this.editModalHeading).toBeHidden();

--- a/e2e/tests/iko/iko-search-field/page.ts
+++ b/e2e/tests/iko/iko-search-field/page.ts
@@ -65,7 +65,9 @@ export class IkoSearchFieldPage {
   // ─── Search field modal ─────────────────────────────────────────────
 
   get addModalHeading(): Locator {
-    return this.page.getByRole('heading', {name: 'Add search field'});
+    // Heading comes from `searchFieldsOverview.add`, renamed "Add search field" →
+    // "Create search field"; accept both so the test also passes on older builds.
+    return this.page.getByRole('heading', {name: /^(Create|Add) search field$/i});
   }
 
   get editModalHeading(): Locator {

--- a/e2e/tests/iko/iko-widget/page.ts
+++ b/e2e/tests/iko/iko-widget/page.ts
@@ -167,16 +167,28 @@ export class IkoWidgetPage {
     return key;
   }
 
-  /** Best-effort dismissal of any open wizard / divider modal. */
+  /**
+   * Best-effort dismissal of any open wizard / divider modal.
+   *
+   * Every wait here is explicitly bounded: this runs from `afterEach`, where an unbounded
+   * `click()` blocks until the whole test times out (a click on a button covered by the modal
+   * overlay never resolves), turning a passing test into a failing one. ESC is the fallback
+   * when the cancel button cannot be clicked.
+   */
   async closeAnyOpenModal(): Promise<void> {
+    const openModal = this.page.locator('cds-modal[open]');
+    if ((await openModal.count().catch(() => 0)) === 0) return;
+
     for (const cancel of [this.wizardCancelButton, this.dividerCancelButton]) {
       if (await cancel.isVisible().catch(() => false)) {
-        await cancel.click().catch(() => undefined);
-        await this.page
-          .locator('cds-modal[open]')
-          .waitFor({state: 'hidden', timeout: 5_000})
-          .catch(() => undefined);
+        await cancel.click({timeout: 3_000}).catch(() => undefined);
+        await openModal.first().waitFor({state: 'hidden', timeout: 3_000}).catch(() => undefined);
       }
+    }
+
+    if (await openModal.first().isVisible().catch(() => false)) {
+      await this.page.keyboard.press('Escape').catch(() => undefined);
+      await openModal.first().waitFor({state: 'hidden', timeout: 3_000}).catch(() => undefined);
     }
   }
 

--- a/e2e/utils/ui.utils.ts
+++ b/e2e/utils/ui.utils.ts
@@ -1,4 +1,20 @@
-import { Page, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
+
+/**
+ * Fills an input and verifies the value survives.
+ *
+ * Several Carbon modals reset their reactive form on a `setTimeout` tied to the modal
+ * animation (`resetFormAfterTimeout`), so a value typed right after the modal opens is
+ * silently wiped. Re-fill until the value sticks instead of racing the reset.
+ */
+export async function fillStable(input: Locator, value: string, settleMs = 500) {
+  await expect(async () => {
+    await expect(input).toBeEditable();
+    await input.fill(value);
+    await input.page().waitForTimeout(settleMs);
+    await expect(input).toHaveValue(value, {timeout: 1_000});
+  }).toPass({timeout: 20_000});
+}
 
 export async function expectNotificationMessage(
   page: Page,

--- a/e2e/utils/value-path-selector.utils.ts
+++ b/e2e/utils/value-path-selector.utils.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect, Locator} from '@playwright/test';
+import {VALUE_PATH_SELECTOR_TEST_IDS} from '../constants';
+
+/**
+ * Helpers for `valtimo-value-path-selector`.
+ *
+ * The component renders either a combo box (dropdown mode) or a plain text input
+ * (manual mode), switched by a Carbon toggle. Which mode it starts in depends on
+ * the surrounding configuration, so tests must never assume a default.
+ *
+ * The toggle must be clicked on its host element (`data-test-id` = toggle). Its two
+ * inner candidates are both dead ends: `.cds--toggle__switch` sits inside a
+ * `<label for="...">` pointing at a `<button>` (browsers do not forward label clicks to
+ * buttons, so the click is a silent no-op), and the `role="switch"` button itself is a
+ * 1x1px visually-hidden a11y control that Playwright cannot click.
+ */
+
+/** Switches the selector to manual mode (if it is not already) and returns the text input. */
+export async function ensureManualPathMode(selector: Locator): Promise<Locator> {
+  const input = selector.getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.input);
+  const toggle = selector.getByTestId(VALUE_PATH_SELECTOR_TEST_IDS.toggle);
+
+  await expect(async () => {
+    if ((await input.count()) === 0) {
+      await toggle.click();
+    }
+    await expect(input).toBeVisible({timeout: 2_000});
+  }).toPass({timeout: 15_000});
+
+  return input;
+}
+
+/**
+ * Switches the selector to manual mode and types a path into it.
+ *
+ * Toggling to manual mode runs a `setTimeout(detectChanges, 1)` before the input is
+ * wired to the parent form, so a value filled immediately can land before the CVA
+ * subscription is active and the required `path` control never commits (leaving the
+ * modal's save button disabled). Re-fill until the input actually holds the value.
+ */
+export async function fillValuePathManually(selector: Locator, path: string): Promise<void> {
+  const input = await ensureManualPathMode(selector);
+
+  await expect(async () => {
+    await input.fill(path);
+    await input.blur();
+    await expect(input).toHaveValue(path);
+  }).toPass({timeout: 10_000});
+}

--- a/e2e/utils/version.utils.ts
+++ b/e2e/utils/version.utils.ts
@@ -14,9 +14,25 @@
  * limitations under the License.
  */
 
-import {Page} from '@playwright/test';
+import {expect, Page} from '@playwright/test';
 
 const VERSION_DROPDOWN_TEST_ID = 'caseVersionSelectDropdown';
+
+/**
+ * Waits until the URL stops changing.
+ *
+ * Selecting a version triggers a navigation that the app follows up with a redirect to the
+ * `/general` tab. That redirect can land well after the click, so a caller that only waits for
+ * "the URL changed" may navigate somewhere else and then be thrown back to `/general` on the
+ * previously selected version — mid-test, in another test of the same describe.
+ */
+async function waitForUrlToSettle(page: Page, quietMs = 750): Promise<void> {
+  await expect(async () => {
+    const before = page.url();
+    await page.waitForTimeout(quietMs);
+    expect(page.url()).toBe(before);
+  }).toPass({timeout: 20_000});
+}
 
 async function getDropdownText(page: Page): Promise<string> {
   const dropdown = page.getByTestId(VERSION_DROPDOWN_TEST_ID);
@@ -38,18 +54,24 @@ async function getDropdownText(page: Page): Promise<string> {
  */
 export async function ensureDraftVersionSelected(page: Page): Promise<string> {
   const dropdown = page.getByTestId(VERSION_DROPDOWN_TEST_ID);
-  const selectedText = await getDropdownText(page);
 
-  if (!selectedText.includes('DRAFT')) {
-    const currentUrl = page.url();
-    await dropdown.click();
-    const draftOption = page
-      .getByRole('listbox')
-      .locator('[data-test-id^="caseVersion"]:has-text("DRAFT")')
-      .first();
-    await draftOption.click();
-    await page.waitForURL(url => url.toString() !== currentUrl);
-  }
+  await expect(async () => {
+    if (!(await getDropdownText(page)).includes('DRAFT')) {
+      const currentUrl = page.url();
+      await dropdown.click();
+      const draftOption = page
+        .getByRole('listbox')
+        .locator('[data-test-id^="caseVersion"]:has-text("DRAFT")')
+        .first();
+      await draftOption.click();
+      await page.waitForURL(url => url.toString() !== currentUrl);
+    }
+
+    // Only trust the selection once the navigation it triggers has finished: the app can still
+    // redirect afterwards, which would otherwise strand the caller on the previous version.
+    await waitForUrlToSettle(page);
+    expect(await getDropdownText(page)).toContain('DRAFT');
+  }).toPass({timeout: 60_000});
 
   return getVersionFromUrl(page);
 }
@@ -61,18 +83,22 @@ export async function ensureDraftVersionSelected(page: Page): Promise<string> {
  */
 export async function ensureFinalVersionSelected(page: Page): Promise<string> {
   const dropdown = page.getByTestId(VERSION_DROPDOWN_TEST_ID);
-  const selectedText = await getDropdownText(page);
 
-  if (selectedText.includes('DRAFT')) {
-    const currentUrl = page.url();
-    await dropdown.click();
-    const finalOption = page
-      .getByRole('listbox')
-      .locator('[data-test-id^="caseVersion"]:not(:has-text("DRAFT"))')
-      .first();
-    await finalOption.click();
-    await page.waitForURL(url => url.toString() !== currentUrl);
-  }
+  await expect(async () => {
+    if ((await getDropdownText(page)).includes('DRAFT')) {
+      const currentUrl = page.url();
+      await dropdown.click();
+      const finalOption = page
+        .getByRole('listbox')
+        .locator('[data-test-id^="caseVersion"]:not(:has-text("DRAFT"))')
+        .first();
+      await finalOption.click();
+      await page.waitForURL(url => url.toString() !== currentUrl);
+    }
+
+    await waitForUrlToSettle(page);
+    expect(await getDropdownText(page)).not.toContain('DRAFT');
+  }).toPass({timeout: 60_000});
 
   return getVersionFromUrl(page);
 }

--- a/frontend/projects/valtimo/components/src/lib/directives/valtimo-cds-modal/valtimo-cds-modal.directive.spec.html
+++ b/frontend/projects/valtimo/components/src/lib/directives/valtimo-cds-modal/valtimo-cds-modal.directive.spec.html
@@ -32,3 +32,9 @@
     }
   </div>
 </cds-modal>
+
+<!-- Separate host for the min-height behaviour: it needs a `.cds--modal-content` to write to, but
+     not a `cds-modal` element (the ESC handling above is what depends on the real tag). -->
+<div class="min-height-host" valtimoCdsModal [minContentHeight]="600">
+  <div class="cds--modal-content"></div>
+</div>

--- a/frontend/projects/valtimo/components/src/lib/directives/valtimo-cds-modal/valtimo-cds-modal.directive.spec.ts
+++ b/frontend/projects/valtimo/components/src/lib/directives/valtimo-cds-modal/valtimo-cds-modal.directive.spec.ts
@@ -39,6 +39,13 @@ describe('ValtimoCdsModalDirective', () => {
     return event;
   };
 
+  const minHeightHost = (): HTMLElement => fixture.nativeElement.querySelector('.min-height-host');
+  const minHeightContent = (): HTMLElement =>
+    minHeightHost().querySelector('.cds--modal-content') as HTMLElement;
+
+  // MutationObserver callbacks are delivered as microtasks; a macrotask tick drains them.
+  const flushMutations = () => new Promise(resolve => setTimeout(resolve));
+
   beforeEach(() => {
     TestBed.configureTestingModule({imports: [TestHostComponent]});
     fixture = TestBed.createComponent(TestHostComponent);
@@ -169,5 +176,33 @@ describe('ValtimoCdsModalDirective', () => {
     dispatchEscape();
 
     expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('applies the min-height to the modal content', () => {
+    expect(minHeightContent().style.getPropertyValue('min-height')).toContain('600px');
+  });
+
+  it('does not react to style changes, so its own write cannot feed the observer', async () => {
+    // The directive writes the min-height into the subtree it observes. If it reacted to style
+    // mutations it would answer its own write with another write — a microtask loop that freezes
+    // the page. Clearing the style must therefore go unanswered.
+    const content = minHeightContent();
+
+    // Let the deferred write from ngAfterViewInit land before measuring.
+    await flushMutations();
+    content.style.removeProperty('min-height');
+    await flushMutations();
+
+    expect(content.style.getPropertyValue('min-height')).toBe('');
+  });
+
+  it('applies the min-height to modal content added later', async () => {
+    const added = document.createElement('div');
+    added.classList.add('cds--modal-content');
+    minHeightHost().appendChild(added);
+
+    await flushMutations();
+
+    expect(added.style.getPropertyValue('min-height')).toContain('600px');
   });
 });

--- a/frontend/projects/valtimo/components/src/lib/directives/valtimo-cds-modal/valtimo-cds-modal.directive.ts
+++ b/frontend/projects/valtimo/components/src/lib/directives/valtimo-cds-modal/valtimo-cds-modal.directive.ts
@@ -26,12 +26,16 @@ import {
   RendererStyleFlags2,
 } from '@angular/core';
 
+const OPEN_ATTRIBUTE_NAME = 'ng-reflect-open';
+
 @Directive({
   selector: '[valtimoCdsModal]',
   standalone: true,
 })
 export class ValtimoCdsModalDirective implements AfterViewInit, OnDestroy {
-  @Input() public readonly minContentHeight = 0;
+  // Not `readonly`: Angular assigns inputs, and template type checking reports every binding to
+  // a read-only property as TS2540 "Cannot assign to ... because it is a read-only property".
+  @Input() public minContentHeight = 0;
 
   private _mutationObserver: MutationObserver;
 
@@ -46,14 +50,21 @@ export class ValtimoCdsModalDirective implements AfterViewInit, OnDestroy {
       this.handleMutations(mutations);
     });
 
+    // Only the open/close attribute is of interest. Observing *every* attribute would include the
+    // min-height this directive writes on the modal content below: that write mutates the observed
+    // subtree, so it would schedule another callback, which writes again — a microtask loop that
+    // starves the main thread and freezes the page. (It stayed dormant while the value was a plain
+    // `<n>px`, which the CSSOM stores verbatim, so re-writing it was a no-op that recorded no
+    // mutation. A value the browser re-serializes, such as `min(...)`, never compares equal to what
+    // was set, so every write does record one.)
     this._mutationObserver.observe(this.elementRef.nativeElement, {
       attributes: true,
+      attributeFilter: [OPEN_ATTRIBUTE_NAME],
       childList: true,
       subtree: true,
-      characterData: true,
     });
 
-    const open = this.elementRef.nativeElement.getAttribute('ng-reflect-open');
+    const open = this.elementRef.nativeElement.getAttribute(OPEN_ATTRIBUTE_NAME);
     if (open === 'true') {
       this.applyDocumentOverflowHidden();
     }
@@ -132,8 +143,6 @@ export class ValtimoCdsModalDirective implements AfterViewInit, OnDestroy {
   };
 
   private handleMutations(mutations: MutationRecord[]): void {
-    const OPEN_ATTRIBUTE_NAME = 'ng-reflect-open';
-
     for (const mutation of mutations) {
       if (mutation.type === 'attributes' && mutation.attributeName === OPEN_ATTRIBUTE_NAME) {
         const open = this.elementRef.nativeElement.getAttribute(OPEN_ATTRIBUTE_NAME);


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
Related to https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/536
Close the pull request https://github.com/valtimo-platform/valtimo/pull/798
Please test the modals as well, specially the one when starting a process inside a case

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: 

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
