### PR TITLE
fix: processes keep their concept status after a case import

### DIFF
--- a/backend/core/src/main/java/com/ritense/valtimo/service/OperatonProcessService.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/service/OperatonProcessService.java
@@ -533,6 +533,25 @@ public class OperatonProcessService {
         });
     }
 
+    /**
+     * A process definition that is saved as a draft is kept suspended, so it cannot be started. The draft
+     * state lives only in the suspension state of the deployed definition, not in the BPMN itself, which is
+     * why it has to be applied separately whenever a definition is (re)deployed.
+     */
+    @Transactional
+    public void setProcessDefinitionDraft(String processDefinitionId, boolean draft) {
+        denyAuthorization();
+
+        AuthorizationContext.runWithoutAuthorization(() -> {
+            if (draft) {
+                repositoryService.suspendProcessDefinitionById(processDefinitionId);
+            } else {
+                repositoryService.activateProcessDefinitionById(processDefinitionId);
+            }
+            return null;
+        });
+    }
+
     @Transactional
     public void deleteProcessDefinition(String processDefinitionId) {
         denyAuthorization();

--- a/backend/process-document/src/main/java/com/ritense/processdocument/domain/config/ProcessDocumentLinkConfigItem.java
+++ b/backend/process-document/src/main/java/com/ritense/processdocument/domain/config/ProcessDocumentLinkConfigItem.java
@@ -16,6 +16,7 @@
 
 package com.ritense.processdocument.domain.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ritense.processdocument.domain.ProcessDefinitionCaseDefinition;
 import com.ritense.processdocument.domain.ProcessDocumentDefinition;
 
@@ -23,6 +24,8 @@ public class ProcessDocumentLinkConfigItem {
     private String processDefinitionKey;
     private Boolean canInitializeDocument;
     private Boolean startableByUser;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean draft;
 
     public ProcessDocumentLinkConfigItem() {
         //Default constructor
@@ -63,6 +66,21 @@ public class ProcessDocumentLinkConfigItem {
         this.startableByUser = startableByUser;
     }
 
+    public Boolean getDraft() {
+        return draft;
+    }
+
+    /**
+     * The default is false
+     */
+    public boolean draft() {
+        return Boolean.TRUE.equals(draft);
+    }
+
+    public void setDraft(Boolean draft) {
+        this.draft = draft;
+    }
+
     public boolean equalsProcessDocumentDefinition(ProcessDocumentDefinition processDocumentDefinition) {
         return processDocumentDefinition.processDocumentDefinitionId().processDefinitionKey().toString().equals(getProcessDefinitionKey())
                 && processDocumentDefinition.startableByUser() == isStartableByUser()
@@ -82,6 +100,7 @@ public class ProcessDocumentLinkConfigItem {
                 "processDefinitionKey='" + processDefinitionKey + '\'' +
                 ", canInitializeDocument=" + canInitializeDocument +
                 ", startableByUser=" + startableByUser +
+                ", draft=" + draft +
                 '}';
     }
 }

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporter.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporter.kt
@@ -51,6 +51,8 @@ class ProcessDocumentLinkExporter(
                 this.processDefinitionKey = processDefinitionWithConfig.second.key
                 this.startableByUser = processDefinitionWithConfig.first.startableByUser
                 this.canInitializeDocument = processDefinitionWithConfig.first.canInitializeDocument
+                // only written for drafts, so exports of case definitions without drafts stay unchanged
+                this.draft = processDefinitionWithConfig.second.isSuspended().takeIf { it }
             }
         }
 

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/importer/ProcessDocumentLinkImporter.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/importer/ProcessDocumentLinkImporter.kt
@@ -102,6 +102,9 @@ class ProcessDocumentLinkImporter(
                 }
                 processDefinitionCaseDefinitionService.createProcessDocumentDefinition(request)
             }
+
+            // deploying a process definition always activates it, so the draft state has to be restored
+            processService.setProcessDefinitionDraft(processDefinition.id, item.draft())
         }
     }
 

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/listener/ProcessDefinitionCaseEventListener.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/listener/ProcessDefinitionCaseEventListener.kt
@@ -83,7 +83,8 @@ class ProcessDefinitionCaseEventListener(
                 caseDefinitionId = event.caseDefinitionId,
             )
         }
-        processService.getDeployedDefinitions(event.caseDefinitionId).forEach { definition ->
+        // all definitions, not just the active ones: a process saved as a draft is suspended and would be left behind
+        processService.getAllDefinitions(event.caseDefinitionId).forEach { definition ->
             processService.deleteProcessDefinition(definition.id)
         }
     }

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/importer/ProcessDocumentLinkRoundTripIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/importer/ProcessDocumentLinkRoundTripIntTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processdocument.importer
+
+import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthorization
+import com.ritense.case.service.CaseDefinitionService
+import com.ritense.exporter.ExportService
+import com.ritense.exporter.request.CaseDefinitionExportRequest
+import com.ritense.importer.ImportService
+import com.ritense.processdocument.BaseIntegrationTest
+import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import com.ritense.valtimo.operaton.service.OperatonRepositoryService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.operaton.bpm.engine.RepositoryService
+import org.springframework.beans.factory.annotation.Autowired
+
+class ProcessDocumentLinkRoundTripIntTest @Autowired constructor(
+    private val exportService: ExportService,
+    private val importService: ImportService,
+    private val operatonRepositoryService: OperatonRepositoryService,
+    private val repositoryService: RepositoryService,
+    private val caseDefinitionService: CaseDefinitionService,
+) : BaseIntegrationTest() {
+
+    @Test
+    fun `should preserve process settings when exporting and importing a case definition`() {
+        val source = CaseDefinitionId.of("notahouse", "1.0.0")
+
+        // a process saved as a draft is kept suspended, which is only visible on the deployed definition
+        val draftProcessDefinitionId = processDefinitionIdOf(source, "loan-process-demo-2")
+        repositoryService.suspendProcessDefinitionById(draftProcessDefinitionId)
+
+        var imported: CaseDefinitionId? = null
+        try {
+            imported = exportAndImport(source, "notahouse-copy")
+
+            assertThat(settingsByProcessDefinitionKey(imported))
+                .isEqualTo(settingsByProcessDefinitionKey(source))
+                .containsEntry("loan-process-demo-2", ProcessSettings(startableByUser = true, canInitializeDocument = true, draft = true))
+        } finally {
+            // the case definitions are shared between integration tests, so leave no traces behind
+            repositoryService.activateProcessDefinitionById(draftProcessDefinitionId)
+            imported?.let { runWithoutAuthorization { caseDefinitionService.deleteCaseDefinition(it) } }
+        }
+    }
+
+    private fun exportAndImport(source: CaseDefinitionId, keyOverride: String): CaseDefinitionId {
+        val zip = runWithoutAuthorization {
+            exportService.export(CaseDefinitionExportRequest(source)).toByteArray()
+        }
+        return runWithoutAuthorization {
+            importService.import(zip.inputStream(), emptyList(), keyOverride, keyOverride, null)
+        } ?: error("Import of case definition '$source' did not return a case definition id")
+    }
+
+    private fun processDefinitionIdOf(caseDefinitionId: CaseDefinitionId, processDefinitionKey: String) =
+        runWithoutAuthorization {
+            processDefinitionCaseDefinitionService.findProcessDefinitionCaseDefinitions(caseDefinitionId)
+                .single { it.processDefinitionKey == processDefinitionKey }
+                .id.processDefinitionId.id
+        }
+
+    private fun settingsByProcessDefinitionKey(caseDefinitionId: CaseDefinitionId) = runWithoutAuthorization {
+        processDefinitionCaseDefinitionService.findProcessDefinitionCaseDefinitions(caseDefinitionId)
+            .associate { link ->
+                link.processDefinitionKey!! to ProcessSettings(
+                    startableByUser = link.startableByUser,
+                    canInitializeDocument = link.canInitializeDocument,
+                    draft = operatonRepositoryService.findProcessDefinitionById(link.id.processDefinitionId.id)!!
+                        .isSuspended()
+                )
+            }
+    }
+
+    private data class ProcessSettings(
+        val startableByUser: Boolean,
+        val canInitializeDocument: Boolean,
+        val draft: Boolean,
+    )
+}

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -28,6 +28,11 @@
 
 ## Bugfixes
 
+* **Processes keep their concept status after an import**
+
+  On the *Processen* tab of an imported dossier, every process came back as a normal process, even when it
+  was still a concept in the dossier that was exported. Concepts now stay concepts.
+
 * **Actions now respect the linked building block version**
 
   Starting a building block from the actions of a case now always runs the version of that building block


### PR DESCRIPTION


On the *Processen* tab of a dossier that was imported from another environment, a process that was still a concept in the original dossier came back as a normal process. Concepts now stay concepts. Deleting a dossier also cleans up its concept processes, which were previously left behind.

The ticket itself reports *Door gebruiker te starten* flipping to 'Nee' after an import. That setting is **not** what this PR changes, and it does not reproduce on `next-minor`: it survived a dossier built through the UI, a dossier with twelve processes and mixed settings, importing with and without a new key, re-importing over an existing dossier, and a definitive dossier — verified both in integration tests and against a running environment. The export/import code is byte-identical between `13.40.0` and `next-minor`, so this is not something that was fixed after the reported version.

Closed for now; the branch `bugfix/845-preserve-process-settings-on-import` is kept in case the concept fix is worth reopening under its own ticket.
