### PR TITLE
chore: bump freemarker plugin to 8.5.2

### DIFF
--- a/frontend/release-plugins.json
+++ b/frontend/release-plugins.json
@@ -1,4 +1,4 @@
 {
-  "@valtimo-plugins/freemarker": "8.5.1",
+  "@valtimo-plugins/freemarker": "8.5.2",
   "@valtimo-plugins/smtpmail": "2.0.6"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -100,5 +100,5 @@ semver4jVersion=5.6.0
 
 projectVersion=13.1.3
 
-freemarkerPluginVersion=8.5.1
+freemarkerPluginVersion=8.5.2
 smtpmailPluginVersion=2.0.6


### PR DESCRIPTION
Bumps the freemarker plugin from 8.5.1 to 8.5.2 in `gradle.properties` and `frontend/release-plugins.json`.