### PR TITLE
GH-581: Check object permissions before calling the Objecten API

### DIFF
--- a/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/client/ObjectenApiClient.kt
+++ b/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/client/ObjectenApiClient.kt
@@ -51,12 +51,6 @@ class ObjectenApiClient(
         authentication: ObjectenApiAuthentication,
         objectUrl: URI
     ): ObjectWrapper {
-        val result = buildRestClient(authentication)
-            .get()
-            .uri(objectUrl)
-            .retrieve()
-            .body<ObjectWrapper>()!!
-
         authorizationService.requirePermission(
             EntityAuthorizationRequest(
                 Object::class.java,
@@ -64,6 +58,12 @@ class ObjectenApiClient(
                 Object()
             )
         )
+
+        val result = buildRestClient(authentication)
+            .get()
+            .uri(objectUrl)
+            .retrieve()
+            .body<ObjectWrapper>()!!
 
         outboxService.send {
             ObjectViewed(
@@ -79,6 +79,14 @@ class ObjectenApiClient(
         objectUrl: URI,
         index: Int
     ): ObjectRecord {
+        authorizationService.requirePermission(
+            EntityAuthorizationRequest(
+                Object::class.java,
+                ObjectActionProvider.VIEW,
+                Object()
+            )
+        )
+
         val recordUrl = UriComponentsBuilder
             .fromUri(objectUrl)
             .pathSegment(index.toString())
@@ -90,14 +98,6 @@ class ObjectenApiClient(
             .uri(recordUrl)
             .retrieve()
             .body<ObjectRecord>()!!
-
-        authorizationService.requirePermission(
-            EntityAuthorizationRequest(
-                Object::class.java,
-                ObjectActionProvider.VIEW,
-                Object()
-            )
-        )
 
         outboxService.send {
             ObjectViewed(
@@ -116,6 +116,14 @@ class ObjectenApiClient(
         ordering: String? = null,
         pageable: Pageable
     ): ObjectsList {
+        authorizationService.requirePermission(
+            EntityAuthorizationRequest(
+                Object::class.java,
+                ObjectActionProvider.VIEW_LIST,
+                Object()
+            )
+        )
+
         val objectTypeUrl = UriComponentsBuilder.newInstance()
             .uri(objecttypesApiUrl)
             .host(objecttypesApiUrl.host)
@@ -156,14 +164,6 @@ class ObjectenApiClient(
             .retrieve()
             .body<ObjectsList>()!!
 
-        authorizationService.requirePermission(
-            EntityAuthorizationRequest(
-                Object::class.java,
-                ObjectActionProvider.VIEW_LIST,
-                Object()
-            )
-        )
-
         outboxService.send {
             ObjectsListed(
                 objectMapper.valueToTree(result.results)
@@ -181,6 +181,14 @@ class ObjectenApiClient(
         ordering: String? = null,
         pageable: Pageable
     ): ObjectsList {
+        authorizationService.requirePermission(
+            EntityAuthorizationRequest(
+                Object::class.java,
+                ObjectActionProvider.VIEW_LIST,
+                Object()
+            )
+        )
+
         val objectTypeUrl = UriComponentsBuilder.newInstance()
             .uri(objecttypesApiUrl)
             .host(objecttypesApiUrl.host)
@@ -221,14 +229,6 @@ class ObjectenApiClient(
             .header(ACCEPT_CRS, EPSG_4326)
             .retrieve()
             .body<ObjectsList>()!!
-
-        authorizationService.requirePermission(
-            EntityAuthorizationRequest(
-                Object::class.java,
-                ObjectActionProvider.VIEW_LIST,
-                Object()
-            )
-        )
 
         outboxService.send {
             ObjectsListed(

--- a/backend/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/client/ObjectenApiClientTest.kt
+++ b/backend/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/client/ObjectenApiClientTest.kt
@@ -46,7 +46,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
@@ -55,6 +57,7 @@ import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpHeaders.CONTENT_TYPE
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.reactive.function.client.ClientRequest
@@ -306,6 +309,27 @@ internal class ObjectenApiClientTest {
     }
 
     @Test
+    fun `should throw exception and not call api when not authorized to get object`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObject(
+                TestAuthentication(),
+                deniedApi.url("/some-object").toUri()
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception and not call api when not authorized to get objectrecord`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObjectRecord(
+                TestAuthentication(),
+                deniedApi.url("/some-object").toUri(),
+                2
+            )
+        }
+    }
+
+    @Test
     fun `should get objectslist`() {
         val client = ObjectenApiClient(restClientBuilder, outboxService, objectMapper, authorizationService)
 
@@ -473,6 +497,20 @@ internal class ObjectenApiClientTest {
     }
 
     @Test
+    fun `should throw exception and not call api when not authorized to get objects by object type url`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObjectsByObjecttypeUrl(
+                TestAuthentication(),
+                deniedApi.url("/some-object").toUri(),
+                deniedApi.url("/some-objectTypesApi").toUri(),
+                "typeId",
+                "",
+                PageRequest.of(0, 10)
+            )
+        }
+    }
+
+    @Test
     fun `should send outbox message when getting objects by object type url with search params`() {
         val client = ObjectenApiClient(restClientBuilder, outboxService, objectMapper, authorizationService)
 
@@ -563,6 +601,21 @@ internal class ObjectenApiClientTest {
         mockApi.takeRequest()
 
         verify(outboxService, times(0)).send(eventCapture.capture())
+    }
+
+    @Test
+    fun `should throw exception and not call api when not authorized to get objects by object type url with search params`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObjectsByObjecttypeUrlWithSearchParams(
+                authentication = TestAuthentication(),
+                objecttypesApiUrl = deniedApi.url("/some-object").toUri(),
+                objectsApiUrl = deniedApi.url("/some-objectTypesApi").toUri(),
+                objectypeId = "typeId",
+                searchString = "test",
+                ordering = "ordering",
+                pageable = PageRequest.of(0, 10)
+            )
+        }
     }
 
     @Test
@@ -1116,6 +1169,37 @@ internal class ObjectenApiClientTest {
         return MockResponse()
             .addHeader("Content-Type", "application/json")
             .setBody(body)
+    }
+
+    /**
+     * Asserts that a read operation is denied before any request leaves for the Objecten API.
+     *
+     * The permission check has to happen before the fetch: otherwise the response status of the
+     * Objecten API surfaces to an unauthorized caller, who can then tell an existing object apart
+     * from a non-existent one. The mock API answers 404 to make that leak visible - when the check
+     * runs too late, the caller sees the 404 instead of an [AccessDeniedException].
+     *
+     * A dedicated [MockWebServer] is used so that the enqueued response cannot leak into the
+     * queue of another test in this class.
+     */
+    private fun assertReadDeniedWithoutCallingApi(invoke: (ObjectenApiClient, MockWebServer) -> Unit) {
+        val deniedApi = MockWebServer()
+        deniedApi.start()
+        try {
+            deniedApi.enqueue(mockResponse("").setResponseCode(404))
+
+            val deniedAuthorizationService: AuthorizationService = mock {
+                on { this.requirePermission<Any>(any()) } doThrow AccessDeniedException("Unauthorized")
+            }
+            val client = ObjectenApiClient(restClientBuilder, outboxService, objectMapper, deniedAuthorizationService)
+
+            assertThrows<AccessDeniedException> { invoke(client, deniedApi) }
+
+            assertEquals(0, deniedApi.requestCount)
+            verify(outboxService, times(0)).send(any())
+        } finally {
+            deniedApi.shutdown()
+        }
     }
 
     class TestAuthentication : ObjectenApiAuthentication {

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -74,9 +74,3 @@
 * **Exporting case definitions**
 
   Case definitions that had a process definition removed via the database were unable to be exported.
-
-* **Object permissions are checked before the object is retrieved**
-
-  A user without permission to view objects is now refused before anything is requested from the Objecten API.
-  Previously the object was retrieved first, so the answer of the Objecten API could tell such a user whether an
-  object exists.

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -74,3 +74,9 @@
 * **Exporting case definitions**
 
   Case definitions that had a process definition removed via the database were unable to be exported.
+
+* **Object permissions are checked before the object is retrieved**
+
+  A user without permission to view objects is now refused before anything is requested from the Objecten API.
+  Previously the object was retrieved first, so the answer of the Objecten API could tell such a user whether an
+  object exists.

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -18,4 +18,8 @@
 
 ## Bugfixes
 
-* New bugfix.
+* **Object permissions are checked before the object is retrieved**
+
+  A user without permission to view objects is now refused before anything is requested from the Objecten API.
+  Previously the object was retrieved first, so the answer of the Objecten API could tell such a user whether an
+  object exists.


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/581

A user without permission to view objects was refused only after the object had already been
retrieved from the Objecten API. Because the API's answer came back first, the error such a user
received revealed whether the object existed — a one-bit existence oracle — and every request
that was going to be denied still made a pointless outbound call. The permission check now runs
before anything is requested, in all four read operations. The write operations already checked
first and are unchanged.

Nothing is lost by checking first: the entity passed to the check is a fieldless `Object()`, so
the check has no dependency on the response.

The four new tests each fail against the unpatched code with
`HttpClientErrorException$NotFound` — that failure *is* the leak, which is why the mock enqueues a
404 rather than a success.

## Scope

This fixes the concrete defect in issue 581 only. The issue also raises **per-object scoping**,
which is a permission-model question rather than a bug: `Object` is deliberately a fieldless
capability marker, so no permission condition can scope it. That is being handled as a roadmap
item and the issue should **not** be closed as fixed on the back of this PR — a `view` grant still
means "may read any object in a configured Objecten API".

Worth noting for the reporter: the write paths cited in the issue (`createObject`, `objectPatch`,
`objectUpdate`, `deleteObject`) already checked permission before the outbound call, so the
write/delete escalation described there does not apply to this defect.

Not verified against a running application: this is a reordering inside the API client with no UI
surface of its own, covered by unit tests that assert no request reaches the mock API when
permission is denied.

Note for the reviewer: this and #580 both add to `documentation/release-notes/13.x.x/13.41.0/README.md`
and will conflict there on merge. The conflict is additive — keep both entries.
