### PR TITLE
GH-855: Form flow expressions containing a colon are corrupted when imported

### DIFF
--- a/backend/apps/evenementenvergunning/src/main/resources/config/application.yml
+++ b/backend/apps/evenementenvergunning/src/main/resources/config/application.yml
@@ -194,7 +194,7 @@ valtimo:
         zaakdetails:
             linktozaak:
                 enabled: true
-    imports:
+    import:
         whitelistedPaths:
             - "GZAC_.*"
             - "VALTIMO_.*"

--- a/backend/apps/gzac/src/main/resources/config/application.yml
+++ b/backend/apps/gzac/src/main/resources/config/application.yml
@@ -194,7 +194,7 @@ valtimo:
         zaakdetails:
             linktozaak:
                 enabled: true
-    imports:
+    import:
         whitelistedPaths:
             - "GZAC_.*"
             - "VALTIMO_.*"

--- a/backend/changelog/src/main/kotlin/com/ritense/valtimo/changelog/service/ChangelogDeployer.kt
+++ b/backend/changelog/src/main/kotlin/com/ritense/valtimo/changelog/service/ChangelogDeployer.kt
@@ -82,22 +82,14 @@ class ChangelogDeployer(
     }
 
     fun resolveProperties(content: String): String {
-        var resolvedContent = content
-        Regex("\\$\\{([^\\}]+)\\}").findAll(content)
-            .map { it.groupValues }
-            .forEach { (placeholder, placeholderValue) ->
-                try {
-                    val name = placeholderValue.substringBefore(':')
-                    val default = placeholderValue.substringAfter(':', missingDelimiterValue = "").takeIf { ':' in placeholderValue }
-                    val resolvedValue = environment.getProperty(name)?.takeIf { it.isNotBlank() } ?: default
-                    if (resolvedValue != null) {
-                        resolvedContent = resolvedContent.replace(placeholder, resolvedValue)
-                    }
-                } catch (e: Exception) {
-                    // ignored
-                }
-            }
-        return resolvedContent
+        return PROPERTY_PLACEHOLDER_PATTERN.replace(content) { match ->
+            val name = match.groupValues[1]
+            // Only present when the placeholder actually contained a ':'
+            val default = match.groups[2]?.value
+            environment.getProperty(name)?.takeIf { it.isNotBlank() }
+                ?: default
+                ?: match.value
+        }
     }
 
     // Uses TreeMap when parsing to ObjectNode. Will sort keys alphabetically when serialized
@@ -109,6 +101,13 @@ class ChangelogDeployer(
 
     companion object {
         private val logger = KotlinLogging.logger {}
+
+        /**
+         * Matches Spring-style property placeholders only: `${name}` or `${name:default}`, where the name is
+         * limited to property key characters. Expressions that happen to use the same delimiters, like
+         * `${someBean.call('doc:/a', 'pv:b')}`, are left untouched.
+         */
+        private val PROPERTY_PLACEHOLDER_PATTERN = Regex("""\$\{([A-Za-z0-9_.\-\[\]]+)(?::([^{}]*))?}""")
     }
 
 }

--- a/backend/changelog/src/test/kotlin/com/ritense/valtimo/changelog/ChangelogDeployerIntTest.kt
+++ b/backend/changelog/src/test/kotlin/com/ritense/valtimo/changelog/ChangelogDeployerIntTest.kt
@@ -151,4 +151,13 @@ internal class ChangelogDeployerIntTest : BaseIntegrationTest() {
 
         assertThat(result).isEqualTo(content)
     }
+
+    @Test
+    fun `should leave expression containing a colon untouched`() {
+        val content = """{"value": "${'$'}{someBean.doSomething(step.submissionData, {'doc:/a':'/b'})}"}"""
+
+        val result = changelogDeployer.resolveProperties(content)
+
+        assertThat(result).isEqualTo(content)
+    }
 }

--- a/backend/importer/src/main/kotlin/com/ritense/importer/ValtimoImportService.kt
+++ b/backend/importer/src/main/kotlin/com/ritense/importer/ValtimoImportService.kt
@@ -525,7 +525,8 @@ class ValtimoImportService(
             // Only present when the placeholder actually contained a ':'
             val default = match.groups[2]?.value
             if (whitelistedEnvironmentProperties.none { it.matches(name) }) {
-                logger.debug { "Property '$name' is not whitelisted. Leaving '${match.value}' untouched." }
+                // Only the name is logged: a default value can hold a secret
+                logger.debug { "Property '$name' is not whitelisted. Leaving its placeholder untouched." }
                 match.value
             } else {
                 environment.getProperty(name)?.takeIf { it.isNotBlank() }

--- a/backend/importer/src/main/kotlin/com/ritense/importer/ValtimoImportService.kt
+++ b/backend/importer/src/main/kotlin/com/ritense/importer/ValtimoImportService.kt
@@ -520,26 +520,19 @@ class ValtimoImportService(
     }
 
     private fun resolveProperties(content: String): String {
-        var resolvedContent = content
-        Regex("\\$\\{([^\\}]+)\\}").findAll(content)
-            .map { it.groupValues }
-            .forEach { (placeholder, placeholderValue) ->
-                try {
-                    val name = placeholderValue.substringBefore(':')
-                    val default = placeholderValue.substringAfter(':', missingDelimiterValue = "").takeIf { ':' in placeholderValue }
-                    val resolvedValue = if (whitelistedEnvironmentProperties.any { it.matches(name) }) {
-                        environment.getProperty(name)?.takeIf { it.isNotBlank() } ?: default
-                    } else {
-                        default
-                    }
-                    if (resolvedValue != null) {
-                        resolvedContent = resolvedContent.replace(placeholder, resolvedValue)
-                    }
-                } catch (e: Exception) {
-                    // ignored
-                }
+        return PROPERTY_PLACEHOLDER_PATTERN.replace(content) { match ->
+            val name = match.groupValues[1]
+            // Only present when the placeholder actually contained a ':'
+            val default = match.groups[2]?.value
+            if (whitelistedEnvironmentProperties.none { it.matches(name) }) {
+                logger.debug { "Property '$name' is not whitelisted. Leaving '${match.value}' untouched." }
+                match.value
+            } else {
+                environment.getProperty(name)?.takeIf { it.isNotBlank() }
+                    ?: default
+                    ?: match.value
             }
-        return resolvedContent
+        }
     }
 
     // change entries to be nested
@@ -581,6 +574,13 @@ class ValtimoImportService(
 
     private companion object {
         val logger = KotlinLogging.logger {}
+
+        /**
+         * Matches Spring-style property placeholders only: `${name}` or `${name:default}`, where the name is
+         * limited to property key characters. Expressions that happen to use the same delimiters, like
+         * `${valtimoFormFlow.completeTask(x, y, {'doc:/a':'/b'})}` or `${doc:someField}`, are left untouched.
+         */
+        val PROPERTY_PLACEHOLDER_PATTERN = Regex("""\$\{([A-Za-z0-9_.\-\[\]]+)(?::([^{}]*))?}""")
 
         class WrappedImporter(
 

--- a/backend/importer/src/test/kotlin/com/ritense/importer/ValtimoImportServiceTest.kt
+++ b/backend/importer/src/test/kotlin/com/ritense/importer/ValtimoImportServiceTest.kt
@@ -254,13 +254,14 @@ class ValtimoImportServiceTest {
     }
 
     @Test
-    fun `should use default even when property is not whitelisted`() {
+    fun `should leave placeholder untouched when property is not whitelisted`() {
         val environment = mock(Environment::class.java)
         val service = ValtimoImportService(setOf(), environment, emptyList(), null)
+        val content = """{"url": "${'$'}{NOT_WHITELISTED:https://default.example.com}"}"""
 
-        val result = service.invokeResolveProperties("""{"url": "${'$'}{NOT_WHITELISTED:https://default.example.com}"}""")
+        val result = service.invokeResolveProperties(content)
 
-        assertThat(result).isEqualTo("""{"url": "https://default.example.com"}""")
+        assertThat(result).isEqualTo(content)
     }
 
     @Test
@@ -282,6 +283,45 @@ class ValtimoImportServiceTest {
         val result = service.invokeResolveProperties(content)
 
         assertThat(result).isEqualTo(content)
+    }
+
+    @Test
+    fun `should leave form flow expression containing a colon untouched`() {
+        val environment = mock(Environment::class.java)
+        val service = ValtimoImportService(setOf(), environment, listOf(Regex("valtimo.*")), null)
+        val content = """
+            {"onComplete": ["${'$'}{valtimoFormFlow.completeTask(additionalProperties, step.submissionData, {'doc:/address/streetName':'/street', 'pv:approved':'/approval'})}"]}
+        """.trimIndent()
+
+        val result = service.invokeResolveProperties(content)
+
+        assertThat(result).isEqualTo(content)
+    }
+
+    @Test
+    fun `should leave value resolver expression untouched`() {
+        val environment = mock(Environment::class.java)
+        val service = ValtimoImportService(setOf(), environment, listOf(Regex("VALTIMO_.*")), null)
+        val content = """{"navigateTo": "/iko/demo/bsn/details/${'$'}{doc:ikoSearchResult.id}"}"""
+
+        val result = service.invokeResolveProperties(content)
+
+        assertThat(result).isEqualTo(content)
+    }
+
+    @Test
+    fun `should resolve whitelisted property next to an expression`() {
+        val environment = mock(Environment::class.java)
+        whenever(environment.getProperty("VALTIMO_API_URL")).thenReturn("https://api.example.com")
+        val service = ValtimoImportService(setOf(), environment, listOf(Regex("VALTIMO_.*")), null)
+
+        val result = service.invokeResolveProperties(
+            """{"url": "${'$'}{VALTIMO_API_URL}", "expression": "${'$'}{someBean.call('doc:/a', 'pv:b')}"}"""
+        )
+
+        assertThat(result).isEqualTo(
+            """{"url": "https://api.example.com", "expression": "${'$'}{someBean.call('doc:/a', 'pv:b')}"}"""
+        )
     }
 
     private fun ValtimoImportService.invokeResolveProperties(content: String): String {

--- a/documentation/features/plugins/README.md
+++ b/documentation/features/plugins/README.md
@@ -93,7 +93,10 @@ valtimo:
       - "GZAC_.*"
 ```
 
-This ensures that only environment variables matching the given patterns are available in the deployment file.
+This ensures that only environment variables matching the given patterns are available in the deployment file. A
+`${...}` placeholder whose name does not match any of the patterns is left in the file as-is, including its default
+value if it has one. This keeps expressions that use the same syntax, such as
+`${valtimoFormFlow.completeTask(additionalProperties, step.submissionData, {'doc:/path':'/other'})}`, intact.
 
 {% endtab %}
 {% endtabs %}

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -18,7 +18,11 @@
 
 ## Bugfixes
 
-* New bugfix.
+* **Form flow steps with a colon in their expressions work again after import**
+
+  Importing a case no longer breaks form flow steps whose start or complete expression contains a colon, such as one
+  that saves submission data to a document or process variable. These steps stopped working after import because part
+  of the expression was cut off.
 
 ## Security
 


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/855

## Bug

Auto-deploying a case broke form flow steps whose expressions contained a colon, such as a step that saves submission data to a document or process variable. Part of the expression was cut off, so the step no longer worked.

## Fix

Expressions are now imported exactly as written.
