### PR TITLE
GH-580: Restrict reflective resource type resolution to known authorization resources

### DIFF
--- a/backend/authorization/src/main/kotlin/com/ritense/authorization/AuthorizationResourceTypeResolver.kt
+++ b/backend/authorization/src/main/kotlin/com/ritense/authorization/AuthorizationResourceTypeResolver.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization
+
+import com.ritense.valtimo.contract.annotation.SkipComponentScan
+import org.springframework.stereotype.Service
+
+/**
+ * Resolves a resource type name to its [Class], but only for names that are known authorization
+ * resource types.
+ *
+ * Resource type names can originate from a request body. Loading an arbitrary caller supplied class
+ * name runs that class's static initializer and reveals whether the class is present on the
+ * classpath, so resolution is restricted to the finite set of resource types that
+ * [PbacRegistryService] derives from the application itself. Anything else is rejected before the
+ * class loader is consulted.
+ */
+@Service
+@SkipComponentScan
+class AuthorizationResourceTypeResolver(
+    private val pbacRegistryService: PbacRegistryService,
+) {
+
+    /**
+     * @throws UnknownAuthorizationResourceTypeException when [resourceType] is not a known
+     * authorization resource type.
+     */
+    fun resolve(resourceType: String): Class<*> {
+        if (resourceType !in pbacRegistryService.getAllowedResourceTypes()) {
+            // The submitted value is deliberately left out of the message. Echoing it back turns
+            // this check into an oracle for what is present on the classpath.
+            throw UnknownAuthorizationResourceTypeException(
+                "Unknown authorization resource type"
+            )
+        }
+
+        return Class.forName(resourceType)
+    }
+}

--- a/backend/authorization/src/main/kotlin/com/ritense/authorization/PbacRegistryService.kt
+++ b/backend/authorization/src/main/kotlin/com/ritense/authorization/PbacRegistryService.kt
@@ -52,6 +52,34 @@ class PbacRegistryService(
     @Volatile
     private var cachedScannedActionProviders: List<ResourceActionProvider<*>>? = null
 
+    @Volatile
+    private var cachedResourceTypeAllowlist: Set<String>? = null
+
+    /**
+     * The fully qualified class names that are valid authorization resource types.
+     *
+     * Used to guard reflective resolution of externally supplied resource names, see
+     * [com.ritense.authorization.AuthorizationResourceTypeResolver]. Derived from the application
+     * classpath and Spring configuration, so it is stable for the lifetime of the application.
+     *
+     * Deliberately does not reuse the registry metadata cache. Building that metadata also walks
+     * the fields of every resource class reflectively, which is unnecessary here and too expensive
+     * for a request path that is used on nearly every page.
+     */
+    fun getAllowedResourceTypes(): Set<String> {
+        cachedResourceTypeAllowlist?.let { return it }
+
+        return synchronized(cacheLock) {
+            cachedResourceTypeAllowlist ?: createResourceTypeAllowlist().also {
+                cachedResourceTypeAllowlist = it
+            }
+        }
+    }
+
+    private fun createResourceTypeAllowlist(): Set<String> {
+        return discoverResourceTypes().keys + discoverSpecificationFactoryResourceTypes()
+    }
+
     fun getRegistry(): PbacRegistryDto {
         val metadata = getOrCreateRegistryMetadata()
 

--- a/backend/authorization/src/main/kotlin/com/ritense/authorization/UnknownAuthorizationResourceTypeException.kt
+++ b/backend/authorization/src/main/kotlin/com/ritense/authorization/UnknownAuthorizationResourceTypeException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package com.ritense.authorization.web.request
+package com.ritense.authorization
 
-import com.ritense.authorization.web.request.PermissionResourceConstraints.RESOURCE_MAX_LENGTH
-import com.ritense.authorization.web.request.PermissionResourceConstraints.RESOURCE_NAME_PATTERN
-import jakarta.validation.constraints.Pattern
-import jakarta.validation.constraints.Size
-
-class PermissionContext(
-    @field:Size(max = RESOURCE_MAX_LENGTH)
-    @field:Pattern(regexp = RESOURCE_NAME_PATTERN)
-    val resource: String,
-    val identifier: String
-)
+/**
+ * Thrown when a resource type name does not belong to a known authorization resource type.
+ *
+ * Carries no reference to the rejected value, so that it cannot leak into a response or a log line.
+ */
+class UnknownAuthorizationResourceTypeException(
+    message: String
+) : RuntimeException(message)

--- a/backend/authorization/src/main/kotlin/com/ritense/authorization/autoconfigure/AuthorizationAutoConfiguration.kt
+++ b/backend/authorization/src/main/kotlin/com/ritense/authorization/autoconfigure/AuthorizationAutoConfiguration.kt
@@ -19,6 +19,7 @@ package com.ritense.authorization.autoconfigure
 import com.fasterxml.jackson.databind.Module
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.authorization.AuthorizationEntityMapper
+import com.ritense.authorization.AuthorizationResourceTypeResolver
 import com.ritense.authorization.AuthorizationService
 import com.ritense.authorization.AuthorizationServiceHolder
 import com.ritense.authorization.AuthorizationSupportedHelper
@@ -160,9 +161,18 @@ class AuthorizationAutoConfiguration(
     @Bean
     @ConditionalOnMissingBean(PermissionResource::class)
     fun permissionResource(
-        authorizationService: AuthorizationService
+        authorizationService: AuthorizationService,
+        resourceTypeResolver: AuthorizationResourceTypeResolver
     ): PermissionResource {
-        return PermissionResource(authorizationService)
+        return PermissionResource(authorizationService, resourceTypeResolver)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AuthorizationResourceTypeResolver::class)
+    fun authorizationResourceTypeResolver(
+        pbacRegistryService: PbacRegistryService
+    ): AuthorizationResourceTypeResolver {
+        return AuthorizationResourceTypeResolver(pbacRegistryService)
     }
 
     @Bean

--- a/backend/authorization/src/main/kotlin/com/ritense/authorization/web/PermissionResource.kt
+++ b/backend/authorization/src/main/kotlin/com/ritense/authorization/web/PermissionResource.kt
@@ -17,7 +17,9 @@
 package com.ritense.authorization.web
 
 import com.ritense.authorization.Action
+import com.ritense.authorization.AuthorizationResourceTypeResolver
 import com.ritense.authorization.AuthorizationService
+import com.ritense.authorization.UnknownAuthorizationResourceTypeException
 import com.ritense.authorization.request.EntityAuthorizationRequest
 import com.ritense.authorization.request.RelatedEntityAuthorizationRequest
 import com.ritense.authorization.web.request.PermissionAvailableRequest
@@ -38,7 +40,8 @@ import org.springframework.web.bind.annotation.RestController
 @SkipComponentScan
 @RequestMapping("/api", produces = [APPLICATION_JSON_UTF8_VALUE])
 class PermissionResource(
-    private var authorizationService: AuthorizationService
+    private var authorizationService: AuthorizationService,
+    private val resourceTypeResolver: AuthorizationResourceTypeResolver,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(PermissionResource::class.java)
@@ -53,20 +56,27 @@ class PermissionResource(
                 try {
                     val authorizationRequest = if (it.context == null) {
                         EntityAuthorizationRequest(
-                            it.getResourceAsClass(),
+                            resourceTypeResolver.resolve(it.resource),
                             Action(it.action),
                         )
                     } else {
                         RelatedEntityAuthorizationRequest(
-                            it.getResourceAsClass(),
+                            resourceTypeResolver.resolve(it.resource),
                             Action(it.action),
-                            it.context.getResourceAsClass(),
+                            resourceTypeResolver.resolve(it.context.resource),
                             it.context.identifier
                         )
                     }
                     authorizationService.hasPermission(authorizationRequest)
+                } catch (ex: UnknownAuthorizationResourceTypeException) {
+                    // Reported as "no permission", the same as a known resource type the user is not
+                    // allowed to access, so that the response does not reveal which resource types
+                    // exist. Logged at debug because any authenticated caller can trigger it.
+                    logger.debug("Failed to determine permissions for action '${it.action}'", ex)
+                    false
                 } catch (ex: Exception) {
-                    logger.error("Failed to determine permissions for $it", ex)
+                    // The resource type has passed the allowlist at this point, so it is safe to log.
+                    logger.error("Failed to determine permissions for resource '${it.resource}'", ex)
                     false
                 }
 

--- a/backend/authorization/src/main/kotlin/com/ritense/authorization/web/request/PermissionAvailableRequest.kt
+++ b/backend/authorization/src/main/kotlin/com/ritense/authorization/web/request/PermissionAvailableRequest.kt
@@ -16,15 +16,17 @@
 
 package com.ritense.authorization.web.request
 
-import com.fasterxml.jackson.annotation.JsonIgnore
+import com.ritense.authorization.web.request.PermissionResourceConstraints.RESOURCE_MAX_LENGTH
+import com.ritense.authorization.web.request.PermissionResourceConstraints.RESOURCE_NAME_PATTERN
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 data class PermissionAvailableRequest(
+    @field:Size(max = RESOURCE_MAX_LENGTH)
+    @field:Pattern(regexp = RESOURCE_NAME_PATTERN)
     val resource: String,
     val action: String,
+    @field:Valid
     val context: PermissionContext? = null,
-) {
-    @JsonIgnore
-    fun getResourceAsClass(): Class<*> {
-        return Class.forName(resource)
-    }
-}
+)

--- a/backend/authorization/src/main/kotlin/com/ritense/authorization/web/request/PermissionResourceConstraints.kt
+++ b/backend/authorization/src/main/kotlin/com/ritense/authorization/web/request/PermissionResourceConstraints.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization.web.request
+
+/**
+ * Input constraints shared by the request objects that carry an authorization resource type name.
+ *
+ * These reject obviously malformed input early. They are a second line of defence only. The control
+ * that matters is the allowlist applied by
+ * [com.ritense.authorization.AuthorizationResourceTypeResolver].
+ */
+internal object PermissionResourceConstraints {
+
+    /**
+     * A fully qualified Java class name: dot separated identifiers.
+     */
+    const val RESOURCE_NAME_PATTERN = "^[a-zA-Z_$][a-zA-Z\\d_$]*(\\.[a-zA-Z_$][a-zA-Z\\d_$]*)*$"
+
+    const val RESOURCE_MAX_LENGTH = 512
+}

--- a/backend/authorization/src/test/kotlin/com/ritense/authorization/AuthorizationResourceTypeResolverTest.kt
+++ b/backend/authorization/src/test/kotlin/com/ritense/authorization/AuthorizationResourceTypeResolverTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization
+
+import com.ritense.authorization.testimpl.RelatedTestEntity
+import com.ritense.authorization.testimpl.TestEntity
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class AuthorizationResourceTypeResolverTest {
+
+    private lateinit var pbacRegistryService: PbacRegistryService
+    private lateinit var resolver: AuthorizationResourceTypeResolver
+
+    private val allowedResourceTypes = setOf(
+        TestEntity::class.java.name,
+        RelatedTestEntity::class.java.name,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        pbacRegistryService = mock()
+        whenever(pbacRegistryService.getAllowedResourceTypes()).thenReturn(allowedResourceTypes)
+        resolver = AuthorizationResourceTypeResolver(pbacRegistryService)
+    }
+
+    @Test
+    fun `should resolve every allowed resource type`() {
+        allowedResourceTypes.forEach { resourceType ->
+            assertEquals(resourceType, resolver.resolve(resourceType).name)
+        }
+    }
+
+    @Test
+    fun `should reject a class that is on the classpath but is not a resource type`() {
+        assertThrows<UnknownAuthorizationResourceTypeException> {
+            resolver.resolve(Action::class.java.name)
+        }
+    }
+
+    @Test
+    fun `should reject java lang System`() {
+        assertThrows<UnknownAuthorizationResourceTypeException> {
+            resolver.resolve("java.lang.System")
+        }
+    }
+
+    @Test
+    fun `should reject java lang Runtime`() {
+        assertThrows<UnknownAuthorizationResourceTypeException> {
+            resolver.resolve("java.lang.Runtime")
+        }
+    }
+
+    /**
+     * A name that does not exist must be rejected by the allowlist, not by the class loader. If a
+     * [ClassNotFoundException] were to surface here the class loader would have been consulted,
+     * which is what makes the endpoint usable to probe the classpath.
+     */
+    @Test
+    fun `should reject a name that does not exist without consulting the class loader`() {
+        assertThrows<UnknownAuthorizationResourceTypeException> {
+            resolver.resolve("com.example.DoesNotExist")
+        }
+    }
+
+    @Test
+    fun `should reject a resource type that only differs in case`() {
+        assertThrows<UnknownAuthorizationResourceTypeException> {
+            resolver.resolve(TestEntity::class.java.name.lowercase())
+        }
+    }
+
+    @Test
+    fun `should not repeat the rejected value in the failure message`() {
+        val submitted = "com.example.SecretlyPresentOnTheClasspath"
+
+        val exception = assertThrows<UnknownAuthorizationResourceTypeException> {
+            resolver.resolve(submitted)
+        }
+
+        assertFalse(
+            exception.message.orEmpty().contains(submitted),
+            "The rejection message must not echo the submitted resource type, " +
+                "because that turns the check into a classpath oracle",
+        )
+    }
+}

--- a/backend/authorization/src/test/kotlin/com/ritense/authorization/PbacRegistryServiceTest.kt
+++ b/backend/authorization/src/test/kotlin/com/ritense/authorization/PbacRegistryServiceTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization
+
+import com.ritense.authorization.role.RoleRepository
+import com.ritense.authorization.testimpl.RelatedTestEntity
+import com.ritense.authorization.testimpl.RelatedTestEntitySpecificationFactory
+import com.ritense.authorization.testimpl.TestEntity
+import com.ritense.authorization.testimpl.TestEntityActionProvider
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class PbacRegistryServiceTest {
+
+    private lateinit var roleRepository: RoleRepository
+    private lateinit var pbacRegistryService: PbacRegistryService
+
+    @BeforeEach
+    fun setUp() {
+        roleRepository = mock()
+        pbacRegistryService = PbacRegistryService(
+            actionProviders = listOf(TestEntityActionProvider()),
+            mappers = emptyList(),
+            specificationFactories = listOf(RelatedTestEntitySpecificationFactory()),
+            roleRepository = roleRepository,
+        )
+    }
+
+    @Test
+    fun `should allow resource types from action providers and specification factories`() {
+        val allowedResourceTypes = pbacRegistryService.getAllowedResourceTypes()
+
+        assertTrue(TestEntity::class.java.name in allowedResourceTypes)
+        assertTrue(RelatedTestEntity::class.java.name in allowedResourceTypes)
+    }
+
+    /**
+     * The allowlist only contains types that the application itself declares as a resource, through
+     * a [ResourceActionProvider] or an
+     * [com.ritense.authorization.specification.AuthorizationSpecificationFactory]. Everything else
+     * on the classpath stays out of it.
+     */
+    @Test
+    fun `should not allow arbitrary classes on the classpath`() {
+        val allowedResourceTypes = pbacRegistryService.getAllowedResourceTypes()
+
+        assertFalse("java.lang.System" in allowedResourceTypes)
+        assertFalse("java.lang.Runtime" in allowedResourceTypes)
+        assertFalse("java.lang.ProcessBuilder" in allowedResourceTypes)
+        assertFalse(PbacRegistryService::class.java.name in allowedResourceTypes)
+        assertFalse(Action::class.java.name in allowedResourceTypes)
+    }
+
+    @Test
+    fun `should cache the allowed resource types`() {
+        assertSame(
+            pbacRegistryService.getAllowedResourceTypes(),
+            pbacRegistryService.getAllowedResourceTypes(),
+        )
+    }
+
+    /**
+     * The allowlist is used on a request path that the frontend calls on nearly every page, so it
+     * must not drag in the full registry build. That build additionally walks the fields of every
+     * resource class reflectively.
+     */
+    @Test
+    fun `should not build the registry metadata to determine the allowed resource types`() {
+        pbacRegistryService.getAllowedResourceTypes()
+
+        assertNull(cachedRegistryMetadata())
+
+        // The metadata cache is populated by the registry itself, which confirms that reading the
+        // field above is a meaningful assertion.
+        pbacRegistryService.getRegistry()
+
+        assertNotNull(cachedRegistryMetadata())
+    }
+
+    private fun cachedRegistryMetadata(): Any? {
+        return PbacRegistryService::class.java
+            .getDeclaredField("cachedRegistryMetadata")
+            .apply { isAccessible = true }
+            .get(pbacRegistryService)
+    }
+}

--- a/backend/authorization/src/test/kotlin/com/ritense/authorization/testimpl/StaticInitializerProbe.kt
+++ b/backend/authorization/src/test/kotlin/com/ritense/authorization/testimpl/StaticInitializerProbe.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization.testimpl
+
+/**
+ * Holds the flag that [StaticInitializerProbe] sets.
+ *
+ * Kept on a separate class on purpose. A test has to be able to read the flag without initializing
+ * the probe, because initializing the probe is exactly what the test is checking for.
+ */
+object StaticInitializerProbeFlag {
+    @JvmStatic
+    @Volatile
+    var initialized: Boolean = false
+}
+
+/**
+ * Stands in for an arbitrary class that happens to be on the classpath and whose static initializer
+ * has a side effect.
+ *
+ * `Class.forName(String)` initializes the class it loads, so a caller supplied class name reaching
+ * it runs that class's static initializer. This probe makes that observable through
+ * [StaticInitializerProbeFlag], without any of the side effects that make the real thing dangerous.
+ *
+ * Nothing may reference this class in a way that triggers its initialization, other than by
+ * submitting its name to the code under test.
+ */
+class StaticInitializerProbe private constructor() {
+    companion object {
+        init {
+            StaticInitializerProbeFlag.initialized = true
+        }
+    }
+}

--- a/backend/authorization/src/test/kotlin/com/ritense/authorization/web/PermissionResourceTest.kt
+++ b/backend/authorization/src/test/kotlin/com/ritense/authorization/web/PermissionResourceTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization.web
+
+import com.ritense.authorization.AuthorizationResourceTypeResolver
+import com.ritense.authorization.AuthorizationService
+import com.ritense.authorization.PbacRegistryService
+import com.ritense.authorization.request.AuthorizationRequest
+import com.ritense.authorization.testimpl.RelatedTestEntity
+import com.ritense.authorization.testimpl.StaticInitializerProbeFlag
+import com.ritense.authorization.testimpl.TestEntity
+import com.ritense.authorization.web.request.PermissionAvailableRequest
+import com.ritense.authorization.web.request.PermissionContext
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PermissionResourceTest {
+
+    private lateinit var authorizationService: AuthorizationService
+    private lateinit var pbacRegistryService: PbacRegistryService
+    private lateinit var permissionResource: PermissionResource
+
+    @BeforeEach
+    fun setUp() {
+        authorizationService = mock()
+        pbacRegistryService = mock()
+        whenever(pbacRegistryService.getAllowedResourceTypes()).thenReturn(
+            setOf(
+                TestEntity::class.java.name,
+                RelatedTestEntity::class.java.name,
+            )
+        )
+        permissionResource = PermissionResource(
+            authorizationService,
+            AuthorizationResourceTypeResolver(pbacRegistryService),
+        )
+    }
+
+    /**
+     * The regression test for the reported issue. `Class.forName(String)` initializes the class it
+     * loads, so before the allowlist was introduced any authenticated caller could run the static
+     * initializer of any class on the classpath by naming it in the request body.
+     */
+    @Test
+    fun `should not run the static initializer of a class named in the request`() {
+        val probeName = "com.ritense.authorization.testimpl.StaticInitializerProbe"
+
+        assertFalse(
+            StaticInitializerProbeFlag.initialized,
+            "The probe must not have been initialized before the request",
+        )
+
+        val response = permissionResource.userHasPermission(
+            listOf(PermissionAvailableRequest(probeName, "view"))
+        )
+
+        assertEquals(false, response.body!!.single().available)
+        assertFalse(
+            StaticInitializerProbeFlag.initialized,
+            "The static initializer of a resource type named in the request was run, " +
+                "so the class was loaded before it was checked against the allowlist",
+        )
+        verify(authorizationService, never()).hasPermission(any<AuthorizationRequest<Any>>())
+
+        // Proves the probe is actually observable, so the assertions above cannot pass by accident.
+        Class.forName(probeName)
+        assertTrue(
+            StaticInitializerProbeFlag.initialized,
+            "The probe does not observe class initialization, so this test proves nothing",
+        )
+    }
+
+    @Test
+    fun `should report no permission for an unknown resource type`() {
+        val response = permissionResource.userHasPermission(
+            listOf(PermissionAvailableRequest("java.lang.System", "view"))
+        )
+
+        val result = response.body!!.single()
+        assertEquals("java.lang.System", result.resource)
+        assertEquals("view", result.action)
+        assertEquals(false, result.available)
+    }
+
+    @Test
+    fun `should report no permission when the context resource type is unknown`() {
+        val response = permissionResource.userHasPermission(
+            listOf(
+                PermissionAvailableRequest(
+                    TestEntity::class.java.name,
+                    "view",
+                    PermissionContext("java.lang.System", "123"),
+                )
+            )
+        )
+
+        assertEquals(false, response.body!!.single().available)
+        verify(authorizationService, never()).hasPermission(any<AuthorizationRequest<Any>>())
+    }
+
+    @Test
+    fun `should evaluate a known resource type`() {
+        whenever(authorizationService.hasPermission(any<AuthorizationRequest<Any>>())).thenReturn(true)
+
+        val response = permissionResource.userHasPermission(
+            listOf(
+                PermissionAvailableRequest(
+                    TestEntity::class.java.name,
+                    "view",
+                    PermissionContext(RelatedTestEntity::class.java.name, "123"),
+                )
+            )
+        )
+
+        assertEquals(true, response.body!!.single().available)
+        verify(authorizationService).hasPermission(any<AuthorizationRequest<Any>>())
+    }
+
+    @Test
+    fun `should keep evaluating the other entries when one resource type is unknown`() {
+        whenever(authorizationService.hasPermission(any<AuthorizationRequest<Any>>())).thenReturn(true)
+
+        val response = permissionResource.userHasPermission(
+            listOf(
+                PermissionAvailableRequest("java.lang.System", "view"),
+                PermissionAvailableRequest(TestEntity::class.java.name, "view"),
+            )
+        )
+
+        val results = response.body!!
+        assertEquals(2, results.size)
+        assertEquals(false, results[0].available)
+        assertEquals(true, results[1].available)
+    }
+}

--- a/backend/authorization/src/test/kotlin/com/ritense/authorization/web/request/PermissionAvailableRequestValidationTest.kt
+++ b/backend/authorization/src/test/kotlin/com/ritense/authorization/web/request/PermissionAvailableRequestValidationTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization.web.request
+
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PermissionAvailableRequestValidationTest {
+
+    @Test
+    fun `should accept a fully qualified class name`() {
+        val violations = validator.validate(
+            PermissionAvailableRequest(
+                "com.ritense.authorization.testimpl.TestEntity",
+                "view",
+                PermissionContext("com.ritense.authorization.testimpl.TestEntity", "123"),
+            )
+        )
+
+        assertTrue(violations.isEmpty(), "Unexpected violations: $violations")
+    }
+
+    @Test
+    fun `should reject a resource that is not shaped like a class name`() {
+        val violations = validator.validate(
+            PermissionAvailableRequest("../../etc/passwd", "view")
+        )
+
+        assertEquals(1, violations.size)
+        assertEquals("resource", violations.single().propertyPath.toString())
+    }
+
+    @Test
+    fun `should reject a resource containing a newline`() {
+        val violations = validator.validate(
+            PermissionAvailableRequest("java.lang.System\ninjected", "view")
+        )
+
+        assertEquals(1, violations.size)
+    }
+
+    @Test
+    fun `should reject a resource that is too long`() {
+        val violations = validator.validate(
+            PermissionAvailableRequest("a".repeat(513), "view")
+        )
+
+        assertEquals(1, violations.size)
+    }
+
+    @Test
+    fun `should reject a context resource that is not shaped like a class name`() {
+        val violations = validator.validate(
+            PermissionAvailableRequest(
+                "com.ritense.authorization.testimpl.TestEntity",
+                "view",
+                PermissionContext("not a class name", "123"),
+            )
+        )
+
+        assertEquals(1, violations.size)
+        assertEquals("context.resource", violations.single().propertyPath.toString())
+    }
+
+    companion object {
+        private lateinit var validator: Validator
+        private lateinit var validatorFactory: jakarta.validation.ValidatorFactory
+
+        @JvmStatic
+        @BeforeAll
+        fun setUpValidator() {
+            validatorFactory = Validation.buildDefaultValidatorFactory()
+            validator = validatorFactory.validator
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDownValidator() {
+            validatorFactory.close()
+        }
+    }
+}

--- a/backend/authorization/src/test/kotlin/com/ritense/authorization/web/rest/PermissionResourceIT.kt
+++ b/backend/authorization/src/test/kotlin/com/ritense/authorization/web/rest/PermissionResourceIT.kt
@@ -27,6 +27,7 @@ import com.ritense.authorization.permission.condition.PermissionConditionOperato
 import com.ritense.authorization.role.Role
 import com.ritense.authorization.role.RoleRepository
 import com.ritense.authorization.testimpl.RelatedTestEntity
+import com.ritense.authorization.testimpl.StaticInitializerProbeFlag
 import com.ritense.authorization.testimpl.TestEntity
 import com.ritense.authorization.testimpl.TestEntityActionProvider
 import com.ritense.authorization.web.request.PermissionAvailableRequest
@@ -45,6 +46,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
 import java.util.UUID
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @Transactional
 class PermissionResourceIT: BaseIntegrationTest() {
@@ -367,6 +370,70 @@ class PermissionResourceIT: BaseIntegrationTest() {
             .andExpect { jsonPath("$[0].resource").value("test") }
             .andExpect { jsonPath("$[0].action").value("update") }
             .andExpect { jsonPath("$[0].available").value(false) }
+    }
+
+    @Test
+    @WithMockUser(authorities = ["test-role"])
+    fun `requesting permission for an unknown resource type returns available false`() {
+        permissionRepository.deleteAll()
+
+        val permissionRequests = listOf(
+            PermissionAvailableRequest("java.lang.System", "view")
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .post("/api/v1/permissions")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(permissionRequests))
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(jsonPath("$[0].resource").value("java.lang.System"))
+            .andExpect(jsonPath("$[0].action").value("view"))
+            .andExpect(jsonPath("$[0].available").value(false))
+    }
+
+    /**
+     * Loading a class runs its static initializer, so a resource type name taken from the request
+     * body must never reach the class loader unless it is a known authorization resource type.
+     */
+    @Test
+    @WithMockUser(authorities = ["test-role"])
+    fun `requesting permission for an unknown resource type does not load that class`() {
+        permissionRepository.deleteAll()
+
+        val probeName = "com.ritense.authorization.testimpl.StaticInitializerProbe"
+
+        assertFalse(
+            StaticInitializerProbeFlag.initialized,
+            "The probe must not have been initialized before the request",
+        )
+
+        val permissionRequests = listOf(
+            PermissionAvailableRequest(probeName, "view")
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .post("/api/v1/permissions")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(permissionRequests))
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(jsonPath("$[0].available").value(false))
+
+        assertFalse(
+            StaticInitializerProbeFlag.initialized,
+            "The static initializer of a resource type named in the request was run, " +
+                "so the class was loaded before it was checked against the allowlist",
+        )
+
+        // Proves the probe is actually observable, so the assertion above cannot pass by accident.
+        Class.forName(probeName)
+        assertTrue(
+            StaticInitializerProbeFlag.initialized,
+            "The probe does not observe class initialization, so this test proves nothing",
+        )
     }
 
     @Test

--- a/backend/authorization/src/test/kotlin/com/ritense/authorization/web/rest/PermissionResourceSecurityIT.kt
+++ b/backend/authorization/src/test/kotlin/com/ritense/authorization/web/rest/PermissionResourceSecurityIT.kt
@@ -85,6 +85,37 @@ class PermissionResourceSecurityIT : SecuritySpecificEndpointIntegrationTest() {
         assertHttpStatus(request, HttpStatus.OK)
     }
 
+    /**
+     * A resource type that is not a known authorization resource must be answered with a plain
+     * "no permission", exactly like a known resource the user has no permission for. Not an error,
+     * and not a stack trace, because that would tell the caller which classes are present.
+     */
+    @Test
+    @WithMockUser(authorities = ["test-role"])
+    fun `should report no permission for an unknown resource type when authenticated`() {
+
+        val permissionRequests = listOf(
+            PermissionAvailableRequest(
+                "java.lang.System",
+                "view",
+                PermissionContext(
+                    "java.lang.Runtime",
+                    "123"
+                )
+            )
+        )
+
+        val request = MockMvcRequestBuilders.request(HttpMethod.POST, "/api/v1/permissions")
+        request.content(TestUtil.convertObjectToJsonBytes(permissionRequests))
+        request.contentType(MediaType.APPLICATION_JSON)
+        request.accept(MediaType.APPLICATION_JSON)
+        request.with { r: MockHttpServletRequest ->
+            r.remoteAddr = "8.8.8.8"
+            r
+        }
+        assertHttpStatus(request, HttpStatus.OK)
+    }
+
     @Test
     fun `should not be able to request permissions when not authenticated`() {
 

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -74,3 +74,12 @@
 * **Exporting case definitions**
 
   Case definitions that had a process definition removed via the database were unable to be exported.
+
+## Security
+
+* **Permission checks only accept known resource types**
+
+  When Valtimo was asked whether a user may perform an action, the resource type in that question was taken at
+  face value, which allowed any signed-in user to make the server load arbitrary internal parts of the
+  application. Only the resource types that can be selected under **Access control** are accepted now, and
+  anything else is answered as "not permitted", so normal use is unaffected.

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -74,12 +74,3 @@
 * **Exporting case definitions**
 
   Case definitions that had a process definition removed via the database were unable to be exported.
-
-## Security
-
-* **Permission checks only accept known resource types**
-
-  When Valtimo was asked whether a user may perform an action, the resource type in that question was taken at
-  face value, which allowed any signed-in user to make the server load arbitrary internal parts of the
-  application. Only the resource types that can be selected under **Access control** are accepted now, and
-  anything else is answered as "not permitted", so normal use is unaffected.

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -19,3 +19,12 @@
 ## Bugfixes
 
 * New bugfix.
+
+## Security
+
+* **Permission checks only accept known resource types**
+
+  When Valtimo was asked whether a user may perform an action, the resource type in that question was taken at
+  face value, which allowed any signed-in user to make the server load arbitrary internal parts of the
+  application. Only the resource types that can be selected under **Access control** are accepted now, and
+  anything else is answered as "not permitted", so normal use is unaffected.


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/580

Asking whether a user may perform an action took the resource type in that question at face
value and loaded it, which let any signed-in user make the server load arbitrary internal
classes and tell which ones are present. Only the resource types that can be selected under
Access control are accepted now. Anything else is answered as "not permitted", exactly as
before, so nothing changes for normal use.

The allowlist is the set `PbacRegistryService` already derives from the application, and it gets
its own narrow cache rather than reusing the registry metadata cache — building that metadata
reflectively walks the fields of every resource class, and this endpoint is on a path the
frontend hits on nearly every page. The rejection never echoes the submitted value and never
reaches the class loader, so the loadability oracle closes too. The endpoint was deliberately
**not** locked to ADMIN: the frontend calls it for ordinary users to decide which UI affordances
to render.

## Verified against a running application

Beyond the unit tests, this was checked on a live stack (real Keycloak, real database):

- `java.lang.System`, `java.lang.Runtime`, `java.lang.ProcessBuilder` and a non-existent FQCN all
  return HTTP 200 with `available: false` and a byte-identical response shape, as non-admin and
  as admin.
- All 22 resource types reported by `GET /api/management/v1/pbac/registry` were probed with a
  valid action each. The backend raised `UnknownAuthorizationResourceTypeException` exactly 9
  times, and those 9 map one-to-one onto the deliberately bogus inputs — **zero registry types
  were rejected**, which is the non-breaking property stated directly rather than inferred.
- Unknown resource types log at DEBUG (9 occurrences) and never at ERROR (0), so an authenticated
  user cannot flood the ERROR log.
- The exception message is `"Unknown authorization resource type"` with no class name, and the
  DEBUG line names only the action.
- `@Pattern`/`@Size` on the request elements **do** take effect through `@Valid` on the
  `List<PermissionAvailableRequest>` body: path traversal, a 600-character value and an empty
  value are each rejected with HTTP 400 before reaching the resolver.

Assumptions:
- Used a dedicated `UnknownAuthorizationResourceTypeException` rather than `require(...)`.
  Catching `IllegalArgumentException` to downgrade that log line to DEBUG would also downgrade
  unrelated failures from `hasPermission`.
- `getResourceAsClass()` is removed from both request objects rather than deprecated, so the sink
  cannot be reintroduced. Nothing outside this module referenced it.

Not verified: the frontend was not exercised in a browser — the dev server would not start in the
verification environment. The non-breaking claim rests on the registry-coverage result above plus
the module's integration and security tests.

Note for the reviewer: this and #581 both add to `documentation/release-notes/13.x.x/13.41.0/README.md`
and will conflict there on merge. The conflict is additive — keep both entries.
