### PR TITLE
Publish backend libraries to the AWS S3 release artifacts bucket

### DIFF
--- a/.github/workflows/backend_publish_release.yml
+++ b/.github/workflows/backend_publish_release.yml
@@ -208,9 +208,10 @@ jobs:
           name: build-reports
           path: backend/build/reports
 
-  # Second leg of the dual publish: push the same release artifacts to the OVHcloud S3
-  # bucket. Runs unconditionally (no Sonatype sunset guard) so it becomes the sole publish
-  # target once Sonatype is switched off.
+  # Second leg of the dual publish: push the same release artifacts to the S3 bucket. Runs
+  # unconditionally (no Sonatype sunset guard) so it becomes the sole publish target once
+  # Sonatype is switched off. The target is spelled out here rather than inherited from the
+  # called workflow's defaults, so changing those cannot silently move a release.
   publish_s3:
     name: Publish to S3
     needs:
@@ -218,8 +219,12 @@ jobs:
     uses: ./.github/workflows/backend_publish_to_s3.yml
     with:
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}.RELEASE
-      s3_bucket: valtimo-releases
+      s3_bucket: valtimo-release-artifacts
+      s3_region: eu-west-1
+      s3_prefix: maven
+      # Native AWS S3, so no S3-compatible store endpoint.
+      s3_endpoint: ""
       build_artifact_name: ${{ needs.build_run_tests.outputs.build_artifact_name }}
     secrets:
-      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_ID }}
-      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_SECRET }}
+      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_ID }}
+      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_SECRET }}

--- a/.github/workflows/backend_publish_release_candidate.yml
+++ b/.github/workflows/backend_publish_release_candidate.yml
@@ -114,8 +114,9 @@ jobs:
           name: build-reports
           path: backend/build/reports
 
-  # Second leg of the dual publish: push the same RC artifacts to the OVHcloud S3 bucket
-  # (RCs share the valtimo-releases bucket with releases).
+  # Second leg of the dual publish: push the same RC artifacts to the S3 bucket (RCs share the
+  # valtimo-release-artifacts bucket with releases). Target spelled out rather than inherited
+  # from the called workflow's defaults, matching backend_publish_release.yml.
   publish_s3:
     name: Publish to S3
     needs:
@@ -124,8 +125,12 @@ jobs:
     uses: ./.github/workflows/backend_publish_to_s3.yml
     with:
       project_version: ${{ inputs.project_version || github.event.inputs.project_version }}
-      s3_bucket: valtimo-releases
+      s3_bucket: valtimo-release-artifacts
+      s3_region: eu-west-1
+      s3_prefix: maven
+      # Native AWS S3, so no S3-compatible store endpoint.
+      s3_endpoint: ""
       build_artifact_name: ${{ needs.build_run_tests.outputs.build_artifact_name }}
     secrets:
-      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_ID }}
-      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_OVHCLOUD_S3_BUCKET_ACCESS_KEY_SECRET }}
+      s3_access_key_id: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_ID }}
+      s3_secret_access_key: ${{ secrets.VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_SECRET }}

--- a/.github/workflows/backend_publish_to_s3.yml
+++ b/.github/workflows/backend_publish_to_s3.yml
@@ -1,11 +1,13 @@
-name: Backend - Publish to S3 (OVHcloud)
+name: Backend - Publish to S3
 
 permissions:
   contents: read
 
-# Publishes the already-built backend libraries to the Valtimo OVHcloud S3 bucket
-# (valtimo-releases, region eu-west-par). Reused by the release and release-candidate
-# pipelines; they differ only in the version string — the bucket is the same.
+# Publishes the already-built backend libraries to the Valtimo release artifacts bucket
+# (valtimo-release-artifacts in eu-west-1). Reused by the release and release-candidate
+# pipelines; they differ only in the version string. Bucket, region, key prefix and endpoint are
+# inputs: leaving s3_region set targets AWS, while passing s3_endpoint with an empty s3_region
+# targets an S3-compatible store instead.
 on:
   workflow_call:
     inputs:
@@ -14,8 +16,23 @@ on:
         required: true
         type: string
       s3_bucket:
-        description: "Target bucket (valtimo-releases)"
+        description: "Target bucket (valtimo-release-artifacts)"
         required: true
+        type: string
+      s3_region:
+        description: "AWS region of the bucket; empty for a non-AWS store, which is addressed by s3_endpoint instead"
+        required: false
+        default: eu-west-1
+        type: string
+      s3_endpoint:
+        description: "Endpoint URL of an S3-compatible store; empty targets native AWS S3"
+        required: false
+        default: ""
+        type: string
+      s3_prefix:
+        description: "Key prefix for the Maven layout inside the bucket; empty publishes to the bucket root"
+        required: false
+        default: maven
         type: string
       build_artifact_name:
         description: Name of the backend build artifact to download with 'download-artifact'
@@ -23,21 +40,25 @@ on:
         type: string
     secrets:
       s3_access_key_id:
-        description: OVHcloud S3 bucket access key ID
+        description: Access key ID for the target bucket
         required: true
       s3_secret_access_key:
-        description: OVHcloud S3 bucket secret access key
+        description: Secret access key for the target bucket
         required: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      # Gradle's `AwsCredentials` reads these standard AWS env var names. The backend
-      # publishes to the OVHcloud S3 bucket, so map the OVH release credentials into them.
+      # Gradle's `AwsCredentials` reads these standard AWS env var names, so map the target
+      # bucket's credentials into them.
       AWS_ACCESS_KEY_ID: ${{ secrets.s3_access_key_id }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.s3_secret_access_key }}
-      AWS_REGION: eu-west-par
+      # Deliberately no AWS_REGION: Gradle's S3 transport builds a legacy AWS SDK client that
+      # ignores it (it would sign for us-east-1 regardless). The region travels in the
+      # repository URL instead — see backend/gradle/publishing-module.gradle.
+      S3_REGION: ${{ inputs.s3_region }}
+      S3_ENDPOINT: ${{ inputs.s3_endpoint }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,14 +80,22 @@ jobs:
           name: ${{ inputs.build_artifact_name }}
           path: .
 
-      - name: Publish backend libraries to S3 (OVHcloud)
+      - name: Publish backend libraries to S3
         env:
           PROJECT_VERSION: ${{ inputs.project_version }}
           S3_BUCKET: ${{ inputs.s3_bucket }}
+          S3_PREFIX: ${{ inputs.s3_prefix }}
         run: |
-          ./gradlew --no-parallel publishAllPublicationsToS3Repository \
-            -PpublishToS3=true \
-            -Ps3Bucket="${S3_BUCKET}" \
-            -PprojectVersion="${PROJECT_VERSION}" \
-            -Dorg.gradle.s3.endpoint=https://s3.eu-west-par.io.cloud.ovh.net \
-            -Dorg.gradle.s3.region=eu-west-par
+          set -euo pipefail
+          args=(--no-parallel
+            publishAllPublicationsToS3Repository
+            -PpublishToS3=true
+            -Ps3Bucket="${S3_BUCKET}"
+            -Ps3Region="${S3_REGION}"
+            -Ps3Prefix="${S3_PREFIX}"
+            -PprojectVersion="${PROJECT_VERSION}")
+          # An empty value is rejected by Gradle, so omit the flag entirely to target AWS S3.
+          if [ -n "${S3_ENDPOINT}" ]; then
+            args+=("-Dorg.gradle.s3.endpoint=${S3_ENDPOINT}")
+          fi
+          ./gradlew "${args[@]}"

--- a/backend/gradle/publishing-module.gradle
+++ b/backend/gradle/publishing-module.gradle
@@ -15,11 +15,19 @@
  */
 
 def publishToS3 = project.hasProperty('publishToS3') && project.property('publishToS3') == 'true'
-// The S3 endpoint + region are supplied at invocation time via -Dorg.gradle.s3.endpoint /
-// -Dorg.gradle.s3.region, so the build works against any S3-compatible store (AWS S3,
-// OVHcloud, …) without hardcoding the host.
 // Bucket per pipeline: valtimo-releases for release/RC, valtimo-snapshots for snapshots.
 def s3Bucket = project.findProperty('s3Bucket') ?: 'valtimo-snapshots'
+// The region has to be part of the host for AWS: Gradle's S3 transport has no region property
+// (it reads only org.gradle.s3.endpoint and org.gradle.s3.maxErrorRetry) and its client ignores
+// AWS_REGION, so a bare s3://<bucket> URL is signed for us-east-1 and rejected by buckets
+// elsewhere. Leave empty for an S3-compatible store, which is addressed with
+// -Dorg.gradle.s3.endpoint at invocation time; that endpoint carries its region.
+def s3Region = project.findProperty('s3Region') ?: ''
+// Key prefix for the Maven layout, so the artifacts bucket can carry other artifact types
+// alongside it. Pass -Ps3Prefix= (empty) to publish to the bucket root.
+def s3Prefix = project.hasProperty('s3Prefix') ? project.property('s3Prefix') : 'maven'
+def s3Host = s3Region ? "${s3Bucket}.s3.${s3Region}.amazonaws.com" : s3Bucket
+def s3Url = s3Prefix ? "s3://${s3Host}/${s3Prefix}" : "s3://${s3Host}"
 def sonatypeCentralStagingDir = uri("build/staging-deploy")
 def signingConfigSet = false
 if(System.getenv('SIGNING_KEY_BASE64') &&
@@ -51,7 +59,7 @@ publishing {
                     accessKey System.getenv('AWS_ACCESS_KEY_ID')
                     secretKey System.getenv('AWS_SECRET_ACCESS_KEY')
                 }
-                url = uri("s3://${s3Bucket}")
+                url = uri(s3Url)
             }
         }
     }

--- a/backend/gradle/publishing-module.gradle
+++ b/backend/gradle/publishing-module.gradle
@@ -15,7 +15,7 @@
  */
 
 def publishToS3 = project.hasProperty('publishToS3') && project.property('publishToS3') == 'true'
-// Bucket per pipeline: valtimo-releases for release/RC, valtimo-snapshots for snapshots.
+// Bucket per pipeline: valtimo-release-artifacts for release/RC, valtimo-snapshots for snapshots.
 def s3Bucket = project.findProperty('s3Bucket') ?: 'valtimo-snapshots'
 // The region has to be part of the host for AWS: Gradle's S3 transport has no region property
 // (it reads only org.gradle.s3.endpoint and org.gradle.s3.maxErrorRetry) and its client ignores

--- a/backend/gradle/publishing-module.gradle
+++ b/backend/gradle/publishing-module.gradle
@@ -26,6 +26,9 @@ def s3Region = project.findProperty('s3Region') ?: ''
 // Key prefix for the Maven layout, so the artifacts bucket can carry other artifact types
 // alongside it. Pass -Ps3Prefix= (empty) to publish to the bucket root.
 def s3Prefix = project.hasProperty('s3Prefix') ? project.property('s3Prefix') : 'maven'
+// The amazonaws.com host is required, not a preference: it is the only shape Gradle's
+// S3RegionalResource matches to pull a region out of the URL. Any other domain here makes it fall
+// back to treating the entire host as the bucket name.
 def s3Host = s3Region ? "${s3Bucket}.s3.${s3Region}.amazonaws.com" : s3Bucket
 def s3Url = s3Prefix ? "s3://${s3Host}/${s3Prefix}" : "s3://${s3Host}"
 def sonatypeCentralStagingDir = uri("build/staging-deploy")

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -197,6 +197,7 @@
 * [Release notes](release-notes/release-notes.md)
 * [13.x.x](release-notes/13.x.x/)
   * [13.40.0](release-notes/13.x.x/13.40.0/README.md)
+    * [Backend migration](release-notes/13.x.x/13.40.0/back-end-migration.md)
   * [13.39.0](release-notes/13.x.x/13.39.0/README.md)
     * [Backend migration](release-notes/13.x.x/13.39.0/back-end-migration.md)
   * [13.38.0](release-notes/13.x.x/13.38.0/README.md)

--- a/documentation/release-notes/13.x.x/13.39.0/back-end-migration.md
+++ b/documentation/release-notes/13.x.x/13.39.0/back-end-migration.md
@@ -6,6 +6,12 @@ releases published after that date are available only from S3 (versions already 
 Central stay there). To keep resolving Valtimo
 dependencies, update your Gradle build before then:
 
+{% hint style="warning" %}
+The bucket below is being decommissioned. From 13.40.0 the libraries are published to a different
+bucket — follow the [13.40.0 backend migration](../13.40.0/back-end-migration.md) instead. 13.39.0
+itself also remains available from Maven Central.
+{% endhint %}
+
 1. In your `build.gradle.kts`, add the S3 release bucket to the `repositories { }` block:
 
    ```kotlin

--- a/documentation/release-notes/13.x.x/13.40.0/back-end-migration.md
+++ b/documentation/release-notes/13.x.x/13.40.0/back-end-migration.md
@@ -1,0 +1,22 @@
+# Backend migration
+
+From this version the Valtimo backend libraries are published to the
+`valtimo-release-artifacts` S3 bucket. The bucket used for 13.39.0 is being decommissioned and
+does not receive 13.40.0 or later, so replace that repository entry if you added one.
+
+Publishing to Sonatype Central (Maven Central) still stops on **10 August 2026**; releases
+published after that date are available only from S3 (versions already on Maven Central stay
+there). To keep resolving Valtimo dependencies, update your Gradle build before then:
+
+1. In your `build.gradle.kts`, use the following repository in the `repositories { }` block,
+   replacing the 13.39.0 entry if you already added one:
+
+   ```kotlin
+   maven { url = uri("https://valtimo-release-artifacts.s3.eu-west-1.amazonaws.com/maven/") }
+   ```
+
+2. Build your project and confirm the Valtimo dependencies still resolve.
+3. After 10 August 2026, remove the old `s01.oss.sonatype.org` repositories if you no longer
+   need them.
+
+No credentials are required — the libraries are served over plain HTTPS.


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: _n/a_

From 13.40.0 the backend libraries are published to the AWS bucket `valtimo-release-artifacts`
(eu-west-1) under a `maven/` key prefix, instead of the OVHcloud bucket that is being
decommissioned. Bucket, region, key prefix and endpoint are now workflow inputs, and both callers
pass all of them explicitly so changing a default cannot silently move a release.

Specify the code branch location: `next-minor`

**Relevant comments:**
> Three things were verified against the Gradle 8.14 distribution the build uses, and they shaped
> this diff:
>
> 1. **The region cannot be passed as a property or env var.** `S3ConnectionProperties` reads only
> `org.gradle.s3.endpoint` and `org.gradle.s3.maxErrorRetry` — the `-Dorg.gradle.s3.region` flag
> that was in the workflow never existed. Worse, `S3Client` builds
> `new AmazonS3Client(credentials, clientConfiguration)`, the legacy SDK v1 constructor, which
> ignores `AWS_REGION`: with it set to a real region that client still resolves to endpoint
> `https://s3.amazonaws.com` and region `us-east-1` (checked by running the SDK jars from the
> distribution). A bare `s3://<bucket>` URL would therefore be signed for us-east-1 and rejected by
> a bucket elsewhere. The region is instead carried in the host —
> `s3://<bucket>.s3.<region>.amazonaws.com/<prefix>` — which `S3RegionalResource` does parse, after
> which `configureClient` calls `setRegion(...)` and signs correctly. Both the dead flag and the
> `AWS_REGION` env var are gone.
> 2. **Key prefixes are supported.** Everything after the bucket in the URL becomes the object key,
> and listing is prefix-relative, so `maven/` keeps the Maven layout in its own namespace inside the
> artifacts bucket.
> 3. **No object ACL handling is needed.** Gradle hardcodes the `bucket-owner-full-control` canned
> ACL with no hook to change it, which is exactly the one AWS still accepts on buckets where ACLs
> are disabled (`bucket-owner-enforced`, the default). Public read is a bucket-policy concern, so
> nothing in the pipeline touches ACLs.
>
> **Two prerequisites before this can run green:**
> - Repository secrets `VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_ID` and
> `VALTIMO_RELEASE_S3_BUCKET_ACCESS_KEY_SECRET` must exist, holding a key that can write to
> `valtimo-release-artifacts`.
> - That bucket needs anonymous `s3:GetObject` on `maven/*` (Block Public Access off, policy in
> place), otherwise consumers get 403 on the URL documented for 13.40.0.

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

Consumers must change their repository URL, but that is a release-note migration step rather than
an API change; the previous URL keeps serving 13.39.0, which also remains on Maven Central.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [x] Yes

`documentation/release-notes/13.x.x/13.40.0/back-end-migration.md` tells consumers to switch to
`https://valtimo-release-artifacts.s3.eu-west-1.amazonaws.com/maven/`, is registered in
`SUMMARY.md`, and the 13.39.0 note now warns that its bucket is being decommissioned.

### Tests
Unit tests have been added that cover these changes
- [x] Not applicable

Integration tests have been added that cover these changes
- [x] Not applicable

Describe the testing steps
- [x] Step 1 — resolved repository URL is correct per configuration: with `-Ps3Region` set it is
`s3://valtimo-release-artifacts.s3.eu-west-1.amazonaws.com/maven`; without it,
`s3://valtimo-release-artifacts/maven`; with an empty `-Ps3Prefix`, the bucket root.
- [x] Step 2 — `./gradlew :backend:core:tasks --group=publishing -PpublishToS3=true` still lists
`publishAllPublicationsToS3Repository`; all three workflows parse as YAML and every `run:` block
passes `bash -n`.
- [ ] Step 3 — end-to-end: run the release-candidate pipeline on a throwaway RC, then confirm
`aws s3 ls s3://valtimo-release-artifacts/maven/com/ritense/valtimo/core/<version>/`, an anonymous
`curl` of the `.pom` returning 200, and a scratch Gradle project resolving
`com.ritense.valtimo:core:<version>` from the new URL only. Needs the secrets and bucket policy
above, so it could not be run here.

### Security
The Secure by Design principle has been applied to these changes
- [x] Yes

All inputs reach `run:` blocks through `env:` and are quoted; no untrusted event data is
interpolated. The publish job keeps `permissions: contents: read` and `persist-credentials: false`.

Added or changed REST API endpoints have authentication and authorization in place
- [x] Not applicable

Valtimo access control checks have been implemented
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [x] Not applicable
