### PR TITLE
Story/bugfixes 514

### DIFF
--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -64,38 +64,6 @@
   Fixed an issue where duplicating a divider opened the duplication dialog with an empty, invalid key that 
   could not be edited, leaving the Duplicate button disabled. The dialog now pre-populates the divider key 
   with a unique default value and allows it to be edited before duplicating.
-  
-* **A dashboard widget with the bar chart display type is no longer empty**
-
-  A dashboard widget that is configured with case counts and the bar chart display type showed an empty
-  widget, while the same counts were shown correctly with the donut and meter display types. The bar
-  chart is now rendered.
-
-* **A form flow of a user task now loads completely when another user task is opened**
-
-  When a process has multiple user tasks that are linked to a form flow, opening the next user task
-  showed an empty or half rendered form until the tab was switched or the page was refreshed. The
-  form flow now reloads its step whenever another form flow instance is opened.
-
-* **Quickly opening the next user task no longer empties the task modal**
-
-  When a user completed a task and opened the next one within a fraction of a second, the task modal
-  could lose its content shortly after opening: the delayed cleanup of the previous task cleared the
-  modal after the next task was already shown. That cleanup is now skipped when another task has been
-  opened in the meantime.
-
-* **A form flow step without a translation no longer shows a raw translation key**
-
-  The step indicator above a form flow form showed the raw translation key (for example
-  `formFlow.step.step1.title`) when no translation was defined for a step. It now falls back to the
-  step key from the form flow definition.
-
-* **Breadcrumbs of a DMN decision table no longer stay behind on other screens**
-
-  After opening a decision table of a case and then navigating to another screen through the menu, the
-  breadcrumbs, page title and page header buttons of the decision table could stay visible on that screen
-  until the page was reloaded. The decision table screen now always cleans up its breadcrumbs and title,
-  even when the DMN editor fails to shut down.
 
 * **Start form of a building block now opens in the panel**
 

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -77,6 +77,19 @@
   showed an empty or half rendered form until the tab was switched or the page was refreshed. The
   form flow now reloads its step whenever another form flow instance is opened.
 
+* **Quickly opening the next user task no longer empties the task modal**
+
+  When a user completed a task and opened the next one within a fraction of a second, the task modal
+  could lose its content shortly after opening: the delayed cleanup of the previous task cleared the
+  modal after the next task was already shown. That cleanup is now skipped when another task has been
+  opened in the meantime.
+
+* **A form flow step without a translation no longer shows a raw translation key**
+
+  The step indicator above a form flow form showed the raw translation key (for example
+  `formFlow.step.step1.title`) when no translation was defined for a step. It now falls back to the
+  step key from the form flow definition.
+
 * **Breadcrumbs of a DMN decision table no longer stay behind on other screens**
 
   After opening a decision table of a case and then navigating to another screen through the menu, the

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -31,6 +31,12 @@
   could not be edited, leaving the Duplicate button disabled. The dialog now pre-populates the divider key 
   with a unique default value and allows it to be edited before duplicating.
   
+* **A dashboard widget with the bar chart display type is no longer empty**
+
+  A dashboard widget that is configured with case counts and the bar chart display type showed an empty
+  widget, while the same counts were shown correctly with the donut and meter display types. The bar
+  chart is now rendered.
+
 * **A form flow of a user task now loads completely when another user task is opened**
 
   When a process has multiple user tasks that are linked to a form flow, opening the next user task

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -31,6 +31,13 @@
   could not be edited, leaving the Duplicate button disabled. The dialog now pre-populates the divider key 
   with a unique default value and allows it to be edited before duplicating.
   
+* **Breadcrumbs of a DMN decision table no longer stay behind on other screens**
+
+  After opening a decision table of a case and then navigating to another screen through the menu, the
+  breadcrumbs, page title and page header buttons of the decision table could stay visible on that screen
+  until the page was reloaded. The decision table screen now always cleans up its breadcrumbs and title,
+  even when the DMN editor fails to shut down.
+
 * **Start form of a building block now opens in the panel**
 
   Starting a building block from the 'Start' menu of a case did nothing when the start form of its

--- a/documentation/release-notes/13.x.x/13.41.0/README.md
+++ b/documentation/release-notes/13.x.x/13.41.0/README.md
@@ -31,6 +31,12 @@
   could not be edited, leaving the Duplicate button disabled. The dialog now pre-populates the divider key 
   with a unique default value and allows it to be edited before duplicating.
   
+* **A form flow of a user task now loads completely when another user task is opened**
+
+  When a process has multiple user tasks that are linked to a form flow, opening the next user task
+  showed an empty or half rendered form until the tab was switched or the page was refreshed. The
+  form flow now reloads its step whenever another form flow instance is opened.
+
 * **Breadcrumbs of a DMN decision table no longer stay behind on other screens**
 
   After opening a decision table of a case and then navigating to another screen through the menu, the

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -36,6 +36,38 @@
   Previously the object was retrieved first, so the answer of the Objecten API could tell such a user whether an
   object exists.
 
+* **A dashboard widget with the bar chart display type is no longer empty**
+
+  A dashboard widget that is configured with case counts and the bar chart display type showed an empty
+  widget, while the same counts were shown correctly with the donut and meter display types. The bar
+  chart is now rendered.
+
+* **A form flow of a user task now loads completely when another user task is opened**
+
+  When a process has multiple user tasks that are linked to a form flow, opening the next user task
+  showed an empty or half rendered form until the tab was switched or the page was refreshed. The
+  form flow now reloads its step whenever another form flow instance is opened.
+
+* **Quickly opening the next user task no longer empties the task modal**
+
+  When a user completed a task and opened the next one within a fraction of a second, the task modal
+  could lose its content shortly after opening: the delayed cleanup of the previous task cleared the
+  modal after the next task was already shown. That cleanup is now skipped when another task has been
+  opened in the meantime.
+
+* **A form flow step without a translation no longer shows a raw translation key**
+
+  The step indicator above a form flow form showed the raw translation key (for example
+  `formFlow.step.step1.title`) when no translation was defined for a step. It now falls back to the
+  step key from the form flow definition.
+
+* **Breadcrumbs of a DMN decision table no longer stay behind on other screens**
+
+  After opening a decision table of a case and then navigating to another screen through the menu, the
+  breadcrumbs, page title and page header buttons of the decision table could stay visible on that screen
+  until the page was reloaded. The decision table screen now always cleans up its breadcrumbs and title,
+  even when the DMN editor fails to shut down.
+
 ## Security
 
 * **Permission checks only accept known resource types**

--- a/frontend/projects/valtimo/dashboard/src/lib/display-types/bar-chart/components/bar-chart-display/bar-chart-display.component.html
+++ b/frontend/projects/valtimo/dashboard/src/lib/display-types/bar-chart/components/bar-chart-display/bar-chart-display.component.html
@@ -25,10 +25,10 @@
 <section class="valtimo-donut-widget__content">
   <ng-container *ngIf="barChartData$ | async as barChartData">
     @if (barChartData.length > 0) {
-      <ibm-bar-chart
+      <ibm-simple-bar-chart
         [data]="barChartData"
         [options]="barChartChartOptions$ | async"
-      ></ibm-bar-chart>
+      ></ibm-simple-bar-chart>
     } @else {
       <valtimo-no-results
         [collapseVertically]="true"

--- a/frontend/projects/valtimo/dashboard/src/lib/display-types/bar-chart/components/bar-chart-display/bar-chart-display.component.ts
+++ b/frontend/projects/valtimo/dashboard/src/lib/display-types/bar-chart/components/bar-chart-display/bar-chart-display.component.ts
@@ -51,9 +51,10 @@ export class BarChartDisplayComponent implements DisplayComponent {
   public readonly barChartChartOptions$: Observable<BarChartOptions> =
     this.themeService.currentTheme$.pipe(
       map(currentTheme => ({
-        title: 'Vertical simple bar (discrete)',
         theme: currentTheme,
-        height: '400px',
+        resizable: true,
+        toolbar: {enabled: false},
+        height: '300px',
         axes: {
           left: {
             mapsTo: 'value',

--- a/frontend/projects/valtimo/decision/src/lib/decision-modeler/decision-modeler.component.ts
+++ b/frontend/projects/valtimo/decision/src/lib/decision-modeler/decision-modeler.component.ts
@@ -275,10 +275,17 @@ export class DecisionModelerComponent
   }
 
   public ngOnDestroy(): void {
-    this.dmnEditor?.destroy();
-    this.pageTitleService.enableReset();
+    // Reset the shared page state first: a failing teardown of the editor or the page header
+    // would otherwise leave this page's breadcrumbs and title behind on the next screen.
     this.breadcrumbService.clearThirdBreadcrumb();
     this.breadcrumbService.clearFourthBreadcrumb();
+    this.pageTitleService.enableReset();
+
+    try {
+      this.dmnEditor?.destroy();
+    } catch (err) {
+      console.error('dmn editor destroy error', err);
+    }
   }
 
   public ngAfterViewInit(): void {

--- a/frontend/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
+++ b/frontend/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
@@ -192,15 +192,20 @@ export class FormFlowComponent implements OnDestroy {
         this.currentStepIndex$.next(breadcrumbs.currentStepIndex);
 
         this.breadcrumbs$.next(
-          breadcrumbs.breadcrumbs.map(breadcrumb => ({
-            label:
-              breadcrumb.title ??
-              this.translateService.instant(`formFlow.step.${breadcrumb.key}.title`) ??
-              breadcrumb.key,
-            disabled: breadcrumb.stepInstanceId === null,
-            complete: breadcrumb.completed,
-            stepInstanceId: breadcrumb.stepInstanceId,
-          }))
+          breadcrumbs.breadcrumbs.map(breadcrumb => {
+            const translationKey = `formFlow.step.${breadcrumb.key}.title`;
+            // instant() returns the key itself when no translation exists
+            const translatedTitle = this.translateService.instant(translationKey);
+
+            return {
+              label:
+                breadcrumb.title ??
+                (translatedTitle !== translationKey ? translatedTitle : breadcrumb.key),
+              disabled: breadcrumb.stepInstanceId === null,
+              complete: breadcrumb.completed,
+              stepInstanceId: breadcrumb.stepInstanceId,
+            };
+          })
         );
 
         if (classElement.length > 0) {

--- a/frontend/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
+++ b/frontend/projects/valtimo/process-link/src/lib/components/form-flow/form-flow.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
+import {Component, EventEmitter, Input, OnDestroy, Output, ViewChild} from '@angular/core';
 import {BehaviorSubject, combineLatest, Subscription} from 'rxjs';
 import {FormioForm} from '@formio/angular';
 import {
@@ -37,16 +37,23 @@ import {map} from 'rxjs/operators';
   templateUrl: './form-flow.component.html',
   styleUrls: ['./form-flow.component.scss'],
 })
-export class FormFlowComponent implements OnInit, OnDestroy {
+export class FormFlowComponent implements OnDestroy {
   @ViewChild('form') public readonly form: FormioComponent;
 
   @Input() public readonly formIoFormData: BehaviorSubject<any | null> = new BehaviorSubject<any>(
     null
   );
   @Input() public set formFlowInstanceId(value: string | null) {
-    this.formFlowInstanceId$.next(value);
+    if (this.formFlowInstanceId$.getValue() === value) return;
 
-    if (value) this.getBreadcrumbs();
+    this.formFlowInstanceId$.next(value);
+    // Hide the step of the previous instance until the new one has been loaded.
+    this.formFlowStepType$.next(null);
+
+    if (!value) return;
+
+    this.getBreadcrumbs();
+    this.getFormFlowStep();
   }
 
   @Output() public readonly formFlowComplete = new EventEmitter();
@@ -77,10 +84,6 @@ export class FormFlowComponent implements OnInit, OnDestroy {
   ) {
     this.formioOptions = new FormioOptionsImpl();
     this.formioOptions.disableAlerts = true;
-  }
-
-  public ngOnInit() {
-    this.getFormFlowStep();
   }
 
   public ngOnDestroy(): void {

--- a/frontend/projects/valtimo/task/src/lib/components/task-detail-modal/task-detail-modal.component.spec.ts
+++ b/frontend/projects/valtimo/task/src/lib/components/task-detail-modal/task-detail-modal.component.spec.ts
@@ -18,7 +18,9 @@ import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/t
 import {Router} from '@angular/router';
 import {TranslateService} from '@ngx-translate/core';
 import {PermissionRequest, PermissionService} from '@valtimo/access-control';
+import {CARBON_CONSTANTS} from '@valtimo/components';
 import {DocumentService} from '@valtimo/document';
+import {TaskWithProcessLink} from '@valtimo/process-link';
 import {GlobalNotificationService} from '@valtimo/shared';
 import {SseService} from '@valtimo/sse';
 import {IconService} from 'carbon-components-angular';
@@ -37,6 +39,18 @@ describe('TaskDetailModalComponent', () => {
     created: '2026-01-01',
     assignee: null,
   } as unknown as Task;
+
+  const secondTask = {...task, id: 'task-2', name: 'Second task'} as unknown as Task;
+
+  const taskWithProcessLink = {
+    task,
+    processLinkActivityResult: null,
+  } as unknown as TaskWithProcessLink;
+
+  const secondTaskWithProcessLink = {
+    task: secondTask,
+    processLinkActivityResult: null,
+  } as unknown as TaskWithProcessLink;
 
   let fixture: ComponentFixture<TaskDetailModalComponent>;
   let component: TaskDetailModalComponent;
@@ -195,6 +209,63 @@ describe('TaskDetailModalComponent', () => {
     // the re-fetch skips 403/404 so no global error toast is shown for the expected access loss
     expect(taskService.getTask).toHaveBeenCalledWith(task.id, ['403', '404']);
     expect(component.modalOpen$.getValue()).toBeFalse();
+    flush();
+  }));
+
+  it('clears the task state after the modal close animation', fakeAsync(() => {
+    const intermediateSaveService = TestBed.inject(
+      TaskIntermediateSaveService
+    ) as jasmine.SpyObj<TaskIntermediateSaveService>;
+
+    component.openTaskAndProcessLinkDetails(taskWithProcessLink);
+    tick();
+    expect(component.modalOpen$.getValue()).toBeTrue();
+    expect(component.processLinkPreloaded$.getValue()).toBeTrue();
+
+    component.closeModal();
+    tick(CARBON_CONSTANTS.modalAnimationMs);
+
+    expect(component.processLinkPreloaded$.getValue()).toBeFalse();
+    expect(component.task$.getValue()).toBeNull();
+    expect(component.taskAndProcessLink$.getValue()).toBeNull();
+    expect(intermediateSaveService.setSubmission).toHaveBeenCalledWith({});
+    flush();
+  }));
+
+  it('keeps the next task when it is opened within the close animation of the previous task', fakeAsync(() => {
+    const intermediateSaveService = TestBed.inject(
+      TaskIntermediateSaveService
+    ) as jasmine.SpyObj<TaskIntermediateSaveService>;
+
+    component.openTaskAndProcessLinkDetails(taskWithProcessLink);
+    tick();
+
+    component.closeModal();
+    // reopen for another task before the close animation (and its delayed cleanup) completes
+    tick(CARBON_CONSTANTS.modalAnimationMs / 2);
+    component.openTaskAndProcessLinkDetails(secondTaskWithProcessLink);
+    tick(CARBON_CONSTANTS.modalAnimationMs);
+
+    expect(component.modalOpen$.getValue()).toBeTrue();
+    expect(component.processLinkPreloaded$.getValue()).toBeTrue();
+    expect(component.task$.getValue()?.id).toBe('task-2');
+    expect(component.taskAndProcessLink$.getValue()).toBe(secondTaskWithProcessLink);
+    expect(intermediateSaveService.setSubmission).not.toHaveBeenCalled();
+    flush();
+  }));
+
+  it('resets the preloaded flag when a task without a preloaded process link is opened within the close animation', fakeAsync(() => {
+    component.openTaskAndProcessLinkDetails(taskWithProcessLink);
+    tick();
+
+    component.closeModal();
+    tick(CARBON_CONSTANTS.modalAnimationMs / 2);
+    component.openTaskDetails(secondTask);
+    tick(CARBON_CONSTANTS.modalAnimationMs);
+
+    expect(component.modalOpen$.getValue()).toBeTrue();
+    expect(component.processLinkPreloaded$.getValue()).toBeFalse();
+    expect(component.task$.getValue()?.id).toBe('task-2');
     flush();
   }));
 });

--- a/frontend/projects/valtimo/task/src/lib/components/task-detail-modal/task-detail-modal.component.ts
+++ b/frontend/projects/valtimo/task/src/lib/components/task-detail-modal/task-detail-modal.component.ts
@@ -136,6 +136,8 @@ export class TaskDetailModalComponent implements OnInit, OnDestroy {
     shareReplay(1)
   );
 
+  private _modalSession = 0;
+
   private readonly _subscriptions = new Subscription();
 
   constructor(
@@ -312,6 +314,8 @@ export class TaskDetailModalComponent implements OnInit, OnDestroy {
   }
 
   public openTaskDetails(task: Task | null): void {
+    // A skipped close cleanup can leave the preloaded flag of a previous open behind
+    this.processLinkPreloaded$.next(false);
     if (task) {
       this.task$.next({...task});
     }
@@ -426,8 +430,13 @@ export class TaskDetailModalComponent implements OnInit, OnDestroy {
     this.modalOpen$.next(false);
     this.modalCloseEvent$.next(!this.modalCloseEvent$.getValue());
     this.modalClosed.emit();
-    // Delay clearing task data and submission until after modal close animation completes
+    const session = this._modalSession;
+    // Delay clearing task data and submission until after modal close animation completes.
+    // When the modal has been reopened for another task within that delay, clearing would wipe
+    // the newly opened task, so the cleanup of a stale close is skipped.
     runAfterCarbonModalClosed(() => {
+      if (session !== this._modalSession) return;
+
       this.processLinkPreloaded$.next(false);
       this.task$.next(null);
       this.taskAndProcessLink$.next(null);
@@ -436,6 +445,7 @@ export class TaskDetailModalComponent implements OnInit, OnDestroy {
   }
 
   private openModal(): void {
+    this._modalSession++;
     this.modalOpen$.next(false);
 
     setTimeout(() => {


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/514
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/539
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/783

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: story/bugfixes-514

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps

**DMN breadcrumbs**

  1. Admin → Cases → Bezwaar → Decision tables tab → open E2E Test Decision.
  2. Check the header: Admin / Cases / bezwaar (1.0.1) / Decision tables.
  3. Click any menu item (Admin → Choice fields, Views → Cases, Plugins…).
  4. Expected: clean breadcrumb, the new screen's title, and no Deploy/Back buttons from the DMN.

  Note: under normal conditions this already worked; the fix protects against a failing teardown. To see the bug, add throw new Error('x') as the first line of ngOnDestroy in
  decision-modeler.component.ts and repeat 1-4: the DMN breadcrumbs stay stuck on the next screen. With the fix, move that throw inside the try and everything is cleaned up.

**Form flow between user tasks**

  1. Prep: create an Energietoeslag Aanvraag case (it starts the subprocess automatically and creates the form-flow task). One already exists, so one more gives you two.
  2. Tasks → All tasks tab: two Beoordeel Berekening tasks.
  3. Open the first one → full form (progress bar + fields). Close it.
  4. Open the second one → expected: loads completely right away, no refresh or tab switch needed.
  5. Exact ticket flow: complete one task, then open the other.

  With the previous code the second one came up empty or half rendered. Note: I could not reproduce this locally (there is only one form-flow process link in your database), so this is the test that

  Note: under normal conditions this already worked; the fix protects against a failing teardown. To see the bug, add throw new Error('x') as the first line of ngOnDestroy in
  decision-modeler.component.ts and repeat 1-4: the DMN breadcrumbs stay stuck on the next screen. With the fix, move that throw inside the try and everything is cleaned up.

**Form flow between user tasks**

  1. Prep: create an Energietoeslag Aanvraag case (it starts the subprocess automatically and creates the form-flow task). One already exists, so one more gives you two.
  2. Tasks → All tasks tab: two Beoordeel Berekening tasks.
  3. Open the first one → full form (progress bar + fields). Close it.
  4. Open the second one → expected: loads completely right away, no refresh or tab switch needed.
  5. Exact ticket flow: complete one task, then open the other.

  With the previous code the second one came up empty or half rendered. Note: I could not reproduce this locally (there is only one form-flow process link in your database), so this is the test that
  still really needs to pass.

**Bar chart widget**

  1. Go to Dashboard (/).
  2. Look at the Title / Substitle widget (testing_bug, case counts + bar chart).
  3. Expected: a bar chart with axes and legend; per its configuration, a bar with value 1 in group "2" and nothing in group "1".
  4. Cross-check: the donut (Zaakstatussen) and gauge (Zaken zonder behandelaar) are unchanged.
  5. Optional: create your own widget under Admin → Dashboard with several case counts and display type Bar chart, and check the numbers match the donut using the same configuration.

  Before the fix that widget was completely empty.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
