### PR TITLE
cicd: rename S3 release bucket secrets

### DIFF
--- a/.github/workflows/backend_publish_release.yml
+++ b/.github/workflows/backend_publish_release.yml
@@ -221,5 +221,5 @@ jobs:
       s3_bucket: valtimo-releases
       build_artifact_name: ${{ needs.build_run_tests.outputs.build_artifact_name }}
     secrets:
-      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_ID }}
-      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_SECRET }}
+      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_ID }}
+      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_SECRET }}

--- a/.github/workflows/backend_publish_release_candidate.yml
+++ b/.github/workflows/backend_publish_release_candidate.yml
@@ -127,5 +127,5 @@ jobs:
       s3_bucket: valtimo-releases
       build_artifact_name: ${{ needs.build_run_tests.outputs.build_artifact_name }}
     secrets:
-      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_ID }}
-      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_SECRET }}
+      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_ID }}
+      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_SECRET }}


### PR DESCRIPTION
We are moving the bucket away from OVHCloud since they do not support bucket-wide public read yet. This makes the secret name misleading.