### PR TITLE
GH-852: Case definitions that had a process definition removed via the database were unable to be exported

### DIFF
--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinition.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinition.kt
@@ -1,19 +1,17 @@
 /*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
- *  * Copyright 2015-2026 Ritense BV, the Netherlands.
- *  *
- *  * Licensed under EUPL, Version 1.2 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" basis,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.ritense.processdocument.domain
 

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinition.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinition.kt
@@ -1,17 +1,19 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
  *
- * Licensed under EUPL, Version 1.2 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *  *
+ *  * Licensed under EUPL, Version 1.2 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
  *
- * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package com.ritense.processdocument.domain
 
@@ -46,7 +48,7 @@ class ProcessDefinitionCaseDefinition(
     var processDefinitionKey: String? = null
 
     @Formula("( " +
-        " SELECT   CASE WHEN act_re_procdef.suspension_state_ = 2 THEN true ELSE false END " +
+        " SELECT   COALESCE(CASE WHEN act_re_procdef.suspension_state_ = 2 THEN true ELSE false END, false) " +
         " FROM     act_re_procdef " +
         " WHERE    act_re_procdef.id_ = process_definition_id)")
     var draft: Boolean = false

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinition.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinition.kt
@@ -45,10 +45,10 @@ class ProcessDefinitionCaseDefinition(
         " WHERE    act_re_procdef.id_ = process_definition_id)")
     var processDefinitionKey: String? = null
 
-    @Formula("( " +
-        " SELECT   COALESCE(CASE WHEN act_re_procdef.suspension_state_ = 2 THEN true ELSE false END, false) " +
+    @Formula("COALESCE(( " +
+        " SELECT   CASE WHEN act_re_procdef.suspension_state_ = 2 THEN true ELSE false END " +
         " FROM     act_re_procdef " +
-        " WHERE    act_re_procdef.id_ = process_definition_id)")
+        " WHERE    act_re_procdef.id_ = process_definition_id), false)")
     var draft: Boolean = false
 
     fun copy(

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporter.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,9 @@ class ProcessDocumentLinkExporter(
     override fun export(request: DocumentDefinitionExportRequest): ExportResult {
         val processDefinitions = processDefinitionCaseDefinitionService.findProcessDefinitionCaseDefinitions(
             request.caseDefinitionId
-        ).map { definition ->
-            Pair(definition, operatonRepositoryService.findProcessDefinitionById(definition.id.processDefinitionId.id)!!)
+        ).mapNotNull { definition ->
+            operatonRepositoryService.findProcessDefinitionById(definition.id.processDefinitionId.id)
+                ?.let { processDefinition -> Pair(definition, processDefinition) }
         }
 
         if (processDefinitions.isEmpty()) {

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinitionIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinitionIntTest.kt
@@ -1,0 +1,57 @@
+/*
+ *
+ *  * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *  *
+ *  * Licensed under EUPL, Version 1.2 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.ritense.processdocument.domain
+
+import com.ritense.processdocument.BaseIntegrationTest
+import com.ritense.processdocument.repository.ProcessDefinitionCaseDefinitionRepository
+import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class ProcessDefinitionCaseDefinitionIntTest @Autowired constructor(
+    private val repository: ProcessDefinitionCaseDefinitionRepository
+) : BaseIntegrationTest() {
+
+    @Test
+    fun `should load entity when process definition does not exist`() {
+        val nonExistentProcessDefinitionId = "non-existent-process:1:12345"
+        val caseDefinitionId = CaseDefinitionId("house", "1.0.0")
+
+        val orphanedLink = ProcessDefinitionCaseDefinition(
+            id = ProcessDefinitionCaseDefinitionId(
+                processDefinitionId = ProcessDefinitionId(nonExistentProcessDefinitionId),
+                caseDefinitionId = caseDefinitionId
+            ),
+            canInitializeDocument = false,
+            startableByUser = true
+        )
+        repository.saveAndFlush(orphanedLink)
+
+        val loaded = repository.findByIdCaseDefinitionId(caseDefinitionId)
+
+        val orphanedEntity = loaded.find { it.id.processDefinitionId.id == nonExistentProcessDefinitionId }
+        assertThat(orphanedEntity).isNotNull
+        assertThat(orphanedEntity!!.draft).isFalse
+        assertThat(orphanedEntity.processDefinitionName).isNull()
+        assertThat(orphanedEntity.processDefinitionKey).isNull()
+    }
+}

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinitionIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinitionIntTest.kt
@@ -19,6 +19,7 @@ package com.ritense.processdocument.domain
 import com.ritense.processdocument.BaseIntegrationTest
 import com.ritense.processdocument.repository.ProcessDefinitionCaseDefinitionRepository
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,7 +27,8 @@ import org.springframework.transaction.annotation.Transactional
 
 @Transactional
 class ProcessDefinitionCaseDefinitionIntTest @Autowired constructor(
-    private val repository: ProcessDefinitionCaseDefinitionRepository
+    private val repository: ProcessDefinitionCaseDefinitionRepository,
+    private val entityManager: EntityManager
 ) : BaseIntegrationTest() {
 
     @Test
@@ -43,6 +45,7 @@ class ProcessDefinitionCaseDefinitionIntTest @Autowired constructor(
             startableByUser = true
         )
         repository.saveAndFlush(orphanedLink)
+        entityManager.clear()
 
         val loaded = repository.findByIdCaseDefinitionId(caseDefinitionId)
 

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinitionIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/domain/ProcessDefinitionCaseDefinitionIntTest.kt
@@ -1,19 +1,17 @@
 /*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
- *  * Copyright 2015-2026 Ritense BV, the Netherlands.
- *  *
- *  * Licensed under EUPL, Version 1.2 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" basis,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.ritense.processdocument.domain

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporterIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporterIntTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,13 @@ import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthor
 import com.ritense.exporter.request.DocumentDefinitionExportRequest
 import com.ritense.exporter.request.ProcessDefinitionExportRequest
 import com.ritense.processdocument.BaseIntegrationTest
+import com.ritense.processdocument.domain.ProcessDefinitionCaseDefinition
+import com.ritense.processdocument.domain.ProcessDefinitionCaseDefinitionId
+import com.ritense.processdocument.domain.ProcessDefinitionId
+import com.ritense.processdocument.repository.ProcessDefinitionCaseDefinitionRepository
 import com.ritense.valtimo.operaton.service.OperatonRepositoryService
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
@@ -32,11 +37,13 @@ import org.springframework.core.io.support.ResourcePatternUtils
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.util.StreamUtils
 
-@Transactional(readOnly = true)
+@Transactional
 class ProcessDocumentLinkExporterIntTest @Autowired constructor(
     private val resourceLoader: ResourceLoader,
     private val operatonRepositoryService: OperatonRepositoryService,
-    private val processDocumentLinkExporter: ProcessDocumentLinkExporter
+    private val processDocumentLinkExporter: ProcessDocumentLinkExporter,
+    private val processDefinitionCaseDefinitionRepository: ProcessDefinitionCaseDefinitionRepository,
+    private val entityManager: EntityManager
 ) : BaseIntegrationTest() {
 
     @Test
@@ -66,6 +73,36 @@ class ProcessDocumentLinkExporterIntTest @Autowired constructor(
         assertThat(result.relatedRequests).contains(
             ProcessDefinitionExportRequest(processDefinitionId, caseDefinitionId)
         )
+    }
+
+    @Test
+    fun `should skip orphaned process document links during export`(): Unit = runWithoutAuthorization {
+        val caseDefinitionId = CaseDefinitionId("house", "1.0.0")
+        val documentDefinitionName = "house"
+
+        val orphanedLink = ProcessDefinitionCaseDefinition(
+            id = ProcessDefinitionCaseDefinitionId(
+                processDefinitionId = ProcessDefinitionId("non-existent-process:1:12345"),
+                caseDefinitionId = caseDefinitionId
+            ),
+            canInitializeDocument = false,
+            startableByUser = true
+        )
+        processDefinitionCaseDefinitionRepository.saveAndFlush(orphanedLink)
+        entityManager.clear()
+
+        val result = processDocumentLinkExporter.export(DocumentDefinitionExportRequest(documentDefinitionName, caseDefinitionId))
+
+        val exportFile = result.exportFiles.single {
+            it.path == PATH.format(documentDefinitionName)
+        }
+        val exportJson = exportFile.content.toString(Charsets.UTF_8)
+
+        assertThat(exportJson).doesNotContain("non-existent-process")
+
+        assertThat(result.relatedRequests).noneMatch {
+            it is ProcessDefinitionExportRequest && it.processDefinitionId.contains("non-existent-process")
+        }
     }
 
     companion object {

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -59,3 +59,7 @@
   Starting a building block from the 'Start' menu of a case did nothing when the start form of its
   main process is configured to be shown in a panel. The panel now opens right away. Previously it
   only appeared after first opening the start form of a regular process in the panel.
+
+* **Exporting case definitions**
+
+  Case definitions that had a process definition removed via the database were unable to be exported.


### PR DESCRIPTION
fixes https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/852