### PR TITLE
docs: move continuous sync release note to 13.41.0

### DIFF
--- a/documentation/release-notes/13.x.x/13.40.0/README.md
+++ b/documentation/release-notes/13.x.x/13.40.0/README.md
@@ -24,15 +24,6 @@
   See the [widget documentation](../../../features/case/case-detail/tabs/widgets.md) for the configuration
   details.
 
-* **Continuous sync of building block output mappings**
-
-  Each building block output mapping can now be configured to sync either at the **End** of the building block
-  (the existing behaviour, and still the default) or **Continuously**. A continuous mapping is written back to the
-  parent context on every saved change to the building block data, while the building block is still running,
-  instead of only when it completes. This works for building blocks linked to a call activity, started ad-hoc as a
-  case action, and used in independent processes (writing to process variables via the `pv:` prefix). See the
-  [building block documentation](../../../features/building-blocks/README.md) for the configuration details.
-
 ## Enhancements
 
 * **Zaaktype dropdown now shows the begin and end date**

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -20,6 +20,14 @@
   the case's **Start** menu. See
   [Start a building block by message](../../../features/building-blocks/README.md#start-a-building-block-by-message).
 
+* **Continuous sync of building block output mappings**
+
+  Each building block output mapping can now be configured to sync either at the **End** of the building block
+  (the existing behaviour, and still the default) or **Continuously**. A continuous mapping is written back to the
+  parent context on every saved change to the building block data, while the building block is still running,
+  instead of only when it completes. This works for building blocks linked to a call activity, started ad-hoc as a
+  case action, and used in independent processes (writing to process variables via the `pv:` prefix). See the
+  [building block documentation](../../../features/building-blocks/README.md) for the configuration details.
 
 ## Enhancements
 


### PR DESCRIPTION
The release note for "Continuous sync of building block output mappings" (#884) was written in the `13.40.0` folder, but the feature was released in **13.41.0**. Moved the bullet to `documentation/release-notes/13.x.x/13.41.0/README.md`.

The same fix is applied on `release/13.41.0` so #896 carries the correct placement.