### PR TITLE
Feature/external plugin security hardening

### DIFF
--- a/backend/core/src/main/resources/config/liquibase/13-32-0/13-32-0-master.xml
+++ b/backend/core/src/main/resources/config/liquibase/13-32-0/13-32-0-master.xml
@@ -31,5 +31,6 @@ xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liqui
     <include file="20260720-plugin-configuration-reference-external-plugin-version.xml" relativeToChangelogFile="true"/>
     <include file="20260720-plugin-action-result-mappings.xml" relativeToChangelogFile="true"/>
     <include file="20260728-add-case-external-plugin-tab-plugin-definition.xml" relativeToChangelogFile="true"/>
+    <include file="20260806-external-plugin-security-hardening.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/backend/core/src/main/resources/config/liquibase/13-32-0/20260806-external-plugin-security-hardening.xml
+++ b/backend/core/src/main/resources/config/liquibase/13-32-0/20260806-external-plugin-security-hardening.xml
@@ -1,0 +1,38 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
+                   logicalFilePath="config/liquibase/13-32-0/20260806-external-plugin-security-hardening.xml">
+
+    <changeSet id="1" author="Ritense">
+        <addColumn tableName="external_plugin_definition">
+            <column name="content_hash" type="VARCHAR(128)"/>
+            <column name="pending_content_hash" type="VARCHAR(128)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="2" author="Ritense">
+        <addColumn tableName="external_plugin_configuration">
+            <column name="token_generation" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/autoconfigure/ExternalPluginAutoConfiguration.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/autoconfigure/ExternalPluginAutoConfiguration.kt
@@ -222,16 +222,20 @@ class ExternalPluginAutoConfiguration {
         @Value("\${valtimo.plugin.encryption-secret}") secret: String,
     ) = ExternalPluginServiceTokenKeyProvider(secret)
 
+    // 10-minute default: the discovery poll (60s) re-pushes a fresh token every cycle, so a short
+    // TTL costs nothing operationally while capping how long a leaked token stays usable.
     @Bean
     @ConditionalOnMissingBean(ExternalPluginServiceTokenService::class)
     fun externalPluginServiceTokenService(
         keyProvider: ExternalPluginServiceTokenKeyProvider,
-        @Value("\${valtimo.external-plugin.service-token.ttl:PT24H}") tokenTtl: String,
+        @Value("\${valtimo.external-plugin.service-token.ttl:PT10M}") tokenTtl: String,
     ) = ExternalPluginServiceTokenService(keyProvider, DurationStyle.detectAndParse(tokenTtl))
 
     @Bean
     @ConditionalOnMissingBean(ExternalPluginServiceTokenAuthenticator::class)
-    fun externalPluginServiceTokenAuthenticator() = ExternalPluginServiceTokenAuthenticator()
+    fun externalPluginServiceTokenAuthenticator(
+        configurationRepository: ExternalPluginConfigurationRepository,
+    ) = ExternalPluginServiceTokenAuthenticator(configurationRepository)
 
     @Bean
     @ConditionalOnMissingBean(ExternalPluginEndpointAllowlistFilter::class)
@@ -261,7 +265,9 @@ class ExternalPluginAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(ExternalPluginUserTokenAuthenticator::class)
-    fun externalPluginUserTokenAuthenticator() = ExternalPluginUserTokenAuthenticator()
+    fun externalPluginUserTokenAuthenticator(
+        configurationRepository: ExternalPluginConfigurationRepository,
+    ) = ExternalPluginUserTokenAuthenticator(configurationRepository)
 
     @Bean
     @ConditionalOnMissingBean(ExternalPluginUserTokenFilter::class)
@@ -299,9 +305,15 @@ class ExternalPluginAutoConfiguration {
     @ConditionalOnMissingBean(ExternalPluginUserTokenResource::class)
     fun externalPluginUserTokenResource(
         configurationRepository: ExternalPluginConfigurationRepository,
+        definitionRepository: ExternalPluginDefinitionRepository,
         grantedEndpointRepository: ExternalPluginGrantedEndpointRepository,
         userTokenService: ExternalPluginUserTokenService,
-    ) = ExternalPluginUserTokenResource(configurationRepository, grantedEndpointRepository, userTokenService)
+    ) = ExternalPluginUserTokenResource(
+        configurationRepository,
+        definitionRepository,
+        grantedEndpointRepository,
+        userTokenService,
+    )
 
     @Bean
     @ConditionalOnMissingBean(ExternalPluginUserTokenIntrospectionResource::class)

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/client/ExternalPluginHostClient.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/client/ExternalPluginHostClient.kt
@@ -79,6 +79,12 @@ class ExternalPluginHostClient(
         properties: ObjectNode,
         serviceToken: String,
         gzacBaseUrl: String,
+        /**
+         * The package content hash GZAC pinned at discovery. The host verifies its loaded package
+         * still matches before accepting the push (409 otherwise), so a config and its fresh
+         * service token can never reach plugin code that differs from what the admin accepted.
+         */
+        expectedContentHash: String? = null,
         /** The CloudEvent types the admin granted. The host uses this list — not the manifest. */
         eventSubscriptions: List<String>,
         grantedCapabilities: List<String> = emptyList(),
@@ -104,6 +110,7 @@ class ExternalPluginHostClient(
             set<ObjectNode>("properties", properties)
             put("serviceToken", serviceToken)
             put("gzacBaseUrl", gzacBaseUrl)
+            if (!expectedContentHash.isNullOrBlank()) put("expectedContentHash", expectedContentHash)
             // Authoritative subscription list — replaces whatever the manifest declares.
             set<ObjectNode>("eventSubscriptions", objectMapper.createArrayNode().apply {
                 eventSubscriptions.forEach { add(it) }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/client/ExternalPluginHostClient.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/client/ExternalPluginHostClient.kt
@@ -233,9 +233,16 @@ class ExternalPluginHostClient(
         adminToken: String,
         fileName: String,
         fileBytes: ByteArray,
+        /**
+         * Replace an existing pluginId@version. Only sent after an admin explicitly confirmed the
+         * overwrite (permission re-review, §11); without it the host refuses a duplicate with 409.
+         */
+        overwrite: Boolean = false,
     ): JsonNode {
         val path = "/api/host/plugins"
-        val uri = buildUri(baseUrl, path)
+        // The query string is deliberately not signature-bound — the host strips it before HMAC
+        // verification (same convention as getConfigurationLogs).
+        val uri = buildUri(baseUrl, if (overwrite) "$path?overwrite=true" else path)
         val resource = object : ByteArrayResource(fileBytes) {
             override fun getFilename(): String = fileName
         }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/compatibility/PluginPackageInspector.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/compatibility/PluginPackageInspector.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.externalplugin.compatibility
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.ByteArrayInputStream
@@ -43,6 +44,21 @@ data class PluginCompatibilityRange(
 class PluginPackageInspector(
     private val objectMapper: ObjectMapper,
 ) {
+
+    /**
+     * The package's full parsed `manifest.json`, or null when it is absent or unreadable. Used by
+     * the upload endpoint's overwrite flow to show the package's requested permissions for
+     * re-review and to reset grants to the newly declared sets after a confirmed overwrite.
+     */
+    fun readManifest(zipBytes: ByteArray): JsonNode? {
+        val manifestBytes = readManifestBytes(zipBytes) ?: return null
+        return try {
+            objectMapper.readTree(manifestBytes)
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse manifest.json from uploaded plugin package" }
+            null
+        }
+    }
 
     fun readCompatibilityRange(zipBytes: ByteArray): PluginCompatibilityRange? {
         val manifestBytes = readManifestBytes(zipBytes) ?: return null

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/domain/ExternalPluginConfiguration.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/domain/ExternalPluginConfiguration.kt
@@ -46,4 +46,13 @@ class ExternalPluginConfiguration(
 
     @Column(name = "created_at", nullable = false)
     val createdAt: Instant = Instant.now(),
+
+    /**
+     * Revocation counter for the tokens minted for this configuration. Every issued service/user
+     * token carries the generation it was minted under; a token only validates while its generation
+     * matches this value. Bumping the counter therefore kills every outstanding token instantly —
+     * the discovery cycle re-pushes a fresh token of the new generation to the host.
+     */
+    @Column(name = "token_generation", nullable = false)
+    var tokenGeneration: Long = 0,
 )

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/domain/ExternalPluginDefinition.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/domain/ExternalPluginDefinition.kt
@@ -85,4 +85,24 @@ class ExternalPluginDefinition(
 
     @Column(name = "consecutive_misses", nullable = false)
     var consecutiveMisses: Int = 0,
-)
+
+    /**
+     * The package content hash (manifest + wasm + frontend bundles) pinned at discovery. What runs
+     * on the host is only trusted while it still matches this value.
+     */
+    @Column(name = "content_hash")
+    var contentHash: String? = null,
+
+    /**
+     * Set when discovery finds the host serving *different* content under this pluginId@version
+     * than what was pinned. While set, configuration pushes, plugin invocations and user-token
+     * minting are withheld until an admin explicitly re-accepts the new content.
+     */
+    @Column(name = "pending_content_hash")
+    var pendingContentHash: String? = null,
+) {
+
+    /** True when the host's package changed after acceptance and an admin has not re-accepted it. */
+    val requiresReacceptance: Boolean
+        get() = pendingContentHash != null
+}

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/processlink/ExternalPluginServiceTaskStartListener.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/processlink/ExternalPluginServiceTaskStartListener.kt
@@ -76,6 +76,7 @@ class ExternalPluginServiceTaskStartListener(
         val configuration = configurationService.get(configurationId)
         val definition = definitionService.get(configuration.definitionId)
         validateResolvedDefinition(processLink, definition)
+        requireAcceptedContent(definition, processLink)
         val host = hostService.get(definition.hostId)
         val hostSecret = hostService.decryptedSecret(host)
 
@@ -314,6 +315,21 @@ class ExternalPluginServiceTaskStartListener(
      * plugin's real error code and message. See [ExternalPluginActionFailedException] for why this
      * is a plain exception and not a BpmnError.
      */
+    /**
+     * A definition whose host package changed after acceptance must not be invoked: what would run
+     * is not what the admin accepted. Fails the invocation (surfacing as a process incident) until
+     * an admin re-accepts the new content.
+     */
+    private fun requireAcceptedContent(definition: ExternalPluginDefinition, processLink: ExternalPluginProcessLink) {
+        if (definition.requiresReacceptance) {
+            val message = "External plugin '${definition.pluginId}@${definition.version}' action " +
+                "'${processLink.actionKey}' was not invoked: the plugin package changed on its host " +
+                "and awaits re-acceptance by an administrator"
+            logger.warn { message }
+            throw ExternalPluginActionFailedException(CONTENT_CHANGED_ERROR_CODE, message)
+        }
+    }
+
     private fun actionFailed(
         response: ExternalPluginHostClient.ActionResponse,
         definition: ExternalPluginDefinition,
@@ -332,6 +348,9 @@ class ExternalPluginServiceTaskStartListener(
     }
 
     companion object {
+        /** Error code raised when an invocation is blocked pending content re-acceptance. */
+        const val CONTENT_CHANGED_ERROR_CODE = "EXTERNAL_PLUGIN_CONTENT_CHANGED"
+
         private val logger = KotlinLogging.logger {}
     }
 }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/processlink/ExternalPluginTaskFormSubmissionService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/processlink/ExternalPluginTaskFormSubmissionService.kt
@@ -99,6 +99,26 @@ class ExternalPluginTaskFormSubmissionService(
         )
         val task = requireCompleteTaskPermission(taskInstanceId)
 
+        // The host serves the bundle (and would run the submit hook) from its *current* package —
+        // when that package no longer matches the accepted content, nothing of this plugin may
+        // execute, so the submission is refused rather than the hook silently skipped.
+        val definition = definitionService.get(
+            configurationService.get(processLink.externalPluginConfigurationId).definitionId
+        )
+        if (definition.requiresReacceptance) {
+            logger.warn {
+                "Refusing task-form submission for external plugin " +
+                    "'${definition.pluginId}@${definition.version}': the plugin package changed on its " +
+                    "host and awaits re-acceptance"
+            }
+            return ExternalPluginTaskFormSubmissionResult(
+                errors = listOf(
+                    "The plugin '${definition.pluginId}@${definition.version}' changed on its host and " +
+                        "awaits re-acceptance by an administrator"
+                )
+            )
+        }
+
         // Level 1 — hand the raw submission to the plugin to validate/transform first, if declared.
         val effectiveSubmission = when (val hook = resolveSubmitHook(processLink)) {
             null -> submission

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginHttpSecurityConfigurer.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginHttpSecurityConfigurer.kt
@@ -42,6 +42,7 @@ class ExternalPluginHttpSecurityConfigurer : HttpSecurityConfigurer {
                     .requestMatchers(antMatcher(POST, "/api/management/v1/external-plugin/host/*/upload")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(GET, "/api/management/v1/external-plugin/definition")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(GET, "/api/management/v1/external-plugin/definition/*")).hasAuthority(ADMIN)
+                    .requestMatchers(antMatcher(POST, "/api/management/v1/external-plugin/definition/*/accept-content")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(GET, "/api/management/v1/external-plugin/configuration")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(GET, "/api/management/v1/external-plugin/configuration/*")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(GET, "/api/management/v1/external-plugin/configuration/*/usages")).hasAuthority(ADMIN)
@@ -49,6 +50,7 @@ class ExternalPluginHttpSecurityConfigurer : HttpSecurityConfigurer {
                     .requestMatchers(antMatcher(POST, "/api/management/v1/external-plugin/configuration")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(PUT, "/api/management/v1/external-plugin/configuration/*")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(DELETE, "/api/management/v1/external-plugin/configuration/*")).hasAuthority(ADMIN)
+                    .requestMatchers(antMatcher(POST, "/api/management/v1/external-plugin/configuration/*/revoke-tokens")).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(POST, "/api/management/v1/external-plugin/endpoint-descriptions")).hasAuthority(ADMIN)
                     // Non-management: any authenticated user may mint a downscoped user token for a
                     // plugin tab — the result is always bounded by PBAC ∩ the plugin's allowlist.

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenAuthenticator.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenAuthenticator.kt
@@ -16,16 +16,20 @@
 
 package com.ritense.externalplugin.security
 
+import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_CONFIG_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_VERSION_CLAIM
+import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.TOKEN_GENERATION_CLAIM
 import com.ritense.valtimo.contract.security.jwt.TokenAuthenticator
 import io.jsonwebtoken.Claims
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import java.util.UUID
 
-class ExternalPluginServiceTokenAuthenticator : TokenAuthenticator {
+class ExternalPluginServiceTokenAuthenticator(
+    private val configurationRepository: ExternalPluginConfigurationRepository,
+) : TokenAuthenticator {
 
     override fun supports(claims: Claims): Boolean =
         claims[ExternalPluginServiceTokenKeyProvider.TYPE_CLAIM] ==
@@ -39,11 +43,39 @@ class ExternalPluginServiceTokenAuthenticator : TokenAuthenticator {
         val pluginVersion = claims.get(PLUGIN_VERSION_CLAIM, String::class.java)
             ?: error("$PLUGIN_VERSION_CLAIM claim missing on external plugin service token")
 
+        requireCurrentTokenGeneration(configurationRepository, claims, UUID.fromString(configId))
+
         val principal = ExternalPluginServicePrincipal(
             pluginConfigId = UUID.fromString(configId),
             pluginId = pluginId,
             pluginVersion = pluginVersion,
         )
         return UsernamePasswordAuthenticationToken(principal, jwt, emptyList())
+    }
+
+    companion object {
+
+        /**
+         * Rejects a token whose generation is not the configuration's *current* one. This is the
+         * revocation mechanism: signature and expiry alone would keep a leaked token alive for its
+         * full TTL, whereas bumping the configuration's generation kills every outstanding token on
+         * the next use. A token for a configuration that no longer exists is rejected on the same
+         * grounds, and so is a token without the claim (pre-hardening tokens die at upgrade; the
+         * discovery cycle re-pushes fresh ones within a polling tick).
+         */
+        fun requireCurrentTokenGeneration(
+            configurationRepository: ExternalPluginConfigurationRepository,
+            claims: Claims,
+            configId: UUID,
+        ) {
+            val tokenGeneration = (claims[TOKEN_GENERATION_CLAIM] as? Number)?.toLong()
+                ?: error("$TOKEN_GENERATION_CLAIM claim missing on external plugin token")
+            val configuration = configurationRepository.findById(configId).orElse(null)
+                ?: error("external plugin configuration $configId no longer exists")
+            check(tokenGeneration == configuration.tokenGeneration) {
+                "external plugin token for configuration $configId was revoked " +
+                    "(token generation $tokenGeneration, current ${configuration.tokenGeneration})"
+            }
+        }
     }
 }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginUserTokenAuthenticator.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginUserTokenAuthenticator.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.externalplugin.security
 
+import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
 import com.ritense.externalplugin.service.ExternalPluginUserTokenService.Companion.PLUGIN_CONFIG_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginUserTokenService.Companion.ROLES_CLAIM
 import com.ritense.valtimo.contract.security.jwt.TokenAuthenticator
@@ -29,8 +30,16 @@ import java.util.UUID
  * Rebuilds a *real user* [Authentication] from an external-plugin user token. The authorities are the
  * roles frozen into the token, so `SecurityUtils.getCurrentUserRoles()` (and therefore PBAC) sees the
  * user's actual roles — no Keycloak round-trip required for the (≤15 min) lifetime of the token.
+ *
+ * Like the service-token path, the token's generation claim must match the configuration's current
+ * [com.ritense.externalplugin.domain.ExternalPluginConfiguration.tokenGeneration] — revoking a
+ * configuration's tokens kills outstanding user tokens too, including their use against the host's
+ * `/data` route (the introspection endpoint authenticates with the token under introspection, so a
+ * revoked token no longer introspects successfully either).
  */
-class ExternalPluginUserTokenAuthenticator : TokenAuthenticator {
+class ExternalPluginUserTokenAuthenticator(
+    private val configurationRepository: ExternalPluginConfigurationRepository,
+) : TokenAuthenticator {
 
     override fun supports(claims: Claims): Boolean =
         claims[ExternalPluginUserTokenKeyProvider.TYPE_CLAIM] ==
@@ -41,6 +50,12 @@ class ExternalPluginUserTokenAuthenticator : TokenAuthenticator {
             ?: error("subject claim missing on external plugin user token")
         val configId = claims.get(PLUGIN_CONFIG_ID_CLAIM, String::class.java)
             ?: error("$PLUGIN_CONFIG_ID_CLAIM claim missing on external plugin user token")
+
+        ExternalPluginServiceTokenAuthenticator.requireCurrentTokenGeneration(
+            configurationRepository,
+            claims,
+            UUID.fromString(configId),
+        )
 
         @Suppress("UNCHECKED_CAST")
         val roles = (claims[ROLES_CLAIM] as? List<String>) ?: emptyList()

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationService.kt
@@ -326,6 +326,84 @@ class ExternalPluginConfigurationService(
     }
 
     /**
+     * Applies an admin-confirmed overwrite of an existing plugin version (§11): the admin
+     * re-reviewed the uploaded package's requested permissions in the upload flow, so the new
+     * package hash is pinned as the accepted content and every configuration of the definition is
+     * re-granted to **exactly** the new manifest's declared endpoint/event/capability sets — the
+     * same all-or-nothing footprint the activation screen grants. The subsequent discovery cycle
+     * refreshes the stored manifest (the hash now matches the pin) and pushes the new grants.
+     *
+     * A definition GZAC never discovered is a no-op: discovery will pin the uploaded content on
+     * first sight and there are no configurations to re-grant.
+     */
+    @Transactional
+    fun applyApprovedOverwrite(pluginId: String, version: String, contentHash: String?, manifest: JsonNode?) {
+        val definition = definitionRepository.findByPluginIdAndVersion(pluginId, version) ?: return
+
+        if (contentHash != null) {
+            definition.contentHash = contentHash
+            definition.pendingContentHash = null
+            definitionRepository.save(definition)
+        }
+        if (manifest == null) return
+
+        val declaredEndpoints = declaredEndpoints(manifest)
+        val declaredEvents = declaredEvents(manifest)
+        val declaredCapabilities = declaredCapabilities(manifest)
+
+        configurationRepository.findAllByDefinitionId(definition.id).forEach { configuration ->
+            grantedEndpointRepository.deleteAllByConfigurationId(configuration.id)
+            grantedEventRepository.deleteAllByConfigurationId(configuration.id)
+            grantedCapabilityRepository.deleteAllByConfigurationId(configuration.id)
+            // Flush the deletes before re-inserting — same unique-constraint ordering concern as
+            // in [update].
+            grantedEndpointRepository.flush()
+            grantedEventRepository.flush()
+            grantedCapabilityRepository.flush()
+            saveGrantedEndpoints(configuration.id, declaredEndpoints)
+            saveGrantedEvents(configuration.id, declaredEvents)
+            saveGrantedCapabilities(configuration.id, declaredCapabilities)
+            logger.info {
+                "Re-granted configuration ${configuration.id} to the overwritten manifest of " +
+                    "'$pluginId@$version' (${declaredEndpoints.size} endpoints, " +
+                    "${declaredEvents.size} events, ${declaredCapabilities.size} capabilities)"
+            }
+        }
+    }
+
+    private fun declaredEndpoints(manifest: JsonNode): List<GrantedEndpointEntry> {
+        val declared = manifest.get("permissions")?.get("endpoints") ?: return emptyList()
+        if (!declared.isArray) return emptyList()
+        return declared.mapNotNull { endpoint ->
+            val method = endpoint.get("method")?.asText()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val pattern = endpoint.get("pattern")?.asText()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            GrantedEndpointEntry(method, pattern)
+        }
+    }
+
+    private fun declaredEvents(manifest: JsonNode): List<GrantedEventEntry> {
+        val declared = manifest.get("eventSubscriptions") ?: return emptyList()
+        if (!declared.isArray) return emptyList()
+        return declared.mapNotNull { it.asText().takeIf { s -> s.isNotBlank() } }.map(::GrantedEventEntry)
+    }
+
+    private fun declaredCapabilities(manifest: JsonNode): List<ExternalPluginCapability> {
+        val declared = manifest.get("permissions")?.get("capabilities") ?: return emptyList()
+        if (!declared.isArray) return emptyList()
+        return declared.mapNotNull { capability ->
+            val value = capability.asText().takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            try {
+                ExternalPluginCapability.fromValue(value)
+            } catch (e: IllegalArgumentException) {
+                // Unknown to this GZAC version — grant what is known rather than failing after the
+                // host has already replaced the package; the host-side guard denies the rest anyway.
+                logger.warn { "Skipping unknown capability '$value' while re-granting after overwrite: ${e.message}" }
+                null
+            }
+        }
+    }
+
+    /**
      * Mirrors [ExternalPluginHostService.findUsages] but scoped to a single configuration. Used
      * by the management UI to disable the delete control proactively; the server-side guard in
      * [delete] still enforces the same invariant, so an empty list here does not authorise

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationService.kt
@@ -189,6 +189,16 @@ class ExternalPluginConfigurationService(
         definition: ExternalPluginDefinition,
         host: ExternalPluginHost,
     ): Boolean {
+        if (definition.requiresReacceptance) {
+            // Central guard — every push path (create, update, discovery re-sync, token revocation)
+            // funnels through here. No push means no fresh service token for plugin code that
+            // differs from what the admin accepted.
+            logger.warn {
+                "Refusing to push configuration ${configuration.id}: plugin " +
+                    "'${definition.pluginId}@${definition.version}' changed on its host and awaits re-acceptance"
+            }
+            return false
+        }
         val adminToken = encryptionService.decrypt(host.secret)
         val decrypted = decryptedProperties(configuration)
         val serviceToken = serviceTokenService.issue(configuration, definition)
@@ -212,6 +222,9 @@ class ExternalPluginConfigurationService(
             properties = decrypted,
             serviceToken = serviceToken,
             gzacBaseUrl = host.gzacCallbackBaseUrl ?: fallbackGzacBaseUrl,
+            // The pinned package hash rides along; the host refuses the push (409) if the package
+            // on disk no longer matches, closing the window between discovery and this push.
+            expectedContentHash = definition.contentHash,
             eventSubscriptions = grantedEventTypes,
             grantedCapabilities = grantedCaps,
             grantedEndpoints = grantedEndpointPairs,
@@ -282,6 +295,33 @@ class ExternalPluginConfigurationService(
         // Push the updated decrypted config to the plugin host after commit (never inside the tx).
         pushToHostAfterCommit(saved, definition)
 
+        return saved
+    }
+
+    /**
+     * Revokes every outstanding token (service *and* user) minted for this configuration by
+     * bumping its generation counter: tokens carry the generation they were minted under and only
+     * validate while it matches. After the bump commits, a fresh push hands the host a new token of
+     * the new generation, so a *legitimate* host recovers instantly while every leaked or hoarded
+     * token is dead. If the push cannot happen (host down, or the definition awaits content
+     * re-acceptance) the discovery cycle re-pushes on its next tick — or withholds, which is then
+     * exactly the intent.
+     */
+    @Transactional
+    fun revokeTokens(id: UUID): ExternalPluginConfiguration {
+        val config = configurationRepository.findById(id)
+            .orElseThrow { ExternalPluginNotFoundException("External plugin configuration", id) }
+        val definition = definitionRepository.findById(config.definitionId)
+            .orElseThrow { ExternalPluginNotFoundException("External plugin definition", config.definitionId) }
+
+        config.tokenGeneration += 1
+        val saved = configurationRepository.save(config)
+        logger.info {
+            "Revoked all tokens for external plugin configuration $id " +
+                "(new token generation ${saved.tokenGeneration})"
+        }
+
+        pushToHostAfterCommit(saved, definition)
         return saved
     }
 

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginDefinitionService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginDefinitionService.kt
@@ -38,4 +38,27 @@ class ExternalPluginDefinitionService(
 
     fun getAllByPluginId(pluginId: String): List<ExternalPluginDefinition> =
         definitionRepository.findAllByPluginId(pluginId)
+
+    /**
+     * Re-pins a definition whose host package changed after acceptance. The caller must echo the
+     * exact pending hash it reviewed: this is acceptance of a *specific* package, not of "whatever
+     * the host happens to serve by now" — if the host changed again since the admin looked, the
+     * echoed hash no longer matches and the request is rejected until the newest state is reviewed.
+     */
+    @Transactional
+    fun acceptContent(id: UUID, contentHash: String): ExternalPluginDefinition {
+        val definition = get(id)
+        val pending = definition.pendingContentHash
+            ?: throw IllegalStateException(
+                "External plugin definition ${definition.pluginId}@${definition.version} " +
+                    "has no pending content change to accept"
+            )
+        require(contentHash == pending) {
+            "The accepted content hash does not match the pending one — the plugin package " +
+                "changed again on the host; review the current state before accepting"
+        }
+        definition.contentHash = pending
+        definition.pendingContentHash = null
+        return definitionRepository.save(definition)
+    }
 }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginDiscoveryService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginDiscoveryService.kt
@@ -128,6 +128,16 @@ class ExternalPluginDiscoveryService(
         if (definitions.isEmpty()) return
 
         definitions.forEach { definition ->
+            if (definition.requiresReacceptance) {
+                // No pushes means no fresh service tokens: the last one the host holds expires
+                // within its (short) TTL, after which the changed plugin can no longer call back
+                // into GZAC until an admin re-accepts the new content.
+                logger.warn {
+                    "Withholding configuration pushes for plugin '${definition.pluginId}@${definition.version}': " +
+                        "package content changed on host ${host.id} and awaits re-acceptance"
+                }
+                return@forEach
+            }
             val configs = configurationRepository.findAllByDefinitionId(definition.id)
             configs.forEach { config ->
                 try {
@@ -143,11 +153,12 @@ class ExternalPluginDiscoveryService(
     }
 
     private fun upsertDefinition(host: ExternalPluginHost, pluginId: String, pluginEntry: JsonNode): UUID? {
-        // Plugin-host returns: {pluginId, version, manifest: {pluginId, version, translations, ...}}
-        // The manifest carries no top-level name/description — those live per-locale under
-        // `translations` (see localizedManifestValue).
+        // Plugin-host returns: {pluginId, version, contentHash, manifest: {pluginId, version,
+        // translations, ...}}. The manifest carries no top-level name/description — those live
+        // per-locale under `translations` (see localizedManifestValue).
         val manifest = pluginEntry.get("manifest") ?: pluginEntry
         val version = pluginEntry.get("version")?.asText() ?: manifest.get("version")?.asText() ?: "0.0.0"
+        val discoveredContentHash = pluginEntry.get("contentHash")?.asText()?.takeIf { it.isNotBlank() }
 
         val existing = definitionRepository.findByPluginIdAndVersion(pluginId, version)
         if (existing != null && existing.hostId != host.id) {
@@ -165,6 +176,42 @@ class ExternalPluginDiscoveryService(
             baseUrl = "${host.baseUrl}/plugins/$pluginId",
             status = ExternalPluginDefinitionStatus.AVAILABLE,
         )
+
+        // Content pinning: the hash of the package as first discovered is what the admin's
+        // acceptance covers. Anything else the host serves later under the same pluginId@version is
+        // a change of the running code, so the definition is flagged and its stored (accepted)
+        // manifest/schema stay frozen until an admin re-accepts — see acceptContent on the
+        // definition service. A host without hash support (older host) skips pinning entirely.
+        if (discoveredContentHash != null) {
+            val pinnedContentHash = definition.contentHash
+            when {
+                pinnedContentHash == null -> definition.contentHash = discoveredContentHash
+                discoveredContentHash != pinnedContentHash -> {
+                    if (definition.pendingContentHash != discoveredContentHash) {
+                        logger.warn {
+                            "Package content of external plugin '$pluginId@$version' on host ${host.id} changed " +
+                                "(pinned $pinnedContentHash, now $discoveredContentHash) — " +
+                                "flagged for re-acceptance; configuration pushes are withheld"
+                        }
+                        definition.pendingContentHash = discoveredContentHash
+                    }
+                    // The plugin is present on the host, just changed — keep it visible.
+                    definition.status = ExternalPluginDefinitionStatus.AVAILABLE
+                    definition.consecutiveMisses = 0
+                    definitionRepository.save(definition)
+                    return definition.id
+                }
+                definition.pendingContentHash != null -> {
+                    // The host serves the pinned bytes again (e.g. a tampered package was rolled
+                    // back) — the flag has served its purpose.
+                    logger.info {
+                        "Package content of external plugin '$pluginId@$version' matches the pinned hash again; " +
+                            "clearing the re-acceptance flag"
+                    }
+                    definition.pendingContentHash = null
+                }
+            }
+        }
 
         val newConfigSchema = manifest.get("configurationSchema") as? ObjectNode
         warnOnDroppedSecretFlags(definition, newConfigSchema)

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginHostService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginHostService.kt
@@ -172,7 +172,7 @@ class ExternalPluginHostService(
      * it is a single read.
      */
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    fun uploadPlugin(hostId: UUID, fileName: String, fileBytes: ByteArray): JsonNode {
+    fun uploadPlugin(hostId: UUID, fileName: String, fileBytes: ByteArray, overwrite: Boolean = false): JsonNode {
         val host = get(hostId)
         // An app *is* its single plugin — it serves its own manifest and accepts no uploads. The UI
         // hides the upload affordance for apps; this is the server-side backstop.
@@ -180,7 +180,7 @@ class ExternalPluginHostService(
             "Host $hostId is an app and does not accept plugin uploads; it serves its own plugin."
         }
         val adminToken = decryptedSecret(host)
-        return hostClient.uploadPlugin(host.baseUrl, adminToken, fileName, fileBytes)
+        return hostClient.uploadPlugin(host.baseUrl, adminToken, fileName, fileBytes, overwrite)
     }
 
     companion object {

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginServiceTokenService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginServiceTokenService.kt
@@ -31,12 +31,18 @@ import java.util.Date
  * into GZAC on behalf of a specific external plugin configuration.
  *
  * The token carries no roles. Endpoint access is gated by [com.ritense.externalplugin.security.ExternalPluginEndpointAllowlistFilter].
+ *
+ * The default TTL is deliberately a small multiple of the discovery polling rate (60s): the poll
+ * re-pushes a fresh token to the host on every cycle, so a leaked token is only usable for minutes
+ * rather than a day. Each token also carries the configuration's [ExternalPluginConfiguration
+ * .tokenGeneration]; bumping that counter (the revoke-tokens management endpoint) invalidates every
+ * outstanding token at once — see [com.ritense.externalplugin.security.ExternalPluginServiceTokenAuthenticator].
  */
 @Service
 @SkipComponentScan
 class ExternalPluginServiceTokenService(
     private val keyProvider: ExternalPluginServiceTokenKeyProvider,
-    private val tokenTtl: Duration = Duration.ofHours(24),
+    private val tokenTtl: Duration = DEFAULT_TTL,
 ) {
 
     fun issue(configuration: ExternalPluginConfiguration, definition: ExternalPluginDefinition): String {
@@ -48,6 +54,7 @@ class ExternalPluginServiceTokenService(
             .claim(PLUGIN_CONFIG_ID_CLAIM, configuration.id.toString())
             .claim(PLUGIN_ID_CLAIM, definition.pluginId)
             .claim(PLUGIN_VERSION_CLAIM, definition.version)
+            .claim(TOKEN_GENERATION_CLAIM, configuration.tokenGeneration)
             .issuer(ISSUER)
             .issuedAt(Date.from(now))
             .expiration(Date.from(now.plus(tokenTtl)))
@@ -59,6 +66,9 @@ class ExternalPluginServiceTokenService(
         const val PLUGIN_CONFIG_ID_CLAIM = "plugin_config_id"
         const val PLUGIN_ID_CLAIM = "plugin_id"
         const val PLUGIN_VERSION_CLAIM = "plugin_version"
+        const val TOKEN_GENERATION_CLAIM = "token_generation"
         const val ISSUER = "valtimo-gzac"
+
+        val DEFAULT_TTL: Duration = Duration.ofMinutes(10)
     }
 }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginUserTokenService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginUserTokenService.kt
@@ -45,7 +45,12 @@ class ExternalPluginUserTokenService(
     /** Hard cap: a downscoped user token is never longer-lived than [MAX_TTL]. */
     private val ttl: Duration = if (tokenTtl > MAX_TTL) MAX_TTL else tokenTtl
 
-    fun issue(userLogin: String, roles: List<String>, configurationId: UUID): IssuedUserToken {
+    fun issue(
+        userLogin: String,
+        roles: List<String>,
+        configurationId: UUID,
+        tokenGeneration: Long,
+    ): IssuedUserToken {
         require(userLogin.isNotBlank()) { "userLogin must not be blank" }
         val now = Instant.now()
         val expiresAt = now.plus(ttl)
@@ -55,6 +60,7 @@ class ExternalPluginUserTokenService(
             .claim(ExternalPluginUserTokenKeyProvider.TYPE_CLAIM, ExternalPluginUserTokenKeyProvider.TOKEN_TYPE)
             .claim(ROLES_CLAIM, roles)
             .claim(PLUGIN_CONFIG_ID_CLAIM, configurationId.toString())
+            .claim(TOKEN_GENERATION_CLAIM, tokenGeneration)
             .issuer(ISSUER)
             .issuedAt(Date.from(now))
             .expiration(Date.from(expiresAt))
@@ -67,6 +73,13 @@ class ExternalPluginUserTokenService(
     companion object {
         const val ROLES_CLAIM = "roles"
         const val PLUGIN_CONFIG_ID_CLAIM = "plugin_config_id"
+
+        /**
+         * The configuration's revocation counter at mint time. Validated against the current value
+         * on every use, so bumping the configuration's generation also kills outstanding user
+         * tokens — not just service tokens.
+         */
+        const val TOKEN_GENERATION_CLAIM = "token_generation"
         const val ISSUER = "valtimo-gzac"
 
         val DEFAULT_TTL: Duration = Duration.ofMinutes(15)

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginManagementResource.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginManagementResource.kt
@@ -233,6 +233,13 @@ class ExternalPluginManagementResource(
      * the version details, unless `force=true`. The operator confirms the warning in the UI, which
      * re-issues the request with `force=true` to proceed regardless. A compatible (or
      * undeterminable) plugin uploads straight through.
+     *
+     * A package whose `pluginId@version` already exists on the host is refused with `409 Conflict`
+     * carrying `code=PLUGIN_VERSION_EXISTS`, both content hashes and the uploaded manifest's
+     * requested permissions — the UI shows those for re-review and re-issues the request with
+     * `overwrite=true` once the admin confirms. After a confirmed overwrite the new content hash
+     * is pinned and every configuration of the definition is re-granted to exactly the new
+     * declared permission sets ([ExternalPluginConfigurationService.applyApprovedOverwrite]).
      */
     @RunWithoutAuthorization
     @EndpointDescription(
@@ -244,6 +251,7 @@ class ExternalPluginManagementResource(
         @PathVariable hostId: UUID,
         @RequestParam("file") file: MultipartFile,
         @RequestParam(name = "force", required = false, defaultValue = "false") force: Boolean,
+        @RequestParam(name = "overwrite", required = false, defaultValue = "false") overwrite: Boolean = false,
     ): ResponseEntity<JsonNode> {
         val fileBytes = file.bytes
         if (!force) {
@@ -256,15 +264,33 @@ class ExternalPluginManagementResource(
             }
         }
         val result = try {
-            hostService.uploadPlugin(hostId, file.originalFilename ?: "plugin.zip", fileBytes)
+            hostService.uploadPlugin(hostId, file.originalFilename ?: "plugin.zip", fileBytes, overwrite)
         } catch (e: HttpStatusCodeException) {
-            // The host rejected the upload (bad package, duplicate version, …) or failed on it —
-            // relay its status and error body instead of surfacing a raw 500.
+            val hostBody = parseJsonOrNull(e.responseBodyAsString)
+            if (e.statusCode == HttpStatus.CONFLICT && hostBody?.get("code")?.asText() == PLUGIN_VERSION_EXISTS_CODE) {
+                // Enrich with the uploaded manifest's requested permissions so the UI can render
+                // the re-review screen without parsing the zip client-side.
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(versionExistsBody(hostBody, fileBytes))
+            }
+            // Any other rejection (bad package, …) or failure — relay the host's status and error
+            // body instead of surfacing a raw 500.
             return ResponseEntity.status(e.statusCode)
                 .body(uploadErrorBody("Plugin host rejected the upload", e.responseBodyAsString))
         } catch (e: ResourceAccessException) {
             return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
                 .body(uploadErrorBody("Plugin host is unreachable", e.message))
+        }
+        if (overwrite) {
+            val pluginId = result.get("pluginId")?.asText()
+            val version = result.get("version")?.asText()
+            if (pluginId != null && version != null) {
+                configurationService.applyApprovedOverwrite(
+                    pluginId,
+                    version,
+                    result.get("contentHash")?.asText()?.takeIf { it.isNotBlank() },
+                    pluginPackageInspector.readManifest(fileBytes),
+                )
+            }
         }
         discoveryService.discoverAll()
         return ResponseEntity.status(HttpStatus.CREATED).body(result)
@@ -485,9 +511,68 @@ class ExternalPluginManagementResource(
             put("maxGzacVersion", compatibility.maxGzacVersion)
         }
 
+    /**
+     * The 409 body for an upload targeting an existing pluginId@version: the host's hashes (so the
+     * UI can tell an identical re-upload apart from different content) plus the uploaded
+     * manifest's requested endpoint/event/capability sets for the permission re-review screen.
+     */
+    private fun versionExistsBody(hostBody: JsonNode, fileBytes: ByteArray): JsonNode {
+        val manifest = pluginPackageInspector.readManifest(fileBytes)
+        return objectMapper.createObjectNode().apply {
+            put("code", PLUGIN_VERSION_EXISTS_CODE)
+            put("error", hostBody.get("error")?.asText() ?: "Plugin version already exists")
+            hostBody.get("message")?.asText()?.let { put("message", it) }
+            hostBody.get("currentContentHash")?.takeIf { it.isTextual }
+                ?.let { put("currentContentHash", it.asText()) }
+            hostBody.get("uploadedContentHash")?.takeIf { it.isTextual }
+                ?.let { put("uploadedContentHash", it.asText()) }
+            manifest?.get("pluginId")?.asText()?.let { put("pluginId", it) }
+            manifest?.get("version")?.asText()?.let { put("version", it) }
+            set<JsonNode>(
+                "requestedEndpoints",
+                objectMapper.createArrayNode().apply {
+                    manifest?.get("permissions")?.get("endpoints")?.takeIf { it.isArray }?.forEach { endpoint ->
+                        val method = endpoint.get("method")?.asText()?.takeIf { it.isNotBlank() }
+                        val pattern = endpoint.get("pattern")?.asText()?.takeIf { it.isNotBlank() }
+                        if (method != null && pattern != null) {
+                            addObject().put("method", method).put("pattern", pattern)
+                        }
+                    }
+                },
+            )
+            set<JsonNode>(
+                "requestedEventSubscriptions",
+                objectMapper.createArrayNode().apply {
+                    manifest?.get("eventSubscriptions")?.takeIf { it.isArray }?.forEach { event ->
+                        event.asText().takeIf { it.isNotBlank() }?.let { add(it) }
+                    }
+                },
+            )
+            set<JsonNode>(
+                "requestedCapabilities",
+                objectMapper.createArrayNode().apply {
+                    manifest?.get("permissions")?.get("capabilities")?.takeIf { it.isArray }?.forEach { capability ->
+                        capability.asText().takeIf { it.isNotBlank() }?.let { add(it) }
+                    }
+                },
+            )
+        }
+    }
+
+    private fun parseJsonOrNull(body: String?): JsonNode? = if (body.isNullOrBlank()) null else try {
+        objectMapper.readTree(body)
+    } catch (_: Exception) {
+        null
+    }
+
     private fun uploadErrorBody(message: String, detail: String?): JsonNode =
         objectMapper.createObjectNode().apply {
             put("error", message)
             if (!detail.isNullOrBlank()) put("detail", detail)
         }
+
+    companion object {
+        /** Host 409 code for an upload naming an already-existing pluginId@version. */
+        const val PLUGIN_VERSION_EXISTS_CODE = "PLUGIN_VERSION_EXISTS"
+    }
 }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginManagementResource.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginManagementResource.kt
@@ -30,6 +30,7 @@ import com.ritense.externalplugin.service.ExternalPluginConfigurationService
 import com.ritense.externalplugin.service.ExternalPluginDefinitionService
 import com.ritense.externalplugin.service.ExternalPluginDiscoveryService
 import com.ritense.externalplugin.service.ExternalPluginHostService
+import com.ritense.externalplugin.web.rest.dto.AcceptContentRequest
 import com.ritense.externalplugin.web.rest.dto.ConfigurationCreateRequest
 import com.ritense.externalplugin.web.rest.dto.ConfigurationDetailResponse
 import com.ritense.externalplugin.web.rest.dto.ConfigurationResponse
@@ -287,6 +288,27 @@ class ExternalPluginManagementResource(
     fun getDefinition(@PathVariable definitionId: UUID): ResponseEntity<DefinitionResponse> =
         ResponseEntity.ok(toDefinitionResponse(definitionService.get(definitionId)))
 
+    /**
+     * Re-accepts a definition whose package content changed on its host after the original
+     * acceptance (see `requiresReacceptance` on the definition response). The request echoes the
+     * pending hash the admin reviewed; on success the new hash is pinned and an immediate
+     * re-discovery refreshes the frozen manifest data and resumes configuration pushes.
+     */
+    @RunWithoutAuthorization
+    @EndpointDescription(
+        en = "Accept changed plugin package content",
+        nl = "Gewijzigde plugininhoud accepteren",
+    )
+    @PostMapping("/definition/{definitionId}/accept-content")
+    fun acceptDefinitionContent(
+        @PathVariable definitionId: UUID,
+        @RequestBody request: AcceptContentRequest,
+    ): ResponseEntity<DefinitionResponse> {
+        val definition = definitionService.acceptContent(definitionId, request.contentHash)
+        runCatching { discoveryService.discoverHost(definition.hostId) }
+        return ResponseEntity.ok(toDefinitionResponse(definitionService.get(definitionId)))
+    }
+
     @RunWithoutAuthorization
     @EndpointDescription(
         en = "List external plugin configurations",
@@ -418,6 +440,24 @@ class ExternalPluginManagementResource(
         configurationService.delete(configurationId)
         return ResponseEntity.noContent().build()
     }
+
+    /**
+     * Incident off-switch: instantly invalidates every service and user token minted for this
+     * configuration (they carry a generation counter that must match the configuration's current
+     * one). The configuration itself keeps existing — unlike deletion, which the in-use guards
+     * rightly resist — and a fresh token of the new generation is pushed to the host right after,
+     * so a legitimate host recovers without waiting for the next discovery cycle.
+     */
+    @RunWithoutAuthorization
+    @EndpointDescription(
+        en = "Revoke all tokens of an external plugin configuration",
+        nl = "Alle tokens van een externe-pluginconfiguratie intrekken",
+    )
+    @PostMapping("/configuration/{configurationId}/revoke-tokens")
+    fun revokeConfigurationTokens(
+        @PathVariable configurationId: UUID,
+    ): ResponseEntity<ConfigurationResponse> =
+        ResponseEntity.ok(ConfigurationResponse.from(configurationService.revokeTokens(configurationId)))
 
     @RunWithoutAuthorization
     @EndpointDescription(

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUserTokenResource.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUserTokenResource.kt
@@ -18,6 +18,7 @@ package com.ritense.externalplugin.web.rest
 
 import com.ritense.authorization.annotation.RunWithoutAuthorization
 import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
+import com.ritense.externalplugin.repository.ExternalPluginDefinitionRepository
 import com.ritense.externalplugin.repository.ExternalPluginGrantedEndpointRepository
 import com.ritense.externalplugin.service.ExternalPluginUserTokenService
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
@@ -46,6 +47,7 @@ import java.util.UUID
 @RequestMapping("/api/v1/external-plugin", produces = [APPLICATION_JSON_UTF8_VALUE])
 class ExternalPluginUserTokenResource(
     private val configurationRepository: ExternalPluginConfigurationRepository,
+    private val definitionRepository: ExternalPluginDefinitionRepository,
     private val grantedEndpointRepository: ExternalPluginGrantedEndpointRepository,
     private val userTokenService: ExternalPluginUserTokenService,
 ) {
@@ -68,14 +70,25 @@ class ExternalPluginUserTokenResource(
             ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "No authenticated user")
         val roles = SecurityUtils.getCurrentUserRoles()
 
-        if (!configurationRepository.existsById(configurationId)) {
-            throw ResponseStatusException(
+        val configuration = configurationRepository.findById(configurationId).orElseThrow {
+            ResponseStatusException(
                 HttpStatus.NOT_FOUND,
                 "External plugin configuration $configurationId not found",
             )
         }
 
-        val issued = userTokenService.issue(userLogin, roles, configurationId)
+        // A definition whose package content changed after acceptance no longer gets tokens of any
+        // kind until an admin re-accepts it — the iframe surface goes dark alongside the host push.
+        val definition = definitionRepository.findById(configuration.definitionId).orElse(null)
+        if (definition?.requiresReacceptance == true) {
+            throw ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "Plugin '${definition.pluginId}@${definition.version}' changed on its host and " +
+                    "awaits re-acceptance by an administrator",
+            )
+        }
+
+        val issued = userTokenService.issue(userLogin, roles, configurationId, configuration.tokenGeneration)
         // The configuration's granted endpoints ride along so the iframe host can precheck proxied
         // calls client-side (audit-C1). This leaks nothing: the caller just received a token scoped
         // to exactly these endpoints — the server-side allowlist remains authoritative.

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/dto/ConfigurationDto.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/dto/ConfigurationDto.kt
@@ -103,6 +103,8 @@ data class ConfigurationResponse(
     val definitionId: UUID,
     val title: String,
     val createdAt: Instant,
+    /** Current revocation counter — bumped by `POST /configuration/{id}/revoke-tokens`. */
+    val tokenGeneration: Long,
 ) {
     companion object {
         fun from(configuration: ExternalPluginConfiguration) = ConfigurationResponse(
@@ -110,6 +112,7 @@ data class ConfigurationResponse(
             definitionId = configuration.definitionId,
             title = configuration.title,
             createdAt = configuration.createdAt,
+            tokenGeneration = configuration.tokenGeneration,
         )
     }
 }

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/dto/DefinitionDto.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/dto/DefinitionDto.kt
@@ -58,7 +58,8 @@ data class DefinitionResponse(
     val logoUrl: String?,
     /**
      * The package content hash pinned at discovery, the hash the host serves *now* when it
-     * differs, and whether an admin must re-accept before the plugin runs again. The UI passes
+     * differs, and whether an admin must re-accept before the plugin runs again. Re-acceptance is
+     * a deliberately API-only recovery act (no management-UI flow): the caller passes
      * [pendingContentHash] back on `POST /definition/{id}/accept-content` to confirm which package
      * it reviewed.
      */

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/dto/DefinitionDto.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/web/rest/dto/DefinitionDto.kt
@@ -22,6 +22,11 @@ import com.ritense.externalplugin.domain.ExternalPluginDefinition
 import com.ritense.externalplugin.domain.ExternalPluginDefinitionStatus
 import java.util.UUID
 
+/** Echoes the pending content hash the admin reviewed — see `acceptDefinitionContent`. */
+data class AcceptContentRequest(
+    val contentHash: String,
+)
+
 data class DefinitionResponse(
     val id: UUID,
     val pluginId: String,
@@ -51,6 +56,15 @@ data class DefinitionResponse(
      * `baseUrl` with the version so the management UI can use it directly in `<img src>`.
      */
     val logoUrl: String?,
+    /**
+     * The package content hash pinned at discovery, the hash the host serves *now* when it
+     * differs, and whether an admin must re-accept before the plugin runs again. The UI passes
+     * [pendingContentHash] back on `POST /definition/{id}/accept-content` to confirm which package
+     * it reviewed.
+     */
+    val contentHash: String?,
+    val pendingContentHash: String?,
+    val requiresReacceptance: Boolean,
 ) {
     companion object {
         fun from(definition: ExternalPluginDefinition, compatibility: CompatibilityResult): DefinitionResponse {
@@ -72,6 +86,9 @@ data class DefinitionResponse(
                 currentGzacVersion = compatibility.currentGzacVersion,
                 compatible = compatibility.compatible,
                 logoUrl = if (hasLogo) "${definition.baseUrl}/${definition.version}/logo" else null,
+                contentHash = definition.contentHash,
+                pendingContentHash = definition.pendingContentHash,
+                requiresReacceptance = definition.requiresReacceptance,
             )
         }
     }

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/processlink/ExternalPluginServiceTaskStartListenerTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/processlink/ExternalPluginServiceTaskStartListenerTest.kt
@@ -149,6 +149,25 @@ class ExternalPluginServiceTaskStartListenerTest {
     }
 
     @Test
+    fun `refuses to invoke a plugin whose changed content awaits re-acceptance`() {
+        val changedDefinition = mock<ExternalPluginDefinition> {
+            on { this.hostId } doReturn hostId
+            on { pluginId } doReturn "case-summary"
+            on { version } doReturn "0.1.0"
+            on { requiresReacceptance } doReturn true
+        }
+        whenever(definitionService.get(definitionId)).thenReturn(changedDefinition)
+
+        val thrown = runCatching { listener.notify(globalProcessServiceTaskEvent()) }.exceptionOrNull()
+
+        assertThat(thrown).isInstanceOf(ExternalPluginActionFailedException::class.java)
+        assertThat((thrown as ExternalPluginActionFailedException).errorCode)
+            .isEqualTo(ExternalPluginServiceTaskStartListener.CONTENT_CHANGED_ERROR_CODE)
+        assertThat(thrown).hasMessageContaining("awaits re-acceptance")
+        verify(hostClient, never()).invokeAction(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
     fun `BUILDING_BLOCK reference resolves the configuration via the namespaced key`() {
         val resolver = mock<BuildingBlockPluginConfigurationResolver>()
         val listenerWithResolver = ExternalPluginServiceTaskStartListener(

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/processlink/ExternalPluginTaskFormSubmissionServiceTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/processlink/ExternalPluginTaskFormSubmissionServiceTest.kt
@@ -151,6 +151,32 @@ class ExternalPluginTaskFormSubmissionServiceTest {
         assertThat(result.fieldErrors).isEmpty()
     }
 
+    @Test
+    fun `refuses the submission while the plugin's changed content awaits re-acceptance`() {
+        givenProcessLink(bundleKey = "review")
+        givenTask()
+        givenManifestWithTaskFormBundle(key = "review", submitHandler = true)
+        val changedDefinition = mock<ExternalPluginDefinition> {
+            on { pluginId } doReturn "case-summary"
+            on { version } doReturn "0.1.0"
+            on { requiresReacceptance } doReturn true
+        }
+        whenever(definitionService.get(definitionId)).thenReturn(changedDefinition)
+
+        val result = service.handleSubmission(
+            processLinkId,
+            objectMapper.readTree("""{"decision":"approve"}"""),
+            documentId = "doc-1",
+            taskInstanceId = "task-1",
+        )
+
+        assertThat(result.errors).singleElement().asString().contains("awaits re-acceptance")
+        // Neither the hook nor completion may run for a changed package.
+        verify(hostClient, never()).invokeSubmit(any(), any(), any(), any(), any(), any())
+        verify(processDocumentService, never()).dispatch(any())
+        verify(operatonTaskService, never()).completeTaskWithFormData(any(), any())
+    }
+
     private fun givenProcessLink(bundleKey: String?) {
         val processLink = ExternalPluginTaskFormProcessLink(
             id = processLinkId,

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenFilterTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenFilterTest.kt
@@ -16,19 +16,26 @@
 
 package com.ritense.externalplugin.security
 
+import com.ritense.externalplugin.domain.ExternalPluginConfiguration
+import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_CONFIG_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_VERSION_CLAIM
+import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.TOKEN_GENERATION_CLAIM
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import jakarta.servlet.http.HttpServletRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.mock.web.MockFilterChain
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
+import java.util.Optional
 import java.util.UUID
 import javax.crypto.SecretKey
 
@@ -36,7 +43,8 @@ class ExternalPluginServiceTokenFilterTest {
 
     private val secret = "test-secret-test-secret-test-secret-1234"
     private val keyProvider = ExternalPluginServiceTokenKeyProvider(secret)
-    private val authenticator = ExternalPluginServiceTokenAuthenticator()
+    private val configurationRepository: ExternalPluginConfigurationRepository = mock()
+    private val authenticator = ExternalPluginServiceTokenAuthenticator(configurationRepository)
     private val filter = ExternalPluginServiceTokenFilter(keyProvider, authenticator)
 
     @AfterEach
@@ -101,6 +109,7 @@ class ExternalPluginServiceTokenFilterTest {
     @Test
     fun `authenticates a valid service token and strips the authorization header downstream`() {
         val configId = UUID.randomUUID()
+        stubConfiguration(configId, tokenGeneration = 0)
         val request = MockHttpServletRequest("GET", "/api/v1/document/1")
         request.addHeader("Authorization", "Bearer ${token(configId = configId.toString())}")
         val response = MockHttpServletResponse()
@@ -121,9 +130,67 @@ class ExternalPluginServiceTokenFilterTest {
         assertThat((chain.request as HttpServletRequest).getHeader("Authorization")).isNull()
     }
 
+    @Test
+    fun `rejects a token minted under a previous generation (revoked)`() {
+        val configId = UUID.randomUUID()
+        stubConfiguration(configId, tokenGeneration = 2)
+        val request = MockHttpServletRequest("GET", "/api/v1/document/1")
+        request.addHeader("Authorization", "Bearer ${token(configId = configId.toString(), tokenGeneration = 1)}")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+    }
+
+    @Test
+    fun `rejects a token whose configuration no longer exists`() {
+        whenever(configurationRepository.findById(any())).thenReturn(Optional.empty())
+        val request = MockHttpServletRequest("GET", "/api/v1/document/1")
+        request.addHeader("Authorization", "Bearer ${token()}")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+    }
+
+    @Test
+    fun `rejects a token without a generation claim`() {
+        val configId = UUID.randomUUID()
+        stubConfiguration(configId, tokenGeneration = 0)
+        val request = MockHttpServletRequest("GET", "/api/v1/document/1")
+        request.addHeader(
+            "Authorization",
+            "Bearer ${token(configId = configId.toString(), tokenGeneration = null)}"
+        )
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+    }
+
+    private fun stubConfiguration(configId: UUID, tokenGeneration: Long) {
+        whenever(configurationRepository.findById(configId)).thenReturn(
+            Optional.of(
+                ExternalPluginConfiguration(
+                    id = configId,
+                    definitionId = UUID.randomUUID(),
+                    title = "Config",
+                    tokenGeneration = tokenGeneration,
+                )
+            )
+        )
+    }
+
     private fun token(
         type: String = ExternalPluginServiceTokenKeyProvider.TOKEN_TYPE,
         configId: String = UUID.randomUUID().toString(),
+        tokenGeneration: Long? = 0,
         key: SecretKey = keyProvider.signingKey,
     ): String =
         Jwts.builder()
@@ -131,6 +198,7 @@ class ExternalPluginServiceTokenFilterTest {
             .claim(PLUGIN_CONFIG_ID_CLAIM, configId)
             .claim(PLUGIN_ID_CLAIM, "case-summary")
             .claim(PLUGIN_VERSION_CLAIM, "0.1.0")
+            .apply { if (tokenGeneration != null) claim(TOKEN_GENERATION_CLAIM, tokenGeneration) }
             .signWith(key, Jwts.SIG.HS256)
             .compact()
 }

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginUserTokenFilterTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginUserTokenFilterTest.kt
@@ -17,8 +17,11 @@
 package com.ritense.externalplugin.security
 
 import com.ritense.authorization.AuthorizationContext
+import com.ritense.externalplugin.domain.ExternalPluginConfiguration
+import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
 import com.ritense.externalplugin.service.ExternalPluginUserTokenService.Companion.PLUGIN_CONFIG_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginUserTokenService.Companion.ROLES_CLAIM
+import com.ritense.externalplugin.service.ExternalPluginUserTokenService.Companion.TOKEN_GENERATION_CLAIM
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import jakarta.servlet.FilterChain
@@ -26,10 +29,14 @@ import jakarta.servlet.http.HttpServletRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.mock.web.MockFilterChain
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
+import java.util.Optional
 import java.util.UUID
 import javax.crypto.SecretKey
 
@@ -37,7 +44,20 @@ class ExternalPluginUserTokenFilterTest {
 
     private val secret = "test-secret-test-secret-test-secret-1234"
     private val keyProvider = ExternalPluginUserTokenKeyProvider(secret)
-    private val authenticator = ExternalPluginUserTokenAuthenticator()
+    private val configurationRepository: ExternalPluginConfigurationRepository = mock<ExternalPluginConfigurationRepository>().also {
+        // Every stubbed configuration is at generation 0, matching the default claim in [token].
+        whenever(it.findById(any())).thenAnswer { invocation ->
+            Optional.of(
+                ExternalPluginConfiguration(
+                    id = invocation.getArgument(0),
+                    definitionId = UUID.randomUUID(),
+                    title = "Config",
+                    tokenGeneration = 0,
+                )
+            )
+        }
+    }
+    private val authenticator = ExternalPluginUserTokenAuthenticator(configurationRepository)
     private val filter = ExternalPluginUserTokenFilter(keyProvider, authenticator)
 
     @AfterEach
@@ -119,10 +139,22 @@ class ExternalPluginUserTokenFilterTest {
         assertThat(ignoreAuthorizationDuringChain).isFalse()
     }
 
+    @Test
+    fun `rejects a user token minted under a previous generation (revoked)`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/document/1")
+        request.addHeader("Authorization", "Bearer ${token(tokenGeneration = 1)}") // config is at 0
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, MockHttpServletResponse(), chain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+    }
+
     private fun token(
         type: String = ExternalPluginUserTokenKeyProvider.TOKEN_TYPE,
         configId: String = UUID.randomUUID().toString(),
         roles: List<String> = listOf("ROLE_USER"),
+        tokenGeneration: Long = 0,
         key: SecretKey = keyProvider.signingKey,
     ): String =
         Jwts.builder()
@@ -130,6 +162,7 @@ class ExternalPluginUserTokenFilterTest {
             .claim(ExternalPluginUserTokenKeyProvider.TYPE_CLAIM, type)
             .claim(PLUGIN_CONFIG_ID_CLAIM, configId)
             .claim(ROLES_CLAIM, roles)
+            .claim(TOKEN_GENERATION_CLAIM, tokenGeneration)
             .signWith(key, Jwts.SIG.HS256)
             .compact()
 }

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationServicePushTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationServicePushTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.externalplugin.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ritense.externalplugin.client.ExternalPluginHostClient
+import com.ritense.externalplugin.domain.ExternalPluginConfiguration
+import com.ritense.externalplugin.domain.ExternalPluginDefinition
+import com.ritense.externalplugin.domain.ExternalPluginDefinitionStatus
+import com.ritense.externalplugin.domain.ExternalPluginHost
+import com.ritense.externalplugin.domain.ExternalPluginHostStatus
+import com.ritense.externalplugin.exception.ExternalPluginNotFoundException
+import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
+import com.ritense.externalplugin.repository.ExternalPluginDefinitionRepository
+import com.ritense.externalplugin.repository.ExternalPluginGrantedCapabilityRepository
+import com.ritense.externalplugin.repository.ExternalPluginGrantedEndpointRepository
+import com.ritense.externalplugin.repository.ExternalPluginGrantedEventRepository
+import com.ritense.externalplugin.repository.ExternalPluginHostRepository
+import com.ritense.plugin.service.EncryptionService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * Guards [ExternalPluginConfigurationService.pushToHost]'s security behaviour — the content-hash
+ * binding and the re-acceptance freeze — and the [ExternalPluginConfigurationService.revokeTokens]
+ * generation bump.
+ */
+class ExternalPluginConfigurationServicePushTest {
+
+    private val objectMapper = ObjectMapper()
+
+    private lateinit var configurationRepository: ExternalPluginConfigurationRepository
+    private lateinit var definitionRepository: ExternalPluginDefinitionRepository
+    private lateinit var hostRepository: ExternalPluginHostRepository
+    private lateinit var hostClient: ExternalPluginHostClient
+    private lateinit var encryptionService: EncryptionService
+    private lateinit var propertyEncryptor: PluginPropertyEncryptor
+    private lateinit var serviceTokenService: ExternalPluginServiceTokenService
+    private lateinit var service: ExternalPluginConfigurationService
+
+    private val definition = ExternalPluginDefinition(
+        id = UUID.randomUUID(),
+        pluginId = "case-summary",
+        version = "1.0.0",
+        hostId = UUID.randomUUID(),
+        baseUrl = "https://plugin-host.example.com/plugins/case-summary",
+        status = ExternalPluginDefinitionStatus.AVAILABLE,
+        contentHash = "sha256:accepted",
+    )
+
+    private val configuration = ExternalPluginConfiguration(
+        id = UUID.randomUUID(),
+        definitionId = definition.id,
+        title = "Primary",
+    )
+
+    private val host = ExternalPluginHost(
+        id = definition.hostId,
+        name = "host",
+        baseUrl = "https://plugin-host.example.com",
+        secret = "encrypted-secret",
+        status = ExternalPluginHostStatus.CONNECTED,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        configurationRepository = mock()
+        definitionRepository = mock()
+        hostRepository = mock()
+        hostClient = mock()
+        encryptionService = mock()
+        propertyEncryptor = mock()
+        serviceTokenService = mock()
+        whenever(configurationRepository.save(any<ExternalPluginConfiguration>())).thenAnswer { it.getArgument(0) }
+        whenever(configurationRepository.findById(configuration.id)).thenReturn(Optional.of(configuration))
+        whenever(definitionRepository.findById(definition.id)).thenReturn(Optional.of(definition))
+        whenever(hostRepository.findById(host.id)).thenReturn(Optional.of(host))
+        whenever(encryptionService.decrypt("encrypted-secret")).thenReturn("admin-token")
+        whenever(propertyEncryptor.decryptSecretFields(any(), anyOrNull())).thenAnswer { it.getArgument(0) }
+        whenever(serviceTokenService.issue(any(), any())).thenReturn("svc-token")
+        service = ExternalPluginConfigurationService(
+            configurationRepository,
+            definitionRepository,
+            hostRepository,
+            mock<ExternalPluginGrantedEndpointRepository>(),
+            mock<ExternalPluginGrantedEventRepository>(),
+            mock<ExternalPluginGrantedCapabilityRepository>(),
+            hostClient,
+            propertyEncryptor,
+            encryptionService,
+            objectMapper,
+            serviceTokenService,
+            mock<ExternalPluginHostUsageResolver>(),
+            "gzac.events",
+            "http://localhost:8080",
+        )
+    }
+
+    @Test
+    fun `pushToHost sends the pinned content hash so the host can refuse a changed package`() {
+        service.pushToHost(configuration, definition, host)
+
+        verify(hostClient).pushConfiguration(
+            baseUrl = eq("https://plugin-host.example.com"),
+            adminToken = eq("admin-token"),
+            configId = eq(configuration.id.toString()),
+            pluginId = eq("case-summary"),
+            pluginVersion = eq("1.0.0"),
+            properties = any(),
+            serviceToken = eq("svc-token"),
+            gzacBaseUrl = any(),
+            expectedContentHash = eq("sha256:accepted"),
+            eventSubscriptions = any(),
+            grantedCapabilities = any(),
+            grantedEndpoints = any(),
+            eventBrokerUrl = anyOrNull(),
+            eventBrokerExchange = any(),
+            eventBrokerExchangeType = any(),
+            eventQueueMode = any(),
+            eventQueueTtlMs = anyOrNull(),
+        )
+    }
+
+    @Test
+    fun `pushToHost refuses while the definition's changed content awaits re-acceptance`() {
+        definition.pendingContentHash = "sha256:changed"
+
+        val pushed = service.pushToHost(configuration, definition, host)
+
+        assertThat(pushed).isFalse()
+        // Nothing reaches the host — in particular no fresh service token is minted or shipped.
+        verifyNoInteractions(hostClient)
+        verifyNoInteractions(serviceTokenService)
+    }
+
+    @Test
+    fun `revokeTokens bumps the generation and immediately re-pushes a fresh token`() {
+        val revoked = service.revokeTokens(configuration.id)
+
+        assertThat(revoked.tokenGeneration).isEqualTo(1L)
+        verify(configurationRepository).save(configuration)
+        // The after-commit push runs immediately outside a transaction: the host receives a token
+        // of the *new* generation, so only leaked/hoarded tokens die.
+        verify(serviceTokenService).issue(eq(configuration), eq(definition))
+        verify(hostClient).pushConfiguration(
+            baseUrl = any(),
+            adminToken = any(),
+            configId = eq(configuration.id.toString()),
+            pluginId = any(),
+            pluginVersion = any(),
+            properties = any(),
+            serviceToken = eq("svc-token"),
+            gzacBaseUrl = any(),
+            expectedContentHash = anyOrNull(),
+            eventSubscriptions = any(),
+            grantedCapabilities = any(),
+            grantedEndpoints = any(),
+            eventBrokerUrl = anyOrNull(),
+            eventBrokerExchange = any(),
+            eventBrokerExchangeType = any(),
+            eventQueueMode = any(),
+            eventQueueTtlMs = anyOrNull(),
+        )
+    }
+
+    @Test
+    fun `revokeTokens fails clearly for an unknown configuration`() {
+        val unknownId = UUID.randomUUID()
+        whenever(configurationRepository.findById(unknownId)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { service.revokeTokens(unknownId) }
+            .isInstanceOf(ExternalPluginNotFoundException::class.java)
+        verify(configurationRepository, never()).save(any())
+    }
+}

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationServicePushTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginConfigurationServicePushTest.kt
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -58,6 +59,9 @@ class ExternalPluginConfigurationServicePushTest {
     private lateinit var configurationRepository: ExternalPluginConfigurationRepository
     private lateinit var definitionRepository: ExternalPluginDefinitionRepository
     private lateinit var hostRepository: ExternalPluginHostRepository
+    private lateinit var grantedEndpointRepository: ExternalPluginGrantedEndpointRepository
+    private lateinit var grantedEventRepository: ExternalPluginGrantedEventRepository
+    private lateinit var grantedCapabilityRepository: ExternalPluginGrantedCapabilityRepository
     private lateinit var hostClient: ExternalPluginHostClient
     private lateinit var encryptionService: EncryptionService
     private lateinit var propertyEncryptor: PluginPropertyEncryptor
@@ -93,6 +97,9 @@ class ExternalPluginConfigurationServicePushTest {
         configurationRepository = mock()
         definitionRepository = mock()
         hostRepository = mock()
+        grantedEndpointRepository = mock()
+        grantedEventRepository = mock()
+        grantedCapabilityRepository = mock()
         hostClient = mock()
         encryptionService = mock()
         propertyEncryptor = mock()
@@ -108,9 +115,9 @@ class ExternalPluginConfigurationServicePushTest {
             configurationRepository,
             definitionRepository,
             hostRepository,
-            mock<ExternalPluginGrantedEndpointRepository>(),
-            mock<ExternalPluginGrantedEventRepository>(),
-            mock<ExternalPluginGrantedCapabilityRepository>(),
+            grantedEndpointRepository,
+            grantedEventRepository,
+            grantedCapabilityRepository,
             hostClient,
             propertyEncryptor,
             encryptionService,
@@ -197,5 +204,56 @@ class ExternalPluginConfigurationServicePushTest {
         assertThatThrownBy { service.revokeTokens(unknownId) }
             .isInstanceOf(ExternalPluginNotFoundException::class.java)
         verify(configurationRepository, never()).save(any())
+    }
+
+    @Test
+    fun `applyApprovedOverwrite pins the new hash and re-grants every configuration to the new manifest`() {
+        definition.pendingContentHash = "sha256:stale-flag"
+        whenever(definitionRepository.findByPluginIdAndVersion("case-summary", "1.0.0")).thenReturn(definition)
+        whenever(configurationRepository.findAllByDefinitionId(definition.id)).thenReturn(listOf(configuration))
+        val manifest = objectMapper.readTree(
+            """
+            {
+              "eventSubscriptions": ["com.ritense.valtimo.document.created"],
+              "permissions": {
+                "endpoints": [{"method": "get", "pattern": "/api/v1/document/*"}],
+                "capabilities": ["gzac_api", "not-a-real-capability"]
+              }
+            }
+            """.trimIndent()
+        )
+
+        service.applyApprovedOverwrite("case-summary", "1.0.0", "sha256:new", manifest)
+
+        assertThat(definition.contentHash).isEqualTo("sha256:new")
+        assertThat(definition.pendingContentHash).isNull()
+        verify(definitionRepository).save(definition)
+
+        // Old grants are replaced by exactly the new declared sets.
+        verify(grantedEndpointRepository).deleteAllByConfigurationId(configuration.id)
+        verify(grantedEventRepository).deleteAllByConfigurationId(configuration.id)
+        verify(grantedCapabilityRepository).deleteAllByConfigurationId(configuration.id)
+        val endpointCaptor = argumentCaptor<com.ritense.externalplugin.domain.ExternalPluginGrantedEndpoint>()
+        verify(grantedEndpointRepository).save(endpointCaptor.capture())
+        assertThat(endpointCaptor.firstValue.httpMethod).isEqualTo("GET")
+        assertThat(endpointCaptor.firstValue.endpointPattern).isEqualTo("/api/v1/document/*")
+        val eventCaptor = argumentCaptor<com.ritense.externalplugin.domain.ExternalPluginGrantedEvent>()
+        verify(grantedEventRepository).save(eventCaptor.capture())
+        assertThat(eventCaptor.firstValue.eventType).isEqualTo("com.ritense.valtimo.document.created")
+        // The unknown capability is skipped instead of failing after the host already replaced
+        // the package.
+        val capabilityCaptor = argumentCaptor<com.ritense.externalplugin.domain.ExternalPluginGrantedCapability>()
+        verify(grantedCapabilityRepository).save(capabilityCaptor.capture())
+        assertThat(capabilityCaptor.firstValue.capability.value).isEqualTo("gzac_api")
+    }
+
+    @Test
+    fun `applyApprovedOverwrite is a no-op for a definition GZAC never discovered`() {
+        whenever(definitionRepository.findByPluginIdAndVersion("unknown", "9.9.9")).thenReturn(null)
+
+        service.applyApprovedOverwrite("unknown", "9.9.9", "sha256:new", objectMapper.createObjectNode())
+
+        verify(definitionRepository, never()).save(any())
+        verify(grantedEndpointRepository, never()).deleteAllByConfigurationId(any())
     }
 }

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginDefinitionServiceTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginDefinitionServiceTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.externalplugin.service
+
+import com.ritense.externalplugin.domain.ExternalPluginDefinition
+import com.ritense.externalplugin.domain.ExternalPluginDefinitionStatus
+import com.ritense.externalplugin.repository.ExternalPluginDefinitionRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import java.util.UUID
+
+class ExternalPluginDefinitionServiceTest {
+
+    private lateinit var definitionRepository: ExternalPluginDefinitionRepository
+    private lateinit var service: ExternalPluginDefinitionService
+
+    private val definition = ExternalPluginDefinition(
+        id = UUID.randomUUID(),
+        pluginId = "case-summary",
+        version = "1.0.0",
+        hostId = UUID.randomUUID(),
+        baseUrl = "https://plugin-host.example.com/plugins/case-summary",
+        status = ExternalPluginDefinitionStatus.AVAILABLE,
+        contentHash = "sha256:accepted",
+        pendingContentHash = "sha256:changed",
+    )
+
+    @BeforeEach
+    fun setUp() {
+        definitionRepository = mock()
+        whenever(definitionRepository.findById(definition.id)).thenReturn(Optional.of(definition))
+        whenever(definitionRepository.save(any<ExternalPluginDefinition>())).thenAnswer { it.getArgument(0) }
+        service = ExternalPluginDefinitionService(definitionRepository)
+    }
+
+    @Test
+    fun `acceptContent re-pins the pending hash and clears the flag`() {
+        val accepted = service.acceptContent(definition.id, "sha256:changed")
+
+        assertThat(accepted.contentHash).isEqualTo("sha256:changed")
+        assertThat(accepted.pendingContentHash).isNull()
+        assertThat(accepted.requiresReacceptance).isFalse()
+        verify(definitionRepository).save(definition)
+    }
+
+    @Test
+    fun `acceptContent rejects a stale hash - the package changed again since the admin reviewed it`() {
+        assertThatThrownBy { service.acceptContent(definition.id, "sha256:stale") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("changed again")
+
+        assertThat(definition.contentHash).isEqualTo("sha256:accepted")
+        assertThat(definition.pendingContentHash).isEqualTo("sha256:changed")
+        verify(definitionRepository, never()).save(any())
+    }
+
+    @Test
+    fun `acceptContent rejects a definition without a pending change`() {
+        definition.pendingContentHash = null
+
+        assertThatThrownBy { service.acceptContent(definition.id, "sha256:whatever") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("no pending content change")
+        verify(definitionRepository, never()).save(any())
+    }
+}

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginDiscoveryServiceTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginDiscoveryServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.externalplugin.service
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.externalplugin.client.ExternalPluginHostClient
 import com.ritense.externalplugin.domain.ExternalPluginConfiguration
@@ -220,6 +221,110 @@ class ExternalPluginDiscoveryServiceTest {
         verify(definitionRepository).save(definition)
     }
 
+    @Test
+    fun `pins the package content hash on first discovery`() {
+        val host = host(status = ExternalPluginHostStatus.CONNECTED)
+        givenHost(host)
+        givenPluginListing(host, pluginEntry(contentHash = "sha256:aaa"))
+        whenever(definitionRepository.findByPluginIdAndVersion("case-summary", "1.0.0")).thenReturn(null)
+        whenever(definitionRepository.findAllByHostId(host.id)).thenReturn(emptyList())
+
+        service.discoverAll()
+
+        val captor = argumentCaptor<ExternalPluginDefinition>()
+        verify(definitionRepository).save(captor.capture())
+        assertThat(captor.firstValue.contentHash).isEqualTo("sha256:aaa")
+        assertThat(captor.firstValue.pendingContentHash).isNull()
+    }
+
+    @Test
+    fun `backfills the content hash for a definition discovered before hashing existed`() {
+        val host = host(status = ExternalPluginHostStatus.CONNECTED)
+        givenHost(host)
+        val definition = definition(hostId = host.id, contentHash = null)
+        givenPluginListing(host, pluginEntry(contentHash = "sha256:aaa"))
+        whenever(definitionRepository.findByPluginIdAndVersion("case-summary", "1.0.0")).thenReturn(definition)
+        whenever(definitionRepository.findAllByHostId(host.id)).thenReturn(listOf(definition))
+        whenever(configurationRepository.findAllByDefinitionId(definition.id)).thenReturn(emptyList())
+
+        service.discoverAll()
+
+        assertThat(definition.contentHash).isEqualTo("sha256:aaa")
+        assertThat(definition.pendingContentHash).isNull()
+    }
+
+    @Test
+    fun `flags a changed package for re-acceptance and freezes the accepted manifest data`() {
+        val host = host(status = ExternalPluginHostStatus.CONNECTED)
+        givenHost(host)
+        val definition = definition(hostId = host.id, contentHash = "sha256:aaa").apply { name = "Accepted name" }
+        givenPluginListing(host, pluginEntry(contentHash = "sha256:bbb", name = "Tampered name"))
+        whenever(definitionRepository.findByPluginIdAndVersion("case-summary", "1.0.0")).thenReturn(definition)
+        whenever(definitionRepository.findAllByHostId(host.id)).thenReturn(listOf(definition))
+        whenever(configurationRepository.findAllByDefinitionId(definition.id)).thenReturn(emptyList())
+
+        service.discoverAll()
+
+        assertThat(definition.contentHash).isEqualTo("sha256:aaa")
+        assertThat(definition.pendingContentHash).isEqualTo("sha256:bbb")
+        // The stored manifest data reflects what the admin accepted, not the changed package.
+        assertThat(definition.name).isEqualTo("Accepted name")
+        assertThat(definition.status).isEqualTo(ExternalPluginDefinitionStatus.AVAILABLE)
+    }
+
+    @Test
+    fun `withholds configuration pushes for a definition awaiting re-acceptance`() {
+        val host = host(status = ExternalPluginHostStatus.CONNECTED)
+        givenHost(host)
+        val definition = definition(hostId = host.id, contentHash = "sha256:aaa", pendingContentHash = "sha256:bbb")
+        val configuration = ExternalPluginConfiguration(UUID.randomUUID(), definition.id, "Primary")
+        givenPluginListing(host, pluginEntry(contentHash = "sha256:bbb"))
+        whenever(definitionRepository.findByPluginIdAndVersion("case-summary", "1.0.0")).thenReturn(definition)
+        whenever(definitionRepository.findAllByHostId(host.id)).thenReturn(listOf(definition))
+        whenever(configurationRepository.findAllByDefinitionId(definition.id)).thenReturn(listOf(configuration))
+
+        service.discoverAll()
+
+        verify(configurationService, never()).pushToHost(any(), any(), any())
+    }
+
+    @Test
+    fun `clears the re-acceptance flag when the host serves the pinned content again`() {
+        val host = host(status = ExternalPluginHostStatus.CONNECTED)
+        givenHost(host)
+        val definition = definition(hostId = host.id, contentHash = "sha256:aaa", pendingContentHash = "sha256:bbb")
+        givenPluginListing(host, pluginEntry(contentHash = "sha256:aaa"))
+        whenever(definitionRepository.findByPluginIdAndVersion("case-summary", "1.0.0")).thenReturn(definition)
+        whenever(definitionRepository.findAllByHostId(host.id)).thenReturn(listOf(definition))
+        whenever(configurationRepository.findAllByDefinitionId(definition.id)).thenReturn(emptyList())
+
+        service.discoverAll()
+
+        assertThat(definition.contentHash).isEqualTo("sha256:aaa")
+        assertThat(definition.pendingContentHash).isNull()
+    }
+
+    private fun givenPluginListing(host: ExternalPluginHost, vararg entries: JsonNode) {
+        whenever(hostClient.health(host.baseUrl)).thenReturn(true)
+        whenever(hostService.decryptedSecret(host)).thenReturn("admin-token")
+        whenever(hostClient.listPlugins(host.baseUrl, "admin-token")).thenReturn(entries.toList())
+    }
+
+    private fun pluginEntry(contentHash: String, name: String = "Case summary") = objectMapper.readTree(
+        """
+        {
+          "pluginId": "case-summary",
+          "version": "1.0.0",
+          "contentHash": "$contentHash",
+          "manifest": {
+            "pluginId": "case-summary",
+            "version": "1.0.0",
+            "translations": {"en": {"name": "$name", "description": "Summarises a case"}}
+          }
+        }
+        """.trimIndent(),
+    )
+
     private fun givenHost(host: ExternalPluginHost) {
         whenever(hostRepository.findAll()).thenReturn(listOf(host))
         whenever(hostRepository.findById(eq(host.id))).thenReturn(Optional.of(host))
@@ -240,6 +345,8 @@ class ExternalPluginDiscoveryServiceTest {
     private fun definition(
         hostId: UUID,
         consecutiveMisses: Int = 0,
+        contentHash: String? = null,
+        pendingContentHash: String? = null,
     ): ExternalPluginDefinition = ExternalPluginDefinition(
         id = UUID.randomUUID(),
         pluginId = "case-summary",
@@ -248,5 +355,7 @@ class ExternalPluginDiscoveryServiceTest {
         baseUrl = "https://plugin-host.example.com/plugins/case-summary",
         status = ExternalPluginDefinitionStatus.AVAILABLE,
         consecutiveMisses = consecutiveMisses,
+        contentHash = contentHash,
+        pendingContentHash = pendingContentHash,
     )
 }

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginServiceTokenServiceTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginServiceTokenServiceTest.kt
@@ -33,11 +33,13 @@ class ExternalPluginServiceTokenServiceTest {
     private val keyProvider = ExternalPluginServiceTokenKeyProvider(secret)
 
     @Test
-    fun `defaults to a 24 hour token lifetime`() {
+    fun `defaults to a 10 minute token lifetime`() {
+        // Deliberately short: the discovery poll re-pushes a fresh token every ~60s, so a longer
+        // default would only extend how long a leaked token stays usable.
         val claims = issue(ExternalPluginServiceTokenService(keyProvider))
 
         assertThat(Duration.between(claims.issuedAt.toInstant(), claims.expiration.toInstant()))
-            .isEqualTo(Duration.ofHours(24))
+            .isEqualTo(Duration.ofMinutes(10))
     }
 
     @Test
@@ -50,17 +52,32 @@ class ExternalPluginServiceTokenServiceTest {
             .isEqualTo(ttl)
     }
 
-    private fun issue(service: ExternalPluginServiceTokenService): Claims =
+    @Test
+    fun `stamps the configuration's current token generation into the token`() {
+        val claims = issue(
+            ExternalPluginServiceTokenService(keyProvider),
+            configuration = configuration(tokenGeneration = 5),
+        )
+
+        val generation = claims[ExternalPluginServiceTokenService.TOKEN_GENERATION_CLAIM] as Number
+        assertThat(generation.toLong()).isEqualTo(5L)
+    }
+
+    private fun issue(
+        service: ExternalPluginServiceTokenService,
+        configuration: ExternalPluginConfiguration = configuration(),
+    ): Claims =
         Jwts.parser()
             .verifyWith(keyProvider.signingKey)
             .build()
-            .parseSignedClaims(service.issue(configuration(), definition()))
+            .parseSignedClaims(service.issue(configuration, definition()))
             .payload
 
-    private fun configuration() = ExternalPluginConfiguration(
+    private fun configuration(tokenGeneration: Long = 0) = ExternalPluginConfiguration(
         id = UUID.randomUUID(),
         definitionId = UUID.randomUUID(),
         title = "test",
+        tokenGeneration = tokenGeneration,
     )
 
     private fun definition() = ExternalPluginDefinition(

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginUserTokenServiceTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/service/ExternalPluginUserTokenServiceTest.kt
@@ -34,7 +34,7 @@ class ExternalPluginUserTokenServiceTest {
         val configId = UUID.randomUUID()
         val service = ExternalPluginUserTokenService(keyProvider)
 
-        val issued = service.issue("john.doe", listOf("ROLE_USER", "ROLE_ADMIN"), configId)
+        val issued = service.issue("john.doe", listOf("ROLE_USER", "ROLE_ADMIN"), configId, tokenGeneration = 7)
         val claims = parse(issued.token)
 
         assertThat(claims.subject).isEqualTo("john.doe")
@@ -45,11 +45,14 @@ class ExternalPluginUserTokenServiceTest {
         @Suppress("UNCHECKED_CAST")
         assertThat(claims[ExternalPluginUserTokenService.ROLES_CLAIM] as List<String>)
             .containsExactly("ROLE_USER", "ROLE_ADMIN")
+        assertThat((claims[ExternalPluginUserTokenService.TOKEN_GENERATION_CLAIM] as Number).toLong())
+            .isEqualTo(7L)
     }
 
     @Test
     fun `defaults to a 15 minute lifetime`() {
-        val claims = parse(ExternalPluginUserTokenService(keyProvider).issue("u", emptyList(), UUID.randomUUID()).token)
+        val claims =
+            parse(ExternalPluginUserTokenService(keyProvider).issue("u", emptyList(), UUID.randomUUID(), 0).token)
 
         assertThat(Duration.between(claims.issuedAt.toInstant(), claims.expiration.toInstant()))
             .isEqualTo(Duration.ofMinutes(15))
@@ -59,7 +62,7 @@ class ExternalPluginUserTokenServiceTest {
     fun `caps an over-long configured lifetime at 15 minutes`() {
         val service = ExternalPluginUserTokenService(keyProvider, Duration.ofHours(24))
 
-        val claims = parse(service.issue("u", emptyList(), UUID.randomUUID()).token)
+        val claims = parse(service.issue("u", emptyList(), UUID.randomUUID(), 0).token)
 
         assertThat(Duration.between(claims.issuedAt.toInstant(), claims.expiration.toInstant()))
             .isEqualTo(Duration.ofMinutes(15))

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUploadCompatibilityTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUploadCompatibilityTest.kt
@@ -61,7 +61,7 @@ class ExternalPluginUploadCompatibilityTest {
         hostService = mock()
         discoveryService = mock()
         objectMapper = ObjectMapper()
-        whenever(hostService.uploadPlugin(any(), any(), any()))
+        whenever(hostService.uploadPlugin(any(), any(), any(), any()))
             .thenReturn(objectMapper.createObjectNode().put("pluginId", "x") as JsonNode)
 
         resource = ExternalPluginManagementResource(
@@ -88,7 +88,7 @@ class ExternalPluginUploadCompatibilityTest {
         assertThat(response.body!!.get("incompatible").asBoolean()).isTrue()
         assertThat(response.body!!.get("currentGzacVersion").asText()).isEqualTo("13.1.3")
         assertThat(response.body!!.get("minGzacVersion").asText()).isEqualTo("14.0.0")
-        verify(hostService, never()).uploadPlugin(any(), any(), any())
+        verify(hostService, never()).uploadPlugin(any(), any(), any(), any())
         verify(discoveryService, never()).discoverAll()
     }
 
@@ -101,7 +101,7 @@ class ExternalPluginUploadCompatibilityTest {
         assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
         assertThat(response.body!!.get("incompatible").asBoolean()).isTrue()
         assertThat(response.body!!.get("maxGzacVersion").asText()).isEqualTo("12.1.0")
-        verify(hostService, never()).uploadPlugin(any(), any(), any())
+        verify(hostService, never()).uploadPlugin(any(), any(), any(), any())
     }
 
     @Test
@@ -111,7 +111,7 @@ class ExternalPluginUploadCompatibilityTest {
         val response = resource.uploadPlugin(hostId, file, force = true)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
-        verify(hostService).uploadPlugin(any(), any(), any())
+        verify(hostService).uploadPlugin(any(), any(), any(), any())
         verify(discoveryService).discoverAll()
     }
 
@@ -122,7 +122,7 @@ class ExternalPluginUploadCompatibilityTest {
         val response = resource.uploadPlugin(hostId, file, force = false)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
-        verify(hostService).uploadPlugin(any(), any(), any())
+        verify(hostService).uploadPlugin(any(), any(), any(), any())
     }
 
     @Test
@@ -132,7 +132,7 @@ class ExternalPluginUploadCompatibilityTest {
         val response = resource.uploadPlugin(hostId, file, force = false)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
-        verify(hostService).uploadPlugin(any(), any(), any())
+        verify(hostService).uploadPlugin(any(), any(), any(), any())
     }
 
     private fun pluginZip(manifestJson: String): MockMultipartFile {

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUploadOverwriteTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUploadOverwriteTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.externalplugin.web.rest
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ritense.externalplugin.compatibility.GzacCompatibilityChecker
+import com.ritense.externalplugin.compatibility.GzacVersionProvider
+import com.ritense.externalplugin.compatibility.PluginPackageInspector
+import com.ritense.externalplugin.service.EndpointDescriptionService
+import com.ritense.externalplugin.service.ExternalPluginConfigurationService
+import com.ritense.externalplugin.service.ExternalPluginDefinitionService
+import com.ritense.externalplugin.service.ExternalPluginDiscoveryService
+import com.ritense.externalplugin.service.ExternalPluginHostService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.core.env.Environment
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.web.client.HttpClientErrorException
+import java.io.ByteArrayOutputStream
+import java.util.UUID
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Verifies the upload endpoint's duplicate-version flow: a host `PLUGIN_VERSION_EXISTS` 409 is
+ * enriched with the uploaded manifest's requested permissions (for the UI's re-review screen),
+ * and a confirmed `overwrite=true` upload applies the approved overwrite — pin + re-grant — via
+ * [ExternalPluginConfigurationService.applyApprovedOverwrite].
+ */
+class ExternalPluginUploadOverwriteTest {
+
+    private lateinit var hostService: ExternalPluginHostService
+    private lateinit var configurationService: ExternalPluginConfigurationService
+    private lateinit var discoveryService: ExternalPluginDiscoveryService
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var resource: ExternalPluginManagementResource
+
+    private val hostId = UUID.randomUUID()
+
+    private val manifestJson = """
+        {
+          "pluginId": "case-summary",
+          "version": "0.1.0",
+          "eventSubscriptions": ["com.ritense.valtimo.document.created"],
+          "permissions": {
+            "endpoints": [{"method": "GET", "pattern": "/api/v1/document/*"}],
+            "capabilities": ["gzac_api", "log"]
+          }
+        }
+    """.trimIndent()
+
+    @BeforeEach
+    fun setUp() {
+        hostService = mock()
+        configurationService = mock()
+        discoveryService = mock()
+        objectMapper = ObjectMapper()
+        resource = ExternalPluginManagementResource(
+            hostService,
+            mock<ExternalPluginDefinitionService>(),
+            configurationService,
+            mock(),
+            mock<EndpointDescriptionService>(),
+            discoveryService,
+            mock<Environment>(),
+            GzacCompatibilityChecker(GzacVersionProvider { "13.1.3" }),
+            PluginPackageInspector(objectMapper),
+            objectMapper,
+        )
+    }
+
+    @Test
+    fun `enriches a host version-exists 409 with hashes and the requested permissions`() {
+        whenever(hostService.uploadPlugin(any(), any(), any(), any())).thenThrow(
+            versionExistsException(currentContentHash = "sha256:current", uploadedContentHash = "sha256:uploaded")
+        )
+
+        val response = resource.uploadPlugin(hostId, pluginZip(manifestJson), force = false)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+        val body = response.body!!
+        assertThat(body.get("code").asText()).isEqualTo("PLUGIN_VERSION_EXISTS")
+        assertThat(body.get("pluginId").asText()).isEqualTo("case-summary")
+        assertThat(body.get("version").asText()).isEqualTo("0.1.0")
+        assertThat(body.get("currentContentHash").asText()).isEqualTo("sha256:current")
+        assertThat(body.get("uploadedContentHash").asText()).isEqualTo("sha256:uploaded")
+        assertThat(body.get("requestedEndpoints").single().get("pattern").asText())
+            .isEqualTo("/api/v1/document/*")
+        assertThat(body.get("requestedEventSubscriptions").map { it.asText() })
+            .containsExactly("com.ritense.valtimo.document.created")
+        assertThat(body.get("requestedCapabilities").map { it.asText() })
+            .containsExactly("gzac_api", "log")
+        verify(discoveryService, never()).discoverAll()
+        verify(configurationService, never()).applyApprovedOverwrite(any(), any(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun `a confirmed overwrite pins the new content and re-grants before discovery runs`() {
+        whenever(hostService.uploadPlugin(any(), any(), any(), eq(true))).thenReturn(
+            objectMapper.readTree(
+                """{"pluginId": "case-summary", "version": "0.1.0", "contentHash": "sha256:new"}"""
+            ) as JsonNode
+        )
+
+        val response = resource.uploadPlugin(hostId, pluginZip(manifestJson), force = true, overwrite = true)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+        val manifestCaptor = argumentCaptor<JsonNode>()
+        verify(configurationService).applyApprovedOverwrite(
+            eq("case-summary"),
+            eq("0.1.0"),
+            eq("sha256:new"),
+            manifestCaptor.capture(),
+        )
+        assertThat(manifestCaptor.firstValue.get("pluginId").asText()).isEqualTo("case-summary")
+        verify(discoveryService).discoverAll()
+    }
+
+    @Test
+    fun `a plain upload does not apply any overwrite approval`() {
+        whenever(hostService.uploadPlugin(any(), any(), any(), eq(false))).thenReturn(
+            objectMapper.readTree("""{"pluginId": "case-summary", "version": "0.2.0"}""") as JsonNode
+        )
+
+        val response = resource.uploadPlugin(hostId, pluginZip(manifestJson), force = false)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+        verify(configurationService, never()).applyApprovedOverwrite(any(), any(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun `a non-version-exists host 409 stays a relayed error body`() {
+        whenever(hostService.uploadPlugin(any(), any(), any(), any())).thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.CONFLICT,
+                "Conflict",
+                HttpHeaders.EMPTY,
+                """{"error": "something else"}""".toByteArray(),
+                null,
+            )
+        )
+
+        val response = resource.uploadPlugin(hostId, pluginZip(manifestJson), force = false)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+        assertThat(response.body!!.get("error").asText()).isEqualTo("Plugin host rejected the upload")
+        assertThat(response.body!!.has("code")).isFalse()
+    }
+
+    private fun versionExistsException(
+        currentContentHash: String,
+        uploadedContentHash: String,
+    ): HttpClientErrorException = HttpClientErrorException.create(
+        HttpStatus.CONFLICT,
+        "Conflict",
+        HttpHeaders.EMPTY,
+        """
+            {
+              "code": "PLUGIN_VERSION_EXISTS",
+              "error": "Plugin version already exists: case-summary@0.1.0",
+              "message": "This version already exists on the host.",
+              "currentContentHash": "$currentContentHash",
+              "uploadedContentHash": "$uploadedContentHash"
+            }
+        """.trimIndent().toByteArray(),
+        null,
+    )
+
+    private fun pluginZip(manifest: String): MockMultipartFile {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zos ->
+            zos.putNextEntry(ZipEntry("manifest.json"))
+            zos.write(manifest.toByteArray())
+            zos.closeEntry()
+        }
+        return MockMultipartFile("file", "plugin.zip", "application/zip", out.toByteArray())
+    }
+}

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUserTokenIntrospectionResourceTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUserTokenIntrospectionResourceTest.kt
@@ -47,7 +47,7 @@ class ExternalPluginUserTokenIntrospectionResourceTest {
 
     @Test
     fun `returns the token's subject, configuration id and expiry for a user-token principal`() {
-        val issued = userTokenService.issue("john@example.com", listOf("ROLE_USER"), configurationId)
+        val issued = userTokenService.issue("john@example.com", listOf("ROLE_USER"), configurationId, 0)
         val principal = ExternalPluginUserPrincipal("john@example.com", listOf("ROLE_USER"), configurationId)
         // Mirrors ExternalPluginUserTokenAuthenticator: the raw JWT rides along as credentials.
         SecurityContextHolder.getContext().authentication =

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUserTokenResourceTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginUserTokenResourceTest.kt
@@ -16,8 +16,12 @@
 
 package com.ritense.externalplugin.web.rest
 
+import com.ritense.externalplugin.domain.ExternalPluginConfiguration
+import com.ritense.externalplugin.domain.ExternalPluginDefinition
+import com.ritense.externalplugin.domain.ExternalPluginDefinitionStatus
 import com.ritense.externalplugin.domain.ExternalPluginGrantedEndpoint
 import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
+import com.ritense.externalplugin.repository.ExternalPluginDefinitionRepository
 import com.ritense.externalplugin.repository.ExternalPluginGrantedEndpointRepository
 import com.ritense.externalplugin.service.ExternalPluginUserTokenService
 import com.ritense.externalplugin.service.IssuedUserToken
@@ -38,24 +42,29 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.server.ResponseStatusException
 import java.time.Instant
+import java.util.Optional
 import java.util.UUID
 
 class ExternalPluginUserTokenResourceTest {
 
     private lateinit var configurationRepository: ExternalPluginConfigurationRepository
+    private lateinit var definitionRepository: ExternalPluginDefinitionRepository
     private lateinit var grantedEndpointRepository: ExternalPluginGrantedEndpointRepository
     private lateinit var userTokenService: ExternalPluginUserTokenService
     private lateinit var resource: ExternalPluginUserTokenResource
 
     private val configurationId: UUID = UUID.randomUUID()
+    private val definitionId: UUID = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
         configurationRepository = mock()
+        definitionRepository = mock()
         grantedEndpointRepository = mock()
         userTokenService = mock()
         resource = ExternalPluginUserTokenResource(
             configurationRepository,
+            definitionRepository,
             grantedEndpointRepository,
             userTokenService,
         )
@@ -75,9 +84,11 @@ class ExternalPluginUserTokenResourceTest {
     @Test
     fun `mints a token and returns the configuration's granted endpoints alongside it`() {
         val expiresAt = Instant.now().plusSeconds(900)
-        whenever(configurationRepository.existsById(configurationId)).thenReturn(true)
-        whenever(userTokenService.issue(eq("john@example.com"), eq(listOf("ROLE_USER")), eq(configurationId)))
-            .thenReturn(IssuedUserToken("token-value", expiresAt))
+        stubConfiguration(tokenGeneration = 3)
+        stubDefinition()
+        whenever(
+            userTokenService.issue(eq("john@example.com"), eq(listOf("ROLE_USER")), eq(configurationId), eq(3L))
+        ).thenReturn(IssuedUserToken("token-value", expiresAt))
         whenever(grantedEndpointRepository.findAllByConfigurationId(configurationId)).thenReturn(
             listOf(
                 grantedEndpoint("GET", "/api/v1/documents/**"),
@@ -95,14 +106,18 @@ class ExternalPluginUserTokenResourceTest {
             ExternalPluginUserTokenResource.GrantedEndpointDto("GET", "/api/v1/documents/**"),
             ExternalPluginUserTokenResource.GrantedEndpointDto("POST", "/api/v1/process/*/start"),
         )
+        // The minted token is bound to the configuration's *current* generation, so a later
+        // revoke-tokens bump invalidates it.
+        verify(userTokenService).issue(eq("john@example.com"), eq(listOf("ROLE_USER")), eq(configurationId), eq(3L))
     }
 
     @Test
     fun `returns an empty granted-endpoint list for a configuration that grants nothing`() {
         // An empty list must be surfaced as such (not omitted): the frontend precheck treats an
         // empty allowlist as deny-all, mirroring the server-side allowlist filter.
-        whenever(configurationRepository.existsById(configurationId)).thenReturn(true)
-        whenever(userTokenService.issue(any(), any(), any()))
+        stubConfiguration()
+        stubDefinition()
+        whenever(userTokenService.issue(any(), any(), any(), any()))
             .thenReturn(IssuedUserToken("token-value", Instant.now().plusSeconds(900)))
         whenever(grantedEndpointRepository.findAllByConfigurationId(configurationId)).thenReturn(emptyList())
 
@@ -113,13 +128,13 @@ class ExternalPluginUserTokenResourceTest {
 
     @Test
     fun `rejects an unknown configuration with 404 and does not mint`() {
-        whenever(configurationRepository.existsById(configurationId)).thenReturn(false)
+        whenever(configurationRepository.findById(configurationId)).thenReturn(Optional.empty())
 
         assertThatThrownBy { resource.mintUserToken(configurationId) }
             .isInstanceOf(ResponseStatusException::class.java)
             .extracting { (it as ResponseStatusException).statusCode }
             .isEqualTo(HttpStatus.NOT_FOUND)
-        verify(userTokenService, never()).issue(any(), any(), any())
+        verify(userTokenService, never()).issue(any(), any(), any(), any())
     }
 
     @Test
@@ -130,7 +145,49 @@ class ExternalPluginUserTokenResourceTest {
             .isInstanceOf(ResponseStatusException::class.java)
             .extracting { (it as ResponseStatusException).statusCode }
             .isEqualTo(HttpStatus.UNAUTHORIZED)
-        verify(userTokenService, never()).issue(any(), any(), any())
+        verify(userTokenService, never()).issue(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `refuses to mint with 409 while the plugin's changed content awaits re-acceptance`() {
+        stubConfiguration()
+        stubDefinition(pendingContentHash = "sha256:changed")
+
+        assertThatThrownBy { resource.mintUserToken(configurationId) }
+            .isInstanceOf(ResponseStatusException::class.java)
+            .extracting { (it as ResponseStatusException).statusCode }
+            .isEqualTo(HttpStatus.CONFLICT)
+        verify(userTokenService, never()).issue(any(), any(), any(), any())
+    }
+
+    private fun stubConfiguration(tokenGeneration: Long = 0) {
+        whenever(configurationRepository.findById(configurationId)).thenReturn(
+            Optional.of(
+                ExternalPluginConfiguration(
+                    id = configurationId,
+                    definitionId = definitionId,
+                    title = "Config",
+                    tokenGeneration = tokenGeneration,
+                )
+            )
+        )
+    }
+
+    private fun stubDefinition(pendingContentHash: String? = null) {
+        whenever(definitionRepository.findById(definitionId)).thenReturn(
+            Optional.of(
+                ExternalPluginDefinition(
+                    id = definitionId,
+                    pluginId = "case-summary",
+                    version = "0.1.0",
+                    hostId = UUID.randomUUID(),
+                    baseUrl = "http://localhost:8090/plugins/case-summary",
+                    status = ExternalPluginDefinitionStatus.AVAILABLE,
+                    contentHash = "sha256:accepted",
+                    pendingContentHash = pendingContentHash,
+                )
+            )
+        )
     }
 
     private fun grantedEndpoint(method: String, pattern: String) = ExternalPluginGrantedEndpoint(

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-upload-modal/plugin-upload-modal.component.html
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-upload-modal/plugin-upload-modal.component.html
@@ -42,6 +42,11 @@
       >
       </cds-file-uploader>
     </div>
+
+    <cds-inline-notification
+      *ngIf="$uploadNotification() as uploadNotification"
+      [notificationObj]="uploadNotification"
+    ></cds-inline-notification>
   </section>
 
   <cds-modal-footer>
@@ -69,3 +74,36 @@
   (confirmEvent)="onConfirmIncompatibleUpload()"
   (cancelEvent)="onCancelIncompatibleUpload()"
 ></valtimo-confirmation-modal>
+
+<cds-modal *ngIf="$overwriteReview() as overwriteReview" [open]="true" size="md" valtimoCdsModal>
+  <cds-modal-header (closeSelect)="onCancelOverwrite()">
+    <h3 cdsModalHeaderHeading>
+      {{ 'pluginManagement.upload.overwriteTitle' | translate }}
+    </h3>
+  </cds-modal-header>
+
+  <section cdsModalContent [cdsLayer]="1" class="plugin-upload-modal__overwrite-content">
+    <cds-inline-notification [notificationObj]="overwriteReview.warning"></cds-inline-notification>
+
+    <valtimo-plugin-external-permissions
+      [capabilities]="overwriteReview.capabilities"
+      [endpoints]="overwriteReview.endpoints"
+      [eventSubscriptions]="overwriteReview.eventSubscriptions"
+      (validEvent)="onOverwriteValidityChange($event)"
+    ></valtimo-plugin-external-permissions>
+  </section>
+
+  <cds-modal-footer>
+    <button cdsButton="secondary" [disabled]="$uploading()" (click)="onCancelOverwrite()">
+      {{ 'interface.cancel' | translate }}
+    </button>
+
+    <button
+      cdsButton="danger"
+      [disabled]="!$overwriteAcknowledged() || $uploading()"
+      (click)="onConfirmOverwrite()"
+    >
+      {{ 'pluginManagement.upload.overwriteConfirm' | translate }}
+    </button>
+  </cds-modal-footer>
+</cds-modal>

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-upload-modal/plugin-upload-modal.component.scss
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-upload-modal/plugin-upload-modal.component.scss
@@ -2,8 +2,17 @@
   display: block;
 }
 
-.plugin-upload-modal__content {
+.plugin-upload-modal__content,
+.plugin-upload-modal__overwrite-content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--cds-spacing-05);
+
+  // The modal content is a definite-height scroll area (`.cds--modal-content`, overflow-y auto).
+  // Without this, overflowing content makes the flex column *shrink* its children instead of
+  // scrolling — the inline notification gets squashed to its 48px minimum while its text paints
+  // outside the box. Children keep their natural height; the section scrolls.
+  > * {
+    flex-shrink: 0;
+  }
 }

--- a/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-upload-modal/plugin-upload-modal.component.ts
+++ b/frontend/projects/valtimo/plugin-management/src/lib/components/plugin-upload-modal/plugin-upload-modal.component.ts
@@ -39,11 +39,27 @@ import {
   ListItem,
   LoadingModule,
   ModalModule,
+  NotificationContent,
+  NotificationModule,
 } from 'carbon-components-angular';
 import {ConfirmationModalModule, ValtimoCdsModalDirective} from '@valtimo/components';
-import {ExternalPluginHost, ExternalPluginService} from '@valtimo/plugin';
+import {ExternalPluginEndpoint, ExternalPluginHost, ExternalPluginService} from '@valtimo/plugin';
 import {BehaviorSubject} from 'rxjs';
 import {buildExternalPluginCompatibilityMessage} from '../../utils';
+import {PluginExternalPermissionsComponent} from '../plugin-external-permissions/plugin-external-permissions.component';
+
+/**
+ * State of the overwrite-review dialog: what the already-existing version is, the permissions the
+ * uploaded package requests (shown for re-review) and the pre-built warning notification.
+ */
+interface OverwriteReview {
+  pluginId: string;
+  version: string;
+  endpoints: Array<ExternalPluginEndpoint>;
+  eventSubscriptions: Array<string>;
+  capabilities: Array<string>;
+  warning: NotificationContent;
+}
 
 @Component({
   standalone: true,
@@ -61,8 +77,10 @@ import {buildExternalPluginCompatibilityMessage} from '../../utils';
     FileUploaderModule,
     LayerModule,
     LoadingModule,
+    NotificationModule,
     ValtimoCdsModalDirective,
     ConfirmationModalModule,
+    PluginExternalPermissionsComponent,
   ],
 })
 export class PluginUploadModalComponent implements OnChanges {
@@ -79,6 +97,18 @@ export class PluginUploadModalComponent implements OnChanges {
   // Drives the "upload anyway?" confirmation shown when the backend rejects an incompatible plugin.
   public readonly _compatibilityModalOpen$ = new BehaviorSubject<boolean>(false);
   public readonly $compatibilityWarning = signal<string>('');
+
+  // Inline notification for outcomes the modal handles itself: an identical package that is
+  // already on the host (info) or any other host rejection (error). These 409s are deliberately
+  // kept off the global error toast (X-Skip-Interceptor), so this notification is their only
+  // surface.
+  public readonly $uploadNotification = signal<NotificationContent | null>(null);
+
+  // Drives the overwrite-review dialog shown when the uploaded pluginId@version already exists
+  // with different content: the admin re-reviews the requested permissions and explicitly
+  // confirms before the version is overwritten.
+  public readonly $overwriteReview = signal<OverwriteReview | null>(null);
+  public readonly $overwriteAcknowledged = signal<boolean>(false);
 
   public readonly _fileForm = this._formBuilder.group({
     file: this._formBuilder.control(new Set<any>(), [Validators.required]),
@@ -118,7 +148,7 @@ export class PluginUploadModalComponent implements OnChanges {
     this.$selectedHostId.set(event?.item?.hostId ?? null);
   }
 
-  public onUpload(force = false): void {
+  public onUpload(force = false, overwrite = false): void {
     const hostId = this.$selectedHostId();
     const fileSet = this._fileForm.value.file;
     const file: File | undefined = fileSet?.values()?.next()?.value?.file;
@@ -126,8 +156,9 @@ export class PluginUploadModalComponent implements OnChanges {
     if (!hostId || !file) return;
 
     this.$uploading.set(true);
+    this.$uploadNotification.set(null);
 
-    this._externalPluginService.uploadPlugin(hostId, file, force).subscribe({
+    this._externalPluginService.uploadPlugin(hostId, file, force, overwrite).subscribe({
       next: () => {
         this.$uploading.set(false);
         this.uploadedEvent.emit();
@@ -140,9 +171,28 @@ export class PluginUploadModalComponent implements OnChanges {
             buildExternalPluginCompatibilityMessage(error.error, this._translateService)
           );
           this._compatibilityModalOpen$.next(true);
+        } else if (error.status === 409 && error.error?.code === 'PLUGIN_VERSION_EXISTS') {
+          this._handleVersionExists(error.error);
+        } else if (error.status === 409) {
+          this.$uploadNotification.set(this._buildUploadErrorNotification(error));
         }
       },
     });
+  }
+
+  public onConfirmOverwrite(): void {
+    this.$overwriteReview.set(null);
+    // Compatibility was already checked (or explicitly forced) on the attempt that produced the
+    // version-exists 409; force=true keeps the compatibility gate from prompting a second time.
+    this.onUpload(true, true);
+  }
+
+  public onCancelOverwrite(): void {
+    this.$overwriteReview.set(null);
+  }
+
+  public onOverwriteValidityChange(valid: boolean): void {
+    this.$overwriteAcknowledged.set(valid);
   }
 
   public onConfirmIncompatibleUpload(): void {
@@ -163,6 +213,93 @@ export class PluginUploadModalComponent implements OnChanges {
     this.closeEvent.emit();
     this.$selectedHostId.set(null);
     this.$fileSelected.set(false);
+    this.$uploadNotification.set(null);
+    this.$overwriteReview.set(null);
+    this.$overwriteAcknowledged.set(false);
     this._fileForm.reset({file: new Set()});
+  }
+
+  /**
+   * The uploaded pluginId@version already exists on the host. Identical content means there is
+   * nothing to overwrite — a friendly info suffices. Different (or undeterminable) content opens
+   * the overwrite-review dialog: the requested permissions from the enriched 409 body are shown
+   * for re-review and the admin must explicitly acknowledge them before the overwrite proceeds.
+   */
+  private _handleVersionExists(body: {
+    pluginId?: string;
+    version?: string;
+    currentContentHash?: string;
+    uploadedContentHash?: string;
+    requestedEndpoints?: Array<ExternalPluginEndpoint>;
+    requestedEventSubscriptions?: Array<string>;
+    requestedCapabilities?: Array<string>;
+  }): void {
+    const identical =
+      !!body.currentContentHash &&
+      !!body.uploadedContentHash &&
+      body.currentContentHash === body.uploadedContentHash;
+
+    if (identical) {
+      this.$uploadNotification.set({
+        type: 'info',
+        title: this._translateService.instant('pluginManagement.upload.identicalTitle'),
+        message: this._translateService.instant('pluginManagement.upload.identicalMessage'),
+        showClose: false,
+        lowContrast: true,
+      });
+      return;
+    }
+
+    this.$overwriteAcknowledged.set(false);
+    this.$overwriteReview.set({
+      pluginId: body.pluginId ?? '',
+      version: body.version ?? '',
+      endpoints: body.requestedEndpoints ?? [],
+      eventSubscriptions: body.requestedEventSubscriptions ?? [],
+      capabilities: body.requestedCapabilities ?? [],
+      warning: {
+        type: 'warning',
+        title: this._translateService.instant('pluginManagement.upload.overwriteWarningTitle'),
+        message: this._translateService.instant('pluginManagement.upload.overwriteWarning', {
+          pluginId: body.pluginId ?? '',
+          version: body.version ?? '',
+        }),
+        showClose: false,
+        lowContrast: true,
+      },
+    });
+  }
+
+  private _buildUploadErrorNotification(error: HttpErrorResponse): NotificationContent {
+    const hostBody = this._parseRelayedHostBody(error);
+    const message = [
+      this._translateService.instant('pluginManagement.upload.rejected'),
+      hostBody?.message ?? hostBody?.error ?? '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return {
+      type: 'error',
+      title: this._translateService.instant('pluginManagement.upload.failedTitle'),
+      message,
+      showClose: false,
+      lowContrast: true,
+    };
+  }
+
+  // The backend relays a host rejection as `{error, detail}` where `detail` holds the host's raw
+  // JSON body (e.g. `{code, error, message}`); non-JSON detail is shown as-is.
+  private _parseRelayedHostBody(
+    error: HttpErrorResponse
+  ): {code?: string; error?: string; message?: string} | null {
+    const detail = error.error?.detail;
+    if (typeof detail !== 'string' || detail.length === 0) return null;
+
+    try {
+      return JSON.parse(detail);
+    } catch {
+      return {message: detail};
+    }
   }
 }

--- a/frontend/projects/valtimo/plugin/src/lib/models/external-plugin.model.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/models/external-plugin.model.ts
@@ -144,6 +144,16 @@ interface ExternalPluginDefinition {
   currentGzacVersion: string | null;
   compatible: boolean;
   logoUrl: string | null;
+  /**
+   * Package content hash pinned when the plugin was discovered, and — when the host started
+   * serving different bytes under the same pluginId@version — the hash it serves now. While
+   * `requiresReacceptance` is true the backend withholds configuration pushes, tokens and
+   * invocations; an admin confirms the reviewed `pendingContentHash` via
+   * `POST /definition/{id}/accept-content` to resume.
+   */
+  contentHash: string | null;
+  pendingContentHash: string | null;
+  requiresReacceptance: boolean;
 }
 
 /** The subset of compatibility fields needed to render a warning message. */
@@ -158,6 +168,8 @@ interface ExternalPluginConfiguration {
   definitionId: string;
   title: string;
   createdAt: string;
+  /** Revocation counter — bumped by `POST /configuration/{id}/revoke-tokens`. */
+  tokenGeneration: number;
 }
 
 /** Response of the downscoped user-token mint endpoint (`.../configuration/{id}/user-token`). */

--- a/frontend/projects/valtimo/plugin/src/lib/services/external-plugin.service.ts
+++ b/frontend/projects/valtimo/plugin/src/lib/services/external-plugin.service.ts
@@ -166,15 +166,17 @@ export class ExternalPluginService {
   }
 
   /**
-   * Uploads a plugin package to the host. When `force` is false the backend rejects a plugin that
-   * is incompatible with the running GZAC version with a 409 carrying the version details; the
-   * caller catches it to warn the operator and re-issues with `force=true` to proceed. The
-   * `X-Skip-Interceptor` header keeps that expected 409 from raising a global error toast.
+   * Uploads a plugin package to the host. Two expected 409s drive the upload UX (both kept off
+   * the global error toast by the `X-Skip-Interceptor` header): an incompatible plugin returns
+   * the version details and is retried with `force=true` after the operator confirms, and an
+   * already-existing pluginId@version returns `code=PLUGIN_VERSION_EXISTS` plus the package's
+   * requested permissions and is retried with `overwrite=true` after the operator re-reviews the
+   * permissions and confirms the overwrite.
    */
-  public uploadPlugin(hostId: string, file: File, force = false): Observable<unknown> {
+  public uploadPlugin(hostId: string, file: File, force = false, overwrite = false): Observable<unknown> {
     const formData = new FormData();
     formData.append('file', file, file.name);
-    const params = new HttpParams().set('force', force);
+    const params = new HttpParams().set('force', force).set('overwrite', overwrite);
     const headers = new HttpHeaders().set(InterceptorSkip, '409');
     return this._http.post(`${this._baseUrl}/host/${hostId}/upload`, formData, {headers, params});
   }

--- a/frontend/projects/valtimo/shared/assets/core/en.json
+++ b/frontend/projects/valtimo/shared/assets/core/en.json
@@ -2234,7 +2234,15 @@
     "upload": {
       "title": "Plugin bundle",
       "buttonText": "Choose file",
-      "description": "Only .zip files are accepted"
+      "description": "Only .zip files are accepted",
+      "failedTitle": "Upload failed",
+      "rejected": "The plugin host rejected the upload.",
+      "identicalTitle": "Already up to date",
+      "identicalMessage": "This exact package already exists on the host — the content is identical, so there is nothing to overwrite.",
+      "overwriteTitle": "Overwrite existing plugin version?",
+      "overwriteWarningTitle": "This will overwrite the current plugin version",
+      "overwriteWarning": "Version {{version}} of '{{pluginId}}' already exists on the host with different content. Overwriting it can lead to unexpected behavior for configurations and processes that already use this version. Since the content differs, review the permissions the uploaded package requests below and confirm to proceed — all existing configurations of this version will be reset to exactly these permissions.",
+      "overwriteConfirm": "Overwrite version"
     },
     "noDefinitions": "No plugin definitions found.",
     "noHosts": "No plugin hosts configured.",

--- a/frontend/projects/valtimo/shared/assets/core/nl.json
+++ b/frontend/projects/valtimo/shared/assets/core/nl.json
@@ -2261,7 +2261,15 @@
     "upload": {
       "title": "Plugin-bundel",
       "buttonText": "Bestand kiezen",
-      "description": "Alleen .zip-bestanden worden geaccepteerd"
+      "description": "Alleen .zip-bestanden worden geaccepteerd",
+      "failedTitle": "Uploaden mislukt",
+      "rejected": "De plugin-host heeft de upload geweigerd.",
+      "identicalTitle": "Al up-to-date",
+      "identicalMessage": "Exact dit pakket staat al op de host — de inhoud is identiek, dus er valt niets te overschrijven.",
+      "overwriteTitle": "Bestaande pluginversie overschrijven?",
+      "overwriteWarningTitle": "Dit overschrijft de huidige pluginversie",
+      "overwriteWarning": "Versie {{version}} van '{{pluginId}}' bestaat al op de host met andere inhoud. Overschrijven kan tot onverwacht gedrag leiden voor configuraties en processen die deze versie al gebruiken. Omdat de inhoud verschilt: beoordeel hieronder de permissies die het geüploade pakket vraagt en bevestig om door te gaan — alle bestaande configuraties van deze versie worden opnieuw ingesteld op exact deze permissies.",
+      "overwriteConfirm": "Versie overschrijven"
     },
     "noDefinitions": "Geen plugin-definities gevonden.",
     "noHosts": "Geen plugin-hosts geconfigureerd.",

--- a/plugin-host/app/src/plugin-manager.test.ts
+++ b/plugin-host/app/src/plugin-manager.test.ts
@@ -207,6 +207,43 @@ describe("PluginManager (mocked Extism)", () => {
     expect(instance.close).toHaveBeenCalled();
   });
 
+  describe("package content hash", () => {
+    it("computes a stable hash at load time and exposes it via getContentHash and listPlugins", async () => {
+      manager = makeManager();
+      await manager.loadPlugin(PLUGIN_ID, VERSION);
+
+      const hash = manager.getContentHash(PLUGIN_ID, VERSION);
+      expect(hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(manager.listPlugins()[0]).toMatchObject({ pluginId: PLUGIN_ID, contentHash: hash });
+      expect(manager.listVersions(PLUGIN_ID)[0]).toMatchObject({ contentHash: hash });
+
+      // Reloading unchanged bytes yields the same hash.
+      await manager.loadPlugin(PLUGIN_ID, VERSION);
+      expect(manager.getContentHash(PLUGIN_ID, VERSION)).toBe(hash);
+    });
+
+    it("changes the hash when any packaged file changes — including frontend assets", async () => {
+      manager = makeManager();
+      await manager.loadPlugin(PLUGIN_ID, VERSION);
+      const original = manager.getContentHash(PLUGIN_ID, VERSION);
+
+      const frontendDir = join(storageDir, PLUGIN_ID, VERSION, "frontend");
+      mkdirSync(frontendDir, { recursive: true });
+      writeFileSync(join(frontendDir, "case-tab.bundle.js"), "console.log('v2');");
+      await manager.loadPlugin(PLUGIN_ID, VERSION);
+
+      expect(manager.getContentHash(PLUGIN_ID, VERSION)).not.toBe(original);
+    });
+
+    it("hasVersion reports loaded versions and unloaded-but-on-disk versions", async () => {
+      manager = makeManager();
+      expect(manager.hasVersion(PLUGIN_ID, VERSION)).toBe(true); // on disk, not loaded
+      await manager.loadPlugin(PLUGIN_ID, VERSION);
+      expect(manager.hasVersion(PLUGIN_ID, VERSION)).toBe(true); // loaded
+      expect(manager.hasVersion(PLUGIN_ID, "9.9.9")).toBe(false);
+    });
+  });
+
   it("evicts an instance that has been idle past the TTL, via the periodic sweep", async () => {
     vi.useFakeTimers();
     manager = makeManager({ instanceIdleTtlMs: 1_000 });

--- a/plugin-host/app/src/plugin-manager.ts
+++ b/plugin-host/app/src/plugin-manager.ts
@@ -19,6 +19,7 @@ import createPlugin from "@extism/extism";
 import {mkdir, readdir, readFile, rm, writeFile} from "node:fs/promises";
 import {join} from "node:path";
 import {existsSync} from "node:fs";
+import {createHash} from "node:crypto";
 import type {HostLogger, PluginConfiguration, PluginManifest} from "./models/index.js";
 import {createGzacApiHostFunction, type GzacApiCallContext} from "./host-functions/gzac-api.js";
 import type {KvRepository} from "./db/kv-repository.js";
@@ -31,6 +32,8 @@ interface LoadedPlugin {
   pluginId: string;
   version: string;
   manifest: PluginManifest;
+  /** Package content hash (see {@link computeContentHash}) — GZAC pins this at discovery. */
+  contentHash: string;
   wasmPath: string;
   extismPlugin: ExtismPlugin | null;
   /**
@@ -76,6 +79,37 @@ const DEFAULT_INSTANCE_IDLE_TTL_MS = 10 * 60 * 1000;
 /** Extism cancels a timed-out call with "EXTISM: call canceled due to timeout". */
 function isWasmTimeoutError(err: unknown): boolean {
   return err instanceof Error && /canceled due to timeout/i.test(err.message);
+}
+
+/**
+ * Computes the package content hash: SHA-256 over every file in the plugin version directory
+ * (manifest.json, plugin.wasm, the logo, frontend/**), each record bound to its relative path and
+ * byte length so files cannot be renamed or shuffled without changing the hash. GZAC pins this
+ * value at discovery and flags the definition for re-acceptance when it changes — the on-disk
+ * package is tamper-evident even though the host itself is only semi-trusted.
+ */
+async function computeContentHash(pluginDir: string): Promise<string> {
+  const files: string[] = [];
+  const walk = async (dir: string, prefix: string): Promise<void> => {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(join(dir, entry.name), rel);
+      } else if (entry.isFile()) {
+        files.push(rel);
+      }
+    }
+  };
+  await walk(pluginDir, "");
+  files.sort();
+
+  const hash = createHash("sha256");
+  for (const rel of files) {
+    const content = await readFile(join(pluginDir, rel));
+    hash.update(`${rel}\0${content.length}\0`);
+    hash.update(content);
+  }
+  return `sha256:${hash.digest("hex")}`;
 }
 
 /**
@@ -159,6 +193,8 @@ export class PluginManager {
       );
     }
 
+    const contentHash = await computeContentHash(pluginDir);
+
     const k = this.key(pluginId, version);
 
     // If already loaded, unload first (hot-reload)
@@ -171,13 +207,14 @@ export class PluginManager {
       pluginId,
       version,
       manifest,
+      contentHash,
       wasmPath,
       extismPlugin: null,
       lock: Promise.resolve(),
       lastUsedAt: Date.now(),
     });
 
-    this.logger.info({ pluginId, version }, "Plugin loaded");
+    this.logger.info({ pluginId, version, contentHash }, "Plugin loaded");
   }
 
   /**
@@ -648,16 +685,35 @@ export class PluginManager {
   }
 
   /**
+   * Get the package content hash for a loaded plugin.
+   */
+  getContentHash(pluginId: string, version: string): string | null {
+    const k = this.key(pluginId, version);
+    return this.plugins.get(k)?.contentHash ?? null;
+  }
+
+  /**
+   * Whether this plugin version exists — loaded in memory or present on disk. Used by the upload
+   * route to make versions immutable: a version that ever existed cannot be silently replaced.
+   */
+  hasVersion(pluginId: string, version: string): boolean {
+    if (this.plugins.has(this.key(pluginId, version))) return true;
+    return existsSync(join(this.storageDir, pluginId, version, "manifest.json"));
+  }
+
+  /**
    * List all loaded plugins.
    */
   listPlugins(): Array<{
     pluginId: string;
     version: string;
+    contentHash: string;
     manifest: PluginManifest;
   }> {
     return Array.from(this.plugins.values()).map((p) => ({
       pluginId: p.pluginId,
       version: p.version,
+      contentHash: p.contentHash,
       manifest: p.manifest,
     }));
   }
@@ -667,10 +723,10 @@ export class PluginManager {
    */
   listVersions(
     pluginId: string
-  ): Array<{ version: string; manifest: PluginManifest }> {
+  ): Array<{ version: string; contentHash: string; manifest: PluginManifest }> {
     return Array.from(this.plugins.values())
       .filter((p) => p.pluginId === pluginId)
-      .map((p) => ({ version: p.version, manifest: p.manifest }));
+      .map((p) => ({ version: p.version, contentHash: p.contentHash, manifest: p.manifest }));
   }
 
   /**

--- a/plugin-host/app/src/plugin-manager.ts
+++ b/plugin-host/app/src/plugin-manager.ts
@@ -87,8 +87,11 @@ function isWasmTimeoutError(err: unknown): boolean {
  * byte length so files cannot be renamed or shuffled without changing the hash. GZAC pins this
  * value at discovery and flags the definition for re-acceptance when it changes — the on-disk
  * package is tamper-evident even though the host itself is only semi-trusted.
+ *
+ * Exported so the upload route can hash an extracted-but-not-yet-stored package and tell an
+ * identical re-upload apart from one with different content.
  */
-async function computeContentHash(pluginDir: string): Promise<string> {
+export async function computeContentHash(pluginDir: string): Promise<string> {
   const files: string[] = [];
   const walk = async (dir: string, prefix: string): Promise<void> => {
     for (const entry of await readdir(dir, { withFileTypes: true })) {

--- a/plugin-host/app/src/routes/host-configurations.test.ts
+++ b/plugin-host/app/src/routes/host-configurations.test.ts
@@ -28,7 +28,10 @@ describe("host-configurations routes", () => {
     delete: ReturnType<typeof vi.fn>;
     list: ReturnType<typeof vi.fn>;
   };
-  let pluginManager: { getManifest: ReturnType<typeof vi.fn> };
+  let pluginManager: {
+    getManifest: ReturnType<typeof vi.fn>;
+    getContentHash: ReturnType<typeof vi.fn>;
+  };
   let eventConsumerManager: { sync: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
@@ -39,7 +42,10 @@ describe("host-configurations routes", () => {
       delete: vi.fn(async () => true),
       list: vi.fn(async () => []),
     };
-    pluginManager = { getManifest: vi.fn(() => ({ pluginId: "case-summary", version: "0.1.0" })) };
+    pluginManager = {
+      getManifest: vi.fn(() => ({ pluginId: "case-summary", version: "0.1.0" })),
+      getContentHash: vi.fn(() => "sha256:abc123"),
+    };
     eventConsumerManager = { sync: vi.fn(async () => {}) };
     app = await buildTestApp((a) =>
       hostConfigurationRoutes(a, {
@@ -124,6 +130,24 @@ describe("host-configurations routes", () => {
       const stored = configRegistry.set.mock.calls[0][1].eventBroker;
       expect(stored.queueMode).toBe("durable");
       expect(stored.queueTtlMs).toBe(60 * 60 * 1000);
+    });
+
+    it("accepts a push whose expectedContentHash matches the loaded package", async () => {
+      const res = await postConfig("cfg-1", validBody({ expectedContentHash: "sha256:abc123" }));
+      expect(res.statusCode).toBe(201);
+      expect(configRegistry.set).toHaveBeenCalled();
+    });
+
+    it("refuses a push with 409 when the package content no longer matches the pinned hash", async () => {
+      pluginManager.getContentHash.mockReturnValueOnce("sha256:tampered");
+      const res = await postConfig("cfg-1", validBody({ expectedContentHash: "sha256:abc123" }));
+      expect(res.statusCode).toBe(409);
+      expect(res.json()).toMatchObject({
+        expectedContentHash: "sha256:abc123",
+        actualContentHash: "sha256:tampered",
+      });
+      expect(configRegistry.set).not.toHaveBeenCalled();
+      expect(eventConsumerManager.sync).not.toHaveBeenCalled();
     });
 
     it("returns 400 when serviceToken is missing", async () => {

--- a/plugin-host/app/src/routes/host-configurations.ts
+++ b/plugin-host/app/src/routes/host-configurations.ts
@@ -125,6 +125,7 @@ export async function hostConfigurationRoutes(
       properties: Record<string, unknown>;
       serviceToken: string;
       gzacBaseUrl: string;
+      expectedContentHash?: unknown;
       eventSubscriptions?: unknown;
       grantedCapabilities?: unknown;
       grantedEndpoints?: unknown;
@@ -155,6 +156,27 @@ export async function hostConfigurationRoutes(
         error: `Plugin not loaded: ${pluginId}@${pluginVersion}`,
       });
       return;
+    }
+
+    // GZAC pins the package content hash it discovered and sends it with every push. Refusing a
+    // mismatch here means a config (and its fresh service token) can never be handed to plugin
+    // code that differs from what the admin accepted — even in the window between GZAC's
+    // discovery cycle and this push.
+    const expectedContentHash = request.body.expectedContentHash;
+    if (typeof expectedContentHash === "string" && expectedContentHash.length > 0) {
+      const actualContentHash = pluginManager.getContentHash(pluginId, pluginVersion);
+      if (actualContentHash !== expectedContentHash) {
+        request.log.warn(
+          { configId, pluginId, pluginVersion, expectedContentHash, actualContentHash },
+          "Configuration push refused: package content hash mismatch"
+        );
+        reply.code(409).send({
+          error: `Package content hash mismatch for ${pluginId}@${pluginVersion}`,
+          expectedContentHash,
+          actualContentHash,
+        });
+        return;
+      }
     }
 
     const eventBroker = normalizeEventBroker(request.body.eventBroker);

--- a/plugin-host/app/src/routes/host-management.test.ts
+++ b/plugin-host/app/src/routes/host-management.test.ts
@@ -98,14 +98,15 @@ describe("host-management routes", () => {
     await rm(TMP_BASE, { recursive: true, force: true }).catch(() => {});
   });
 
-  function uploadZip(zipBuffer: Buffer, secret?: string) {
+  function uploadZip(zipBuffer: Buffer, secret?: string, query = "") {
     const boundary = "----vitestboundary";
     return app.inject({
       method: "POST",
-      url: PLUGINS_PATH,
+      url: `${PLUGINS_PATH}${query}`,
       headers: {
         "content-type": `multipart/form-data; boundary=${boundary}`,
         // The signature binds the raw file bytes (not the multipart envelope) — see deferHmac.
+        // The query string is deliberately not signature-bound (hmac-auth strips it).
         ...signHeaders("POST", PLUGINS_PATH, zipBuffer, secret),
       },
       payload: multipartBody(boundary, zipBuffer),
@@ -151,14 +152,34 @@ describe("host-management routes", () => {
       );
     });
 
-    it("refuses to replace an existing version with 409 (versions are immutable)", async () => {
+    it("refuses to replace an existing version with 409 carrying both content hashes", async () => {
       pluginManager.hasVersion.mockReturnValueOnce(true);
       const res = await uploadZip(makeZip(validManifest));
       expect(res.statusCode).toBe(409);
-      expect(res.json()).toMatchObject({
+      const body = res.json() as Record<string, string>;
+      expect(body).toMatchObject({
+        code: "PLUGIN_VERSION_EXISTS",
         error: "Plugin version already exists: case-summary@0.1.0",
+        currentContentHash: "sha256:abc123", // the loaded package's hash (mocked)
       });
+      // The would-be hash of the uploaded package, so callers can tell an identical re-upload
+      // apart from different content.
+      expect(body.uploadedContentHash).toMatch(/^sha256:[0-9a-f]{64}$/);
       expect(pluginManager.storeAndLoad).not.toHaveBeenCalled();
+    });
+
+    it("replaces an existing version when the caller explicitly overwrites", async () => {
+      pluginManager.hasVersion.mockReturnValueOnce(true);
+      const res = await uploadZip(makeZip(validManifest), undefined, "?overwrite=true");
+      expect(res.statusCode).toBe(201);
+      expect(pluginManager.storeAndLoad).toHaveBeenCalledWith(
+        "case-summary",
+        "0.1.0",
+        expect.any(String),
+        expect.any(Buffer),
+        expect.any(String),
+        undefined
+      );
     });
 
     it("rejects an invalid manifest with 400 and validation details", async () => {

--- a/plugin-host/app/src/routes/host-management.test.ts
+++ b/plugin-host/app/src/routes/host-management.test.ts
@@ -62,6 +62,8 @@ describe("host-management routes", () => {
     listPlugins: ReturnType<typeof vi.fn>;
     listVersions: ReturnType<typeof vi.fn>;
     getManifest: ReturnType<typeof vi.fn>;
+    getContentHash: ReturnType<typeof vi.fn>;
+    hasVersion: ReturnType<typeof vi.fn>;
     storeAndLoad: ReturnType<typeof vi.fn>;
     removePlugin: ReturnType<typeof vi.fn>;
   };
@@ -73,6 +75,8 @@ describe("host-management routes", () => {
       listPlugins: vi.fn(() => [{ pluginId: "case-summary", version: "0.1.0" }]),
       listVersions: vi.fn(() => [{ version: "0.1.0" }]),
       getManifest: vi.fn(() => ({ pluginId: "case-summary", version: "0.1.0" })),
+      getContentHash: vi.fn(() => "sha256:abc123"),
+      hasVersion: vi.fn(() => false),
       storeAndLoad: vi.fn(async () => validManifest),
       removePlugin: vi.fn(async () => {}),
     };
@@ -132,7 +136,11 @@ describe("host-management routes", () => {
     it("stores and loads a valid package (file-byte-bound HMAC) → 201", async () => {
       const res = await uploadZip(makeZip(validManifest));
       expect(res.statusCode).toBe(201);
-      expect(res.json()).toMatchObject({ pluginId: "case-summary", version: "0.1.0" });
+      expect(res.json()).toMatchObject({
+        pluginId: "case-summary",
+        version: "0.1.0",
+        contentHash: "sha256:abc123",
+      });
       expect(pluginManager.storeAndLoad).toHaveBeenCalledWith(
         "case-summary",
         "0.1.0",
@@ -141,6 +149,16 @@ describe("host-management routes", () => {
         expect.any(String),
         undefined // no logo declared
       );
+    });
+
+    it("refuses to replace an existing version with 409 (versions are immutable)", async () => {
+      pluginManager.hasVersion.mockReturnValueOnce(true);
+      const res = await uploadZip(makeZip(validManifest));
+      expect(res.statusCode).toBe(409);
+      expect(res.json()).toMatchObject({
+        error: "Plugin version already exists: case-summary@0.1.0",
+      });
+      expect(pluginManager.storeAndLoad).not.toHaveBeenCalled();
     });
 
     it("rejects an invalid manifest with 400 and validation details", async () => {

--- a/plugin-host/app/src/routes/host-management.ts
+++ b/plugin-host/app/src/routes/host-management.ts
@@ -156,6 +156,20 @@ export async function hostManagementRoutes(
         return;
       }
 
+      // Versions are immutable: what an admin approved for pluginId@version must stay the exact
+      // bytes that keep running. Re-uploading the same version would silently hot-reload different
+      // code under an already-accepted identity (a time-of-check/time-of-use gap), so it is
+      // refused outright. Publishing a change requires a new version; removing a version first
+      // requires the delete route, which refuses while configurations still reference it.
+      if (pluginManager.hasVersion(manifest.pluginId, manifest.version)) {
+        reply.code(409).send({
+          error: `Plugin version already exists: ${manifest.pluginId}@${manifest.version}`,
+          message:
+            "Plugin versions are immutable. Publish the change under a new version number.",
+        });
+        return;
+      }
+
       // Read wasm
       const wasmPath = join(extractDir, "plugin.wasm");
       const wasmBuffer = await readFile(wasmPath);
@@ -180,6 +194,7 @@ export async function hostManagementRoutes(
       reply.code(201).send({
         pluginId: manifest.pluginId,
         version: manifest.version,
+        contentHash: pluginManager.getContentHash(manifest.pluginId, manifest.version),
         manifest: result,
       });
     } catch (err) {

--- a/plugin-host/app/src/routes/host-management.ts
+++ b/plugin-host/app/src/routes/host-management.ts
@@ -15,7 +15,7 @@
  */
 
 import { FastifyInstance } from "fastify";
-import { PluginManager } from "../plugin-manager.js";
+import { computeContentHash, PluginManager } from "../plugin-manager.js";
 import { ConfigRegistry } from "../config-registry.js";
 import { AppConfig } from "../config.js";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
@@ -98,6 +98,10 @@ export async function hostManagementRoutes(
    * The .zip must contain manifest.json and plugin.wasm at the root level.
    * pluginId and version are extracted from the manifest.
    *
+   * An upload whose pluginId@version already exists is refused with 409 unless the caller sends
+   * `?overwrite=true` — GZAC only does so after an admin explicitly confirmed the overwrite and
+   * re-reviewed the package's requested permissions, so a version is never replaced silently.
+   *
    * HMAC body binding: the signature covers the uploaded file bytes (the .zip), not the multipart
    * envelope — the backend signs the raw file bytes it sends, which the host reproduces below from
    * the parsed file stream. `deferHmac` skips the shared raw-body hook so verification can run once
@@ -156,18 +160,31 @@ export async function hostManagementRoutes(
         return;
       }
 
-      // Versions are immutable: what an admin approved for pluginId@version must stay the exact
-      // bytes that keep running. Re-uploading the same version would silently hot-reload different
-      // code under an already-accepted identity (a time-of-check/time-of-use gap), so it is
-      // refused outright. Publishing a change requires a new version; removing a version first
-      // requires the delete route, which refuses while configurations still reference it.
-      if (pluginManager.hasVersion(manifest.pluginId, manifest.version)) {
+      // A version is never replaced *silently*: re-uploading an existing pluginId@version without
+      // the explicit overwrite flag is refused, because different code would hot-reload under an
+      // already-accepted identity (a time-of-check/time-of-use gap). GZAC sends `?overwrite=true`
+      // only after an admin confirmed the overwrite and re-reviewed the package's requested
+      // permissions. The 409 carries both content hashes so the caller can tell an identical
+      // re-upload (nothing to do) apart from genuinely different content (review required).
+      const overwrite = (request.query as {overwrite?: string}).overwrite === "true";
+      const versionExists = pluginManager.hasVersion(manifest.pluginId, manifest.version);
+      if (versionExists && !overwrite) {
         reply.code(409).send({
+          // Machine-readable so GZAC's upload UI can branch without string-matching English text.
+          code: "PLUGIN_VERSION_EXISTS",
           error: `Plugin version already exists: ${manifest.pluginId}@${manifest.version}`,
           message:
-            "Plugin versions are immutable. Publish the change under a new version number.",
+            "This version already exists on the host. Overwriting requires explicit admin confirmation.",
+          currentContentHash: pluginManager.getContentHash(manifest.pluginId, manifest.version),
+          uploadedContentHash: await computeContentHash(extractDir),
         });
         return;
+      }
+      if (versionExists) {
+        request.log.warn(
+          { pluginId: manifest.pluginId, version: manifest.version },
+          "Overwriting existing plugin version (admin-confirmed)"
+        );
       }
 
       // Read wasm

--- a/plugin-host/app/src/routes/plugin-bundles.test.ts
+++ b/plugin-host/app/src/routes/plugin-bundles.test.ts
@@ -66,6 +66,21 @@ describe("plugin-bundles routes", () => {
       expect(res.body).toContain("console.log('bundle')");
     });
 
+    it("serves every bundle with a strict anti-exfiltration CSP", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: `/plugins/${PLUGIN}/${VERSION}/bundles/case-tab.bundle.js`,
+      });
+      const csp = res.headers["content-security-policy"] as string;
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("script-src 'self'");
+      expect(csp).toContain("connect-src 'self'");
+      expect(csp).toContain("form-action 'self'");
+      expect(csp).toContain("sandbox allow-scripts allow-forms");
+      expect(res.headers["x-content-type-options"]).toBe("nosniff");
+      expect(res.headers["referrer-policy"]).toBe("no-referrer");
+    });
+
     it("blocks a path-traversal attempt with 403", async () => {
       // %2e%2e%2f decodes to ../ — an attempt to escape the frontend/ directory to reach secret.txt.
       const res = await app.inject({
@@ -99,6 +114,9 @@ describe("plugin-bundles routes", () => {
       expect(res.statusCode).toBe(200);
       expect(res.headers["content-type"]).toBe("image/svg+xml");
       expect(res.headers["access-control-allow-origin"]).toBe("*");
+      // Plugin-authored content: same CSP as the bundles (an SVG can carry script).
+      expect(res.headers["content-security-policy"]).toContain("script-src 'self'");
+      expect(res.headers["x-content-type-options"]).toBe("nosniff");
     });
 
     it("returns 404 when the manifest declares no logo", async () => {

--- a/plugin-host/app/src/routes/plugin-bundles.ts
+++ b/plugin-host/app/src/routes/plugin-bundles.ts
@@ -34,11 +34,49 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 /**
+ * CSP for everything served out of a plugin package. The iframe sandbox already stops privilege
+ * escalation (opaque origin — no GZAC session or token); this policy closes the *exfiltration*
+ * channels a hostile bundle would otherwise have: `connect-src 'self'` kills fetch/XHR/beacon to
+ * third parties, `script-src 'self'` kills remote script loading, `img-src`/`font-src` kill
+ * pixel-beacon exfil, and `form-action 'self'` kills native form posts to external endpoints. An
+ * honest plugin loses nothing — all of its GZAC traffic flows through the parent-proxy postMessage
+ * transport, and its own assets all live under the same bundle path.
+ *
+ * The `sandbox` directive mirrors the embedding iframe's `sandbox="allow-scripts allow-forms"`
+ * attribute so a bundle opened directly in a top-level tab is *also* confined to an opaque origin
+ * instead of running same-origin with the host.
+ */
+const BUNDLE_CSP = [
+  "default-src 'none'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "media-src 'self'",
+  "form-action 'self'",
+  "base-uri 'none'",
+  "object-src 'none'",
+  "sandbox allow-scripts allow-forms",
+].join("; ");
+
+/** Shared hardening headers for plugin-authored content (bundles and the logo). */
+function pluginContentHeaders(reply: import("fastify").FastifyReply, contentType: string) {
+  return reply
+    .header("Content-Type", contentType)
+    .header("Cache-Control", "public, max-age=3600")
+    .header("Access-Control-Allow-Origin", "*")
+    .header("Content-Security-Policy", BUNDLE_CSP)
+    .header("X-Content-Type-Options", "nosniff")
+    .header("Referrer-Policy", "no-referrer");
+}
+
+/**
  * Public routes serving frontend bundles from plugin packages.
  *
  * GET /plugins/:pluginId/:version/bundles/* — serves static files from the
  * plugin's frontend/ directory. No authentication — these are public assets
- * loaded in iframes.
+ * loaded in iframes. Every response carries the strict {@link BUNDLE_CSP}.
  */
 export async function pluginBundleRoutes(
   fastify: FastifyInstance,
@@ -83,11 +121,7 @@ export async function pluginBundleRoutes(
       const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
       const content = await readFile(fullPath);
 
-      reply
-        .header("Content-Type", contentType)
-        .header("Cache-Control", "public, max-age=3600")
-        .header("Access-Control-Allow-Origin", "*")
-        .send(content);
+      pluginContentHeaders(reply, contentType).send(content);
     }
   );
 
@@ -123,11 +157,9 @@ export async function pluginBundleRoutes(
       const ext = extname(logoPath);
       const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
       const content = await readFile(logoPath);
-      reply
-        .header("Content-Type", contentType)
-        .header("Cache-Control", "public, max-age=3600")
-        .header("Access-Control-Allow-Origin", "*")
-        .send(content);
+      // Same policy as the bundles: a logo is plugin-authored content too (an SVG can carry
+      // script, which the CSP neutralises when the file is opened directly).
+      pluginContentHeaders(reply, contentType).send(content);
     }
   );
 }

--- a/plugin-host/docs/external-plugin-system-plan.md
+++ b/plugin-host/docs/external-plugin-system-plan.md
@@ -111,24 +111,29 @@ callbacks.
 
 **3.2 Token (`service/ExternalPluginServiceTokenService.kt`)** — HS256 JWT:
 `sub=external-plugin:{pluginId}:{configId}`, `type=external_plugin_service`, `plugin_config_id`,
-`plugin_id`, `plugin_version`, `iss=valtimo-gzac`, `exp=now+ttl`. **No roles.** Signed with
+`plugin_id`, `plugin_version`, `token_generation` (the configuration's revocation counter —
+§3.6), `iss=valtimo-gzac`, `exp=now+ttl`. **No roles.** Signed with
 `SHA-256(valtimo.plugin.encryption-secret + "|service")` — the shared
 `security/ExternalPluginTokenKeyProvider.kt` base derives a **domain-separated** key per token
 kind (`|service` here, `|user` for the iframe token, §13.3), so a token of one kind can never
 validate against the other kind's parser — the `type` claim is a routing hint, not the security
 boundary. See `security/ExternalPluginServiceTokenKeyProvider.kt`.
 The lifetime `ttl` is the `valtimo.external-plugin.service-token.ttl` property — a Spring duration
-(ISO-8601 `PT24H` or the `24h` shorthand), defaulting to 24h — parsed in the autoconfiguration
-(`DurationStyle.detectAndParse`) and handed to the service; the service itself falls back to 24h
-when constructed without one.
+(ISO-8601 `PT10M` or the `10m` shorthand), defaulting to **10 minutes** — parsed in the
+autoconfiguration (`DurationStyle.detectAndParse`) and handed to the service; the service itself
+falls back to 10 minutes when constructed without one. The short default costs nothing because the
+discovery poll (default 60s) re-pushes a fresh token every cycle (§3.6); it only caps how long a
+*leaked* token stays usable.
 
 **3.3 Recognition (`security/ExternalPluginServiceTokenFilter.kt`)** — registered **before**
 `BearerTokenAuthenticationFilter` (`security/ExternalPluginCallbackHttpSecurityConfigurer.kt`,
 `@Order(450)`): parses the bearer JWT with the service-token signing key; passes through if
-signature or `type` claim don't match (Keycloak tokens untouched); on match sets an
-`ExternalPluginServicePrincipal`, **strips the `Authorization` header**, and runs the rest of the
-chain inside `AuthorizationContext.runWithoutAuthorization` (PBAC is intentionally bypassed for
-service tokens — the allowlist is the sole gate). The service- and user-token filters share the
+signature or `type` claim don't match (Keycloak tokens untouched); on match the authenticator
+first checks the token's `token_generation` claim against the configuration's current counter
+(§3.6) — a mismatch, a missing claim, or a configuration that no longer exists rejects the token —
+then sets an `ExternalPluginServicePrincipal`, **strips the `Authorization` header**, and runs the
+rest of the chain inside `AuthorizationContext.runWithoutAuthorization` (PBAC is intentionally
+bypassed for service tokens — the allowlist is the sole gate). The service- and user-token filters share the
 `AbstractExternalPluginTokenFilter` base, and all three plugin filters are excluded from servlet
 auto-registration (disabled `FilterRegistrationBean`s in the autoconfiguration) so they run only
 inside the Spring Security chain, never a second time as bare servlet filters.
@@ -170,7 +175,7 @@ reported as a 504-shaped reply, with a 502-shaped reply for a failed fetch), so 
 endpoint cannot pin the plugin call and its per-plugin lock indefinitely.
 
 **3.6 Token lifecycle** — operator-tunable TTL (`valtimo.external-plugin.service-token.ttl`,
-default 24h, §3.2), **no separate refresh loop**. Each healthy discovery poll re-pushes every
+default 10m, §3.2), **no separate refresh loop**. Each healthy discovery poll re-pushes every
 configuration with a freshly issued token
 (`service/ExternalPluginDiscoveryService.syncConfigurations()`), continuously replacing tokens
 well inside their lifetime. That poll *is* the refresh mechanism (default 60s,
@@ -182,6 +187,18 @@ the same hosts. Discovery keeps a strict transaction discipline: all host HTTP I
 plugin listing, config re-pushes) runs **outside** any database transaction, with the bookkeeping
 writes in short per-host transactions (`TransactionTemplate`) — a slow or hanging host never pins
 a database connection, and one host's failure never rolls back another host's bookkeeping.
+
+**Revocation.** Every configuration carries a revocation counter
+(`external_plugin_configuration.token_generation`); every token minted for it — service (§3.2)
+*and* user (§13.3) — is stamped with that counter as its `token_generation` claim, and both token
+authenticators accept a token only while its claim equals the configuration's current value (a
+missing claim or a deleted configuration also rejects). `POST
+/api/management/v1/external-plugin/configuration/{id}/revoke-tokens` (ADMIN) bumps the counter and
+immediately re-pushes the configuration, handing the host a fresh token of the new generation: a
+leaked or hoarded token dies on its next use while a legitimate host keeps working without waiting
+for the next poll. Because the host's user-token introspection route authenticates with the token
+under introspection (§13.3), a revoked user token also stops validating for the host's `/data`
+path. Deleting the configuration is the other, heavier kill switch (§12).
 
 **3.7 Caveat** — service tokens bypass PBAC, so the allowlist is the entire authorization surface;
 an over-broad grant (`/api/v1/**`) gives broad role-free access. Hence the activation-time
@@ -315,13 +332,17 @@ DDL lives in the **core** module's changelog, not the external-plugin module's o
   `host_id`, `base_url`, `status`, plus `name`, `description`, `provider`, `min_gzac_version` /
   `max_gzac_version` (populated at discovery from the manifest's `compatibility` block, compared
   against the running GZAC version to surface a non-blocking compatibility warning — §11),
-  `consecutive_misses`. The
+  `consecutive_misses`, **plus** `content_hash` / `pending_content_hash` (changeset
+  `13-32-0/20260806-external-plugin-security-hardening.xml`): the package content hash pinned at
+  discovery, and — when the host serves different bytes under the same `pluginId@version` — the
+  hash it serves instead, which flags the definition for admin re-acceptance (§11). The
   manifest's declared `eventSubscriptions` live here (inside
   `manifest_json`), discovered from the host — but the authoritative subscription list for any
   given activated configuration is `external_plugin_granted_event` (next paragraph), not the
   manifest copy.
 - `external_plugin_configuration` — `definition_id`, `title`, `properties` (encrypted on schema
-  `x-secret` fields), `created_at`. API responses never carry secret values:
+  `x-secret` fields), `created_at`, and `token_generation` (bigint, the revocation counter every
+  minted token is validated against — §3.6). API responses never carry secret values:
   `GET .../configuration/{id}` returns **masked** properties with the `x-secret` fields omitted
   entirely (mirroring the embedded module's `PluginConfigurationDto`), and an update whose payload
   leaves a secret field absent or blank means "unchanged" — the stored ciphertext is kept and the
@@ -403,14 +424,19 @@ immediately instead of waiting for the next polling tick.
 
 ## 7. Plugin host 🟡 (`plugin-host/app/`, Node + Fastify + Extism)
 
-Routes: `GET /health`; `*/api/host/plugins[...]` (HMAC-signed §3.9; POST upload, GET list,
-DELETE); `POST|PUT|DELETE|GET /api/host/configurations/:configId` (HMAC-signed §3.9; push body
+Routes: `GET /health`; `*/api/host/plugins[...]` (HMAC-signed §3.9; POST upload, GET list —
+each listing entry carries the package `contentHash` GZAC pins at discovery, §11 — and DELETE);
+`POST|PUT|DELETE|GET /api/host/configurations/:configId` (HMAC-signed §3.9; push body
 carries `pluginId, pluginVersion, properties, serviceToken, gzacBaseUrl, eventSubscriptions,
-grantedCapabilities, grantedEndpoints` and optionally `eventBroker` — only `serviceToken`/
-`gzacBaseUrl` are actually validated, `pluginId`/`pluginVersion` are not null-checked beyond the
-plugin having to be loaded); `POST /plugins/:id/:version/actions/:key`
+grantedCapabilities, grantedEndpoints` and optionally `eventBroker` and `expectedContentHash` —
+only `serviceToken`/`gzacBaseUrl` are actually validated, `pluginId`/`pluginVersion` are not
+null-checked beyond the plugin having to be loaded, and a push whose `expectedContentHash` does
+not match the loaded package's hash is refused with 409 (§11) so a config and its fresh service
+token can never reach package bytes other than the pinned ones); `POST
+/plugins/:id/:version/actions/:key`
 (HMAC-signed §3.9 — **no GET variant**); public `GET …/plugin-manifest`, `…/logo`,
-`…/bundles/**`, and `POST …/data` (the `handle_request` RPC route, §13.4/§13.5 — browser-facing
+`…/bundles/**` (bundles and logo are served with the strict plugin-content CSP — see below), and
+`POST …/data` (the `handle_request` RPC route, §13.4/§13.5 — browser-facing
 with CORS `*` + `OPTIONS` preflight, so it carries no HMAC, but executing Wasm is gated on a
 chain of checks: the request must name a `configurationId` whose pushed configuration exists,
 targets this plugin version, **and was granted the `frontend_data` capability** — otherwise 403
@@ -437,8 +463,8 @@ plugin-delete guard's `listByPlugin` reads uncached (staleness there would risk 
 a just-pushed configuration references). The plugin manager serialises calls per plugin (a `lock`
 promise chain to avoid Extism reentrancy — unload, delete, and idle eviction chain through the
 **same** lock, so an instance is never closed mid-execution), sets `prefetch` on the broker
-channel, and hot-reloads a plugin (unload + reload) when a newer upload of the same
-`pluginId@version` arrives. Every Wasm call is bounded by a hard wall-clock limit
+channel, and computes each loaded package's `contentHash` at load time (§11). Every Wasm call is
+bounded by a hard wall-clock limit
 (`WASM_TIMEOUT_MS`, default 30 s): Extism cancels a timed-out call, the cached instance is
 dropped and the next call starts from a fresh one. The module's linear memory is capped
 (`WASM_MAX_MEMORY_PAGES`, default 4096 pages = 256 MiB; 0 uncaps), and idle instances — each
@@ -479,7 +505,26 @@ funnel through one generic `callExport`; the public `callAction`/`callEvent`/`ca
   directory — a crafted `../`, absolute, or drive-letter entry name rejects the whole package with
   400 — and only the files a plugin package may legitimately carry are extracted (root-level
   `manifest.json`, `plugin.wasm`, the logo, and `frontend/**`), so a hostile zip cannot plant
-  anything else even inside the temp dir.
+  anything else even inside the temp dir. **Versions are immutable**: an upload whose manifest
+  names a `pluginId@version` that already exists — loaded in memory *or* present on disk
+  (`hasVersion`) — is refused with 409; publishing a change requires a new version number, and
+  freeing a version first goes through the delete route with its configuration guard above. The
+  201 response carries the stored package's `contentHash` (§11).
+- **Plugin-content CSP** (`routes/plugin-bundles.ts`): every response serving plugin-authored
+  content — `…/bundles/**` **and** the logo (an SVG can carry script) — carries
+  `Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self'
+  'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; media-src 'self';
+  form-action 'self'; base-uri 'none'; object-src 'none'; sandbox allow-scripts allow-forms`,
+  plus `X-Content-Type-Options: nosniff` and `Referrer-Policy: no-referrer`. The iframe sandbox
+  (§13.2) stops *escalation*; this policy closes the *exfiltration* channels a hostile bundle
+  would otherwise have — `connect-src 'self'` kills fetch/XHR/beacon to third parties (opaque-
+  origin requests go out with `Origin: null`, which plenty of endpoints accept), `script-src
+  'self'` kills remote script loading, `img-src`/`font-src` kill pixel-beacon exfil, and
+  `form-action 'self'` kills native form posts to external endpoints. An honest plugin loses
+  nothing: its GZAC traffic flows through the parent-proxy postMessage transport and its own
+  assets live under the bundle path. The CSP `sandbox` directive mirrors the embedding iframe's
+  attribute, so a bundle opened directly in a top-level tab is confined to an opaque origin too,
+  instead of running same-origin with the host.
 
 Environment (`models/app-config.ts`): `ADMIN_TOKEN` (required — the shared secret used as the
 HMAC key for every GZAC→host route, §3.9), `PORT` (8090),
@@ -546,7 +591,10 @@ hosts can serve one instance.
 inside a database transaction. Activation and update register the push as an after-commit action
 (`runAfterCommit`), so a slow or unreachable host can never pin a database transaction open; a
 failed push is a warning only, self-healed by the next discovery re-sync. Configuration deletes
-remove the config from the host through the same after-commit mechanism.
+remove the config from the host through the same after-commit mechanism. `pushToHost` refuses to
+push at all — every caller funnels through it — while the definition's package content awaits
+re-acceptance (§11): no push means no fresh service token for package bytes the admin has not
+accepted.
 
 Push body shape (relevant fields):
 
@@ -557,6 +605,7 @@ Push body shape (relevant fields):
   "properties": { },
   "serviceToken": "eyJ…",
   "gzacBaseUrl": "http://gzac:8080",
+  "expectedContentHash": "sha256:…",
   "eventSubscriptions": ["com.ritense.valtimo.document.created", "com.ritense.valtimo.task.completed"],
   "grantedCapabilities": ["gzac_api", "log"],
   "grantedEndpoints": [{"method": "GET", "pattern": "/api/v1/document/*"}],
@@ -569,6 +618,10 @@ Push body shape (relevant fields):
   }
 }
 ```
+
+`expectedContentHash` is the definition's pinned package hash (§11; omitted while none is pinned).
+The host verifies its loaded package still matches before accepting the push and answers 409
+otherwise, closing the window between GZAC's discovery cycle and the push itself.
 
 Every push carries the configuration's granted endpoint list as a `grantedEndpoints` array
 (`{method, pattern}` entries), persisted in the host's `granted_endpoints` column (`NULL` when a
@@ -787,7 +840,7 @@ the origins, and it returns only the distinct `scheme://host[:port]` origins of 
 hosts — no admin tokens, broker URLs or configuration data) and passes the origins into the
 initializer before the meta tag is inserted (the CSP meta is immutable once parsed).
 
-## 11. Multi-version support & compatibility 🟡 (coexistence ✅, compatibility check ✅, in-place upgrade ⛔)
+## 11. Multi-version support, compatibility & content integrity ✅ (side-by-side versions, compatibility check, immutable + pinned packages)
 
 **Why coexistence matters.** Once a case definition becomes *final*, its BPMN — including any
 service tasks bound to an external-plugin action — is immutable. A process link cannot then be
@@ -819,6 +872,33 @@ versions of the same plugin must run side-by-side indefinitely**: there is no pa
    use.
 4. New BPMNs / case definitions bind their service tasks to the v2 configuration; existing final
    case definitions continue to reference their v1 configuration.
+
+**Version immutability & content pinning ✅.** A published version is the exact bytes the admin's
+acceptance covers — enforced end to end:
+
+- *Host — immutable versions.* Every loaded package has a `contentHash`: `sha256:` over every file
+  in the version directory (`manifest.json`, `plugin.wasm`, the logo, `frontend/**`), each record
+  bound to its relative path and byte length so files cannot be renamed or shuffled without
+  changing the hash. The hash is exposed in the plugin listing and the upload response, and an
+  upload naming an existing `pluginId@version` — loaded *or* on disk — is refused with 409 (§7):
+  publishing a change means publishing a new version.
+- *GZAC — pinning at discovery.* The definition stores the hash the host served when the plugin
+  was first discovered (`content_hash` — trust on first use, the same moment the definition
+  becomes configurable). Every later poll compares the discovered hash against the pinned one; a
+  difference sets `pending_content_hash` (surfaced as `requiresReacceptance` on the definition
+  DTO) and leaves the stored manifest/schema **frozen at the accepted state**.
+- *While flagged, the plugin is dark on every surface:* configuration pushes are withheld
+  (`pushToHost` refuses — §8.2 — so the host's last service token expires within its 10-minute
+  TTL), process-link actions fail with `EXTERNAL_PLUGIN_CONTENT_CHANGED`, task-form submissions
+  are refused with a user-visible error, and user tokens are not minted (409 — §13.3). Every push
+  additionally carries `expectedContentHash`, which the host verifies against its loaded package
+  (409 on mismatch), closing the window between GZAC's discovery cycle and the push.
+- *Re-acceptance.* `POST /api/management/v1/external-plugin/definition/{id}/accept-content`
+  (ADMIN) re-pins: the request echoes the exact pending hash the admin reviewed — acceptance of a
+  *specific* package, so a stale echo is rejected when the host has changed yet again — and an
+  immediate re-discovery then refreshes the manifest data and resumes pushes. A host serving the
+  pinned bytes again (a rollback) clears the flag automatically on the next poll. A host whose
+  listing carries no hash is simply not pinned.
 
 **✅ Version visibility in the UI.** The version appears in brackets after the localised plugin
 name (`Name (X.Y.Z)`) wherever that name is rendered, via `getExternalPluginDisplayName` (§10), so
@@ -888,8 +968,9 @@ The frontend surfaces incompatibility as a **non-blocking** warning, localised v
   toast by the `X-Skip-Interceptor: 409` request header) into an "Upload an incompatible plugin?"
   confirmation that re-issues the upload with `force=true`.
 
-**⛔ Other gaps.** Schema migration for an in-place v1 → v2 configuration "upgrade" is not
-implemented and arguably unnecessary given the side-by-side model. Permission-diff prompts and a
+**⛔ Other gaps.** Schema migration for moving a configuration from v1 to v2 is not implemented
+and arguably unnecessary given the side-by-side model (the package bytes of a published version
+are immutable in any case — see content pinning above). Permission-diff prompts and a
 `LATEST/STABLE/DEPRECATED` channel status are open. The compatibility range is a warning rather than
 an activation gate — only upload is a confirm-gate; an admin can still activate a configuration for
 an incompatible definition.
@@ -1071,6 +1152,13 @@ credential:
   the GZAC app's session / full Keycloak token and escalate beyond the allowlist. The opaque origin
   forecloses that, and is the reason the parent-proxy is used even when token *confidentiality*
   is not a concern.
+- **The sandbox stops escalation; the bundle CSP stops exfiltration.** The host serves every
+  bundle (and the logo) with a strict `Content-Security-Policy` — `default-src 'none'`,
+  `script-src 'self'`, `connect-src 'self'`, `form-action 'self'`, … (§7) — so a hostile bundle
+  cannot ship the data it legitimately receives through the parent-proxy off to a third party via
+  `fetch` (opaque-origin requests go out as `Origin: null`, which many endpoints accept), remote
+  script, pixel beacons or native form posts. The two mechanisms are complementary halves of the
+  iframe containment story.
 
 ### 13.3 Downscoped user token ✅
 
@@ -1078,11 +1166,13 @@ credential:
   deliberately **non-management** and **not ADMIN-gated** (any authenticated user; the result is
   always bounded by PBAC ∩ allowlist). Explicitly whitelisted `.authenticated()` in
   `ExternalPluginHttpSecurityConfigurer`. Reads the current user via
-  `SecurityUtils.getCurrentUserLogin()/getCurrentUserRoles()`, verifies the configuration exists, and
-  returns `{ userToken, expiresAt, grantedEndpoints }` — the configuration's granted endpoints ride
-  along so the iframe parent can seed its client-side allowlist precheck (§13.2) without a second
-  call. (Plugin tokens themselves can never call this endpoint — it sits on the hard denylist,
-  §3.4.)
+  `SecurityUtils.getCurrentUserLogin()/getCurrentUserRoles()`, loads the configuration (404 when
+  unknown; **409 while the definition's package content awaits re-acceptance — §11 — so the iframe
+  surface stays dark for a changed plugin**), stamps the configuration's current
+  `token_generation` into the token, and returns `{ userToken, expiresAt, grantedEndpoints }` —
+  the configuration's granted endpoints ride along so the iframe parent can seed its client-side
+  allowlist precheck (§13.2) without a second call. (Plugin tokens themselves can never call this
+  endpoint — it sits on the hard denylist, §3.4.)
 - **Introspection endpoint** `GET /api/v1/external-plugin/user-token/introspect`
   (`ExternalPluginUserTokenIntrospectionResource`) — the plugin host's validation counterpart:
   the host presents a user token as the bearer credential and receives the token's own claims,
@@ -1092,9 +1182,12 @@ credential:
   `ExternalPluginHttpSecurityConfigurer` and reachable for user-token principals through the
   narrow denylist carve-out (§3.4). The host calls it before executing Wasm for `/data` (§13.5).
 - **Token** (`ExternalPluginUserTokenService`): HS256, `sub=userLogin`, custom `roles` claim,
-  `plugin_config_id`, `type=external_plugin_user`, `iss=valtimo-gzac`, `iat`, `exp`. TTL from
-  `valtimo.external-plugin.user-token.ttl`, **hard-capped at 15 minutes**. Signed with its **own**
-  domain-separated key, `SHA-256(valtimo.plugin.encryption-secret + "|user")`
+  `plugin_config_id`, `token_generation` (the configuration's revocation counter — the user-token
+  authenticator applies the same generation check as the service-token path, §3.6, so revoking a
+  configuration's tokens kills its outstanding user tokens too, including their use against the
+  introspection endpoint below), `type=external_plugin_user`, `iss=valtimo-gzac`, `iat`, `exp`.
+  TTL from `valtimo.external-plugin.user-token.ttl`, **hard-capped at 15 minutes**. Signed with
+  its **own** domain-separated key, `SHA-256(valtimo.plugin.encryption-secret + "|user")`
   (`ExternalPluginUserTokenKeyProvider`, on the shared key-provider base — §3.2): a user token can
   never validate against the service-token parser or vice versa, so the `type` claim is a routing
   hint, not the security boundary.
@@ -1293,6 +1386,12 @@ Structure:
   and **menu pages** (§13) are done).
 - DLQ for nacked or expired messages (today `nack(false,false)` drops, `x-expires` deletes the
   queue and its contents).
+- Publisher **package signing** — content pinning (§11) is hash-based trust-on-first-use, tied to
+  whoever can reach the upload endpoint, not to a verified publisher identity.
+- Admin-UI surfaces for content re-acceptance and token revocation — both are API-complete
+  (`accept-content`, `revoke-tokens`; the definition DTO exposes `requiresReacceptance` /
+  `pendingContentHash`, the configuration DTO `tokenGeneration`) but have no dedicated screens
+  yet.
 
 ## 15. Roadmap (priority order)
 
@@ -1363,7 +1462,27 @@ Structure:
   `exception/ExternalPluginHostInUseExceptionTest` (pins the 409 problem-body shape: title,
   `CONFLICT` status, `hostId`, and the `PluginUsageDto` fields). The service-token suite
   (`service/ExternalPluginServiceTokenServiceTest`) asserts the issued JWT's `exp − iat` equals the
-  configured TTL and falls back to 24h when none is set.
+  configured TTL, falls back to 10 minutes when none is set, and stamps the configuration's
+  `token_generation` claim (§3.2).
+- Content-integrity and revocation suites, all green: `service/ExternalPluginDiscoveryServiceTest`
+  (hash pinned on first discovery, backfilled for pre-hash definitions, change flags
+  `pendingContentHash` + freezes the stored manifest + withholds pushes, rollback clears the
+  flag), `service/ExternalPluginConfigurationServicePushTest` (push carries
+  `expectedContentHash`, refuses while re-acceptance is pending, `revokeTokens` bumps the
+  generation and re-pushes a fresh token), `service/ExternalPluginDefinitionServiceTest`
+  (`acceptContent` re-pins, rejects a stale or absent pending hash),
+  `security/ExternalPluginServiceTokenFilterTest` / `security/ExternalPluginUserTokenFilterTest`
+  (tokens of a previous generation, without the claim, or for a deleted configuration are
+  rejected), `processlink/ExternalPluginServiceTaskStartListenerTest` /
+  `processlink/ExternalPluginTaskFormSubmissionServiceTest` (invocations and submissions refused
+  while re-acceptance is pending), and `web/rest/ExternalPluginUserTokenResourceTest` (mint 409
+  while pending; minted token bound to the current generation). Host-side (vitest):
+  `plugin-manager.test.ts` (stable content hash, changes with any packaged file, `hasVersion` on
+  disk and in memory), `routes/host-management.test.ts` (duplicate-version upload → 409),
+  `routes/host-configurations.test.ts` (push hash mismatch → 409), `routes/plugin-bundles.test.ts`
+  (strict CSP + `nosniff` + referrer policy on bundles and logo). PostgreSQL integration tests
+  green — the `20260806-external-plugin-security-hardening.xml` changeset applies and matches the
+  entities.
 - Backend `:backend:plugin:test` (`service/PluginServiceTest`): BUILD SUCCESSFUL — embedded
   `deletePluginConfiguration` proceeds when no fixed process link references the configuration,
   throws `PluginConfigurationInUseException` with the `usages` payload when one does, and a

--- a/plugin-host/docs/external-plugin-system-plan.md
+++ b/plugin-host/docs/external-plugin-system-plan.md
@@ -106,8 +106,11 @@ callbacks.
   `external_plugin_granted_capability` (`configuration_id`, `capability`);
   `update()` with non-null `grantedEndpoints` replaces the endpoint grants, null leaves them
   unchanged. `update()` has **no** `grantedEvents` or `grantedCapabilities` parameter — event
-  and capability grants cannot change after activation. Granted capabilities are pushed to the
-  host alongside the configuration (§18.3) so the host can enforce the allowlist at call time.
+  and capability grants cannot change through the edit flow after activation; the one path that
+  resets them is an admin-confirmed version overwrite, which re-grants every configuration to
+  exactly the newly declared sets after the admin re-reviewed them (§11). Granted capabilities
+  are pushed to the host alongside the configuration (§18.3) so the host can enforce the
+  allowlist at call time.
 
 **3.2 Token (`service/ExternalPluginServiceTokenService.kt`)** — HS256 JWT:
 `sub=external-plugin:{pluginId}:{configId}`, `type=external_plugin_service`, `plugin_config_id`,
@@ -310,11 +313,12 @@ not declare (§3.1).
   `POST .../configuration` `{definitionId, title, properties, grantedEndpoints, grantedEvents,
   grantedCapabilities}`.
 - **Edit**: same component with `[readonlyMode]="true"`; the UI update sends `{title, properties}`
-  only. Granted **events** and **capabilities** are truly immutable post-activation (service-layer
-  `update()` has no `grantedEvents` or `grantedCapabilities` parameter). Granted **endpoints** are
-  immutable *in the UI*, but the backend `update()` will replace them if a non-null
-  `grantedEndpoints` is supplied (§3.1) — the immutability of endpoint grants is a UI guarantee,
-  not a service-layer one.
+  only. Granted **events** and **capabilities** cannot change through the edit flow (service-layer
+  `update()` has no `grantedEvents` or `grantedCapabilities` parameter); the one path that resets
+  them is the admin-confirmed version overwrite, which re-grants to the newly reviewed declared
+  sets (§11). Granted **endpoints** are immutable *in the UI*, but the backend `update()` will
+  replace them if a non-null `grantedEndpoints` is supplied (§3.1) — the immutability of endpoint
+  grants is a UI guarantee, not a service-layer one.
 
 ## 5. Data model ✅
 
@@ -505,11 +509,14 @@ funnel through one generic `callExport`; the public `callAction`/`callEvent`/`ca
   directory — a crafted `../`, absolute, or drive-letter entry name rejects the whole package with
   400 — and only the files a plugin package may legitimately carry are extracted (root-level
   `manifest.json`, `plugin.wasm`, the logo, and `frontend/**`), so a hostile zip cannot plant
-  anything else even inside the temp dir. **Versions are immutable**: an upload whose manifest
-  names a `pluginId@version` that already exists — loaded in memory *or* present on disk
-  (`hasVersion`) — is refused with 409; publishing a change requires a new version number, and
-  freeing a version first goes through the delete route with its configuration guard above. The
-  201 response carries the stored package's `contentHash` (§11).
+  anything else even inside the temp dir. **A version is never replaced silently**: an upload
+  whose manifest names a `pluginId@version` that already exists — loaded in memory *or* present
+  on disk (`hasVersion`) — is refused with 409 carrying `code: PLUGIN_VERSION_EXISTS` and both
+  content hashes (the loaded package's and the uploaded package's, so callers can tell an
+  identical re-upload apart from different content). Only `?overwrite=true` — which GZAC sends
+  after an admin explicitly confirmed the overwrite and re-reviewed the requested permissions
+  (§11) — replaces the package (hot-reload; logged as a warn for audit). The 201 response
+  carries the stored package's `contentHash` (§11).
 - **Plugin-content CSP** (`routes/plugin-bundles.ts`): every response serving plugin-authored
   content — `…/bundles/**` **and** the logo (an SVG can carry script) — carries
   `Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self'
@@ -840,7 +847,7 @@ the origins, and it returns only the distinct `scheme://host[:port]` origins of 
 hosts — no admin tokens, broker URLs or configuration data) and passes the origins into the
 initializer before the meta tag is inserted (the CSP meta is immutable once parsed).
 
-## 11. Multi-version support, compatibility & content integrity ✅ (side-by-side versions, compatibility check, immutable + pinned packages)
+## 11. Multi-version support, compatibility & content integrity ✅ (side-by-side versions, compatibility check, pinned packages & confirmed overwrites)
 
 **Why coexistence matters.** Once a case definition becomes *final*, its BPMN — including any
 service tasks bound to an external-plugin action — is immutable. A process link cannot then be
@@ -873,15 +880,34 @@ versions of the same plugin must run side-by-side indefinitely**: there is no pa
 4. New BPMNs / case definitions bind their service tasks to the v2 configuration; existing final
    case definitions continue to reference their v1 configuration.
 
-**Version immutability & content pinning ✅.** A published version is the exact bytes the admin's
-acceptance covers — enforced end to end:
+**Content pinning & confirmed overwrites ✅.** A published version is the exact bytes the admin's
+acceptance covers, and a version is **never replaced silently**: a re-upload of an already-known
+`pluginId@version` is refused by default, an identical re-upload is a friendly no-op, and
+replacing a version with *different* content requires the admin to re-review the package's
+requested permissions and explicitly confirm the overwrite. Content-change detection on the
+discovery side exists to catch tampering and out-of-band modification of a host's package — a
+change that arrives without the confirmed-overwrite flow is treated as an incident:
 
-- *Host — immutable versions.* Every loaded package has a `contentHash`: `sha256:` over every file
-  in the version directory (`manifest.json`, `plugin.wasm`, the logo, `frontend/**`), each record
-  bound to its relative path and byte length so files cannot be renamed or shuffled without
-  changing the hash. The hash is exposed in the plugin listing and the upload response, and an
-  upload naming an existing `pluginId@version` — loaded *or* on disk — is refused with 409 (§7):
-  publishing a change means publishing a new version.
+- *Host — no silent replacement.* Every loaded package has a `contentHash`: `sha256:` over every
+  file in the version directory (`manifest.json`, `plugin.wasm`, the logo, `frontend/**`), each
+  record bound to its relative path and byte length so files cannot be renamed or shuffled
+  without changing the hash. The hash is exposed in the plugin listing and the upload response.
+  An upload naming an existing `pluginId@version` — loaded *or* on disk — is refused with 409
+  (§7) carrying `code: PLUGIN_VERSION_EXISTS` plus the loaded and uploaded packages' hashes;
+  only an explicit `overwrite=true` replaces the package.
+- *Confirmed overwrite — permission re-review, re-pin, re-grant.* GZAC enriches the
+  version-exists 409 with the uploaded manifest's requested endpoint/event/capability sets
+  (parsed server-side from the zip by `PluginPackageInspector.readManifest`). The upload modal
+  branches on the hashes: identical content shows an "already up to date" info; different
+  content opens a review dialog — a warning that the overwrite can lead to unexpected behavior
+  for anything already using the version, the full requested-permission list (the same
+  `plugin-external-permissions` acceptance component used at activation, including its
+  acknowledgement checkbox) and a danger-styled confirm. Confirming re-issues the upload with
+  `overwrite=true`; on the host's 201, GZAC pins the new content hash (clearing any pending
+  flag) and re-grants **every configuration of the definition to exactly the new declared
+  sets** (`ExternalPluginConfigurationService.applyApprovedOverwrite`) — the same all-or-nothing
+  footprint activation grants — after which the immediate re-discovery refreshes the stored
+  manifest and pushes the new grants and a fresh token.
 - *GZAC — pinning at discovery.* The definition stores the hash the host served when the plugin
   was first discovered (`content_hash` — trust on first use, the same moment the definition
   becomes configurable). Every later poll compares the discovered hash against the pinned one; a
@@ -893,10 +919,15 @@ acceptance covers — enforced end to end:
   are refused with a user-visible error, and user tokens are not minted (409 — §13.3). Every push
   additionally carries `expectedContentHash`, which the host verifies against its loaded package
   (409 on mismatch), closing the window between GZAC's discovery cycle and the push.
-- *Re-acceptance.* `POST /api/management/v1/external-plugin/definition/{id}/accept-content`
-  (ADMIN) re-pins: the request echoes the exact pending hash the admin reviewed — acceptance of a
-  *specific* package, so a stale echo is rejected when the host has changed yet again — and an
-  immediate re-discovery then refreshes the manifest data and resumes pushes. A host serving the
+- *Recovery is a deliberate, API-only administrative act.* `POST
+  /api/management/v1/external-plugin/definition/{id}/accept-content` (ADMIN) re-pins after an
+  operator has investigated the change: the request echoes the exact pending hash under review —
+  acceptance of a *specific* package, so a stale echo is rejected when the host has changed yet
+  again — and an immediate re-discovery then refreshes the manifest data and resumes pushes.
+  There is **no management-UI flow for this by design**: a changed package under a pinned version
+  that did *not* come through the confirmed-overwrite flow is an incident-recovery path, not a
+  routine operation (the routine paths for changed content are a new version or the confirmed
+  overwrite above), so it stays a conscious API call rather than a button. A host serving the
   pinned bytes again (a rollback) clears the flag automatically on the next poll. A host whose
   listing carries no hash is simply not pinned.
 
@@ -964,13 +995,20 @@ The frontend surfaces incompatibility as a **non-blocking** warning, localised v
   info-tooltip on each external row whose definition is incompatible;
 - the configure step (`plugin-add-modal.component`) shows `incompatibleWarning$` for an incompatible
   selection, recomputed on language change;
-- the upload modal (`plugin-upload-modal.component`) turns the `409` (kept off the global error
-  toast by the `X-Skip-Interceptor: 409` request header) into an "Upload an incompatible plugin?"
-  confirmation that re-issues the upload with `force=true`.
+- the upload modal (`plugin-upload-modal.component`) handles every `409` itself (kept off the
+  global error toast by the `X-Skip-Interceptor: 409` request header), branching on the response
+  body: a compatibility rejection (`incompatible: true`) becomes an "Upload an incompatible
+  plugin?" confirmation that re-issues the upload with `force=true`; `code:
+  PLUGIN_VERSION_EXISTS` opens the overwrite-review dialog (or the identical-content info — see
+  the content-pinning section above); any other rejection relayed from the host becomes a
+  localised inline error in the modal with the host's own detail. The overwrite confirm retries
+  with `force=true` as well, because compatibility was already checked (or explicitly forced) on
+  the attempt that produced the version-exists 409.
 
 **⛔ Other gaps.** Schema migration for moving a configuration from v1 to v2 is not implemented
-and arguably unnecessary given the side-by-side model (the package bytes of a published version
-are immutable in any case — see content pinning above). Permission-diff prompts and a
+and arguably unnecessary given the side-by-side model (a published version's bytes never change
+without an explicit admin-confirmed overwrite — see content pinning above). Permission-diff
+prompts and a
 `LATEST/STABLE/DEPRECATED` channel status are open. The compatibility range is a warning rather than
 an activation gate — only upload is a confirm-gate; an admin can still activate a configuration for
 an incompatible definition.
@@ -1388,10 +1426,9 @@ Structure:
   queue and its contents).
 - Publisher **package signing** — content pinning (§11) is hash-based trust-on-first-use, tied to
   whoever can reach the upload endpoint, not to a verified publisher identity.
-- Admin-UI surfaces for content re-acceptance and token revocation — both are API-complete
-  (`accept-content`, `revoke-tokens`; the definition DTO exposes `requiresReacceptance` /
-  `pendingContentHash`, the configuration DTO `tokenGeneration`) but have no dedicated screens
-  yet.
+- Admin-UI surface for token revocation — API-complete (`revoke-tokens`; the configuration DTO
+  exposes `tokenGeneration`) but has no dedicated screen. (Content re-acceptance, by contrast, is
+  **API-only by design** — §11.)
 
 ## 15. Roadmap (priority order)
 
@@ -1469,7 +1506,11 @@ Structure:
   `pendingContentHash` + freezes the stored manifest + withholds pushes, rollback clears the
   flag), `service/ExternalPluginConfigurationServicePushTest` (push carries
   `expectedContentHash`, refuses while re-acceptance is pending, `revokeTokens` bumps the
-  generation and re-pushes a fresh token), `service/ExternalPluginDefinitionServiceTest`
+  generation and re-pushes a fresh token, `applyApprovedOverwrite` pins the new hash and
+  re-grants configurations to the new declared sets while skipping unknown capabilities),
+  `web/rest/ExternalPluginUploadOverwriteTest` (version-exists 409 enriched with hashes and
+  requested permissions; confirmed overwrite applies pin + re-grant before discovery; other host
+  409s stay relayed), `service/ExternalPluginDefinitionServiceTest`
   (`acceptContent` re-pins, rejects a stale or absent pending hash),
   `security/ExternalPluginServiceTokenFilterTest` / `security/ExternalPluginUserTokenFilterTest`
   (tokens of a previous generation, without the claim, or for a deleted configuration are
@@ -1478,7 +1519,8 @@ Structure:
   while re-acceptance is pending), and `web/rest/ExternalPluginUserTokenResourceTest` (mint 409
   while pending; minted token bound to the current generation). Host-side (vitest):
   `plugin-manager.test.ts` (stable content hash, changes with any packaged file, `hasVersion` on
-  disk and in memory), `routes/host-management.test.ts` (duplicate-version upload → 409),
+  disk and in memory), `routes/host-management.test.ts` (duplicate-version upload → 409 with both
+  content hashes; explicit `overwrite=true` replaces),
   `routes/host-configurations.test.ts` (push hash mismatch → 409), `routes/plugin-bundles.test.ts`
   (strict CSP + `nosniff` + referrer policy on bundles and logo). PostgreSQL integration tests
   green — the `20260806-external-plugin-security-hardening.xml` changeset applies and matches the
@@ -1660,8 +1702,9 @@ name is rejected up front), and runs `validateGrantedCapabilitiesCoverManifest()
 exact-match gate as endpoints and events (§3.1): every capability declared in the manifest must be
 granted, and nothing undeclared may be.
 The granted capabilities are persisted and pushed to the host alongside the configuration (§18.3).
-`update()` does not accept `grantedCapabilities` — capability grants are immutable after
-activation (same semantics as event grants).
+`update()` does not accept `grantedCapabilities` — capability grants cannot change through the
+edit flow (same semantics as event grants); only the admin-confirmed version overwrite resets
+them to the newly reviewed declared set (§11).
 
 **Kotlin domain** `ExternalPluginGrantedCapability` (entity),
 `ExternalPluginGrantedCapabilityRepository` (Spring Data JPA), `ExternalPluginCapability` (enum


### PR DESCRIPTION
- **Anti-exfiltration CSP** — every plugin-served asset (bundles + logo) gets a strict
  `Content-Security-Policy` (`connect/script/img/font/form → 'self'`, `sandbox`) plus `nosniff`
  and `no-referrer`; a hostile bundle can no longer ship data to third parties.
- **Package content hashing & pinning** — the host hashes every package (sha256 over all files);
  GZAC pins the hash at discovery and sends it with every config push (host refuses mismatches
  with 409).
- **Tamper quarantine** — if a host serves different bytes than pinned (out-of-band change), the
  plugin goes dark on every surface: no config pushes/tokens, actions fail, task-form submissions
  refused, user tokens denied. Recovery via API-only `accept-content` (deliberately no UI).
- **No silent version replacement + confirmed overwrite flow** — re-uploading an existing
  `pluginId@version` is refused by default; identical content shows an "already up to date" info;
  different content opens a review dialog (warning + full permission re-review + acknowledgement +
  danger confirm). Confirming overwrites, re-pins the hash, and **re-grants all configurations to
  exactly the new manifest's declared permissions**.
- **Service-token TTL 24h → 10 minutes** (default; the 60s discovery poll is the refresh loop).
- **Instant token revocation** — per-configuration generation counter stamped into all service
  *and* user tokens; new ADMIN endpoint `revoke-tokens` kills every outstanding token immediately
  and hands the host a fresh one.
- **Upload UX** — host rejections surface as localized inline errors in the upload modal instead
  of failing silently (en + nl).
- **Supporting** — 2 new ADMIN management endpoints, Liquibase migration (hash + token-generation
  columns), DTO/frontend-model fields, ~40 new tests across host/backend/frontend, plan doc
  updated to describe the current design.