### PR TITLE
GH-718: Apply permission checks to dashboard case data

### DIFF
--- a/backend/case/src/main/kotlin/com/ritense/document/autoconfiguration/DocumentWidgetAutoConfiguration.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/autoconfiguration/DocumentWidgetAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.document.autoconfiguration
 
+import com.ritense.authorization.AuthorizationService
 import com.ritense.document.dashboard.DocumentWidgetDataSource
 import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
 import com.ritense.valtimo.contract.database.QueryDialectHelper
@@ -32,6 +33,7 @@ class DocumentWidgetAutoConfiguration {
     fun documentWidgetDataSource(
         documentRepository: JsonSchemaDocumentRepository,
         queryDialectHelper: QueryDialectHelper,
-        entityManager: EntityManager
-    ) = DocumentWidgetDataSource(documentRepository, queryDialectHelper, entityManager)
+        entityManager: EntityManager,
+        authorizationService: AuthorizationService
+    ) = DocumentWidgetDataSource(documentRepository, queryDialectHelper, entityManager, authorizationService)
 }

--- a/backend/case/src/main/kotlin/com/ritense/document/dashboard/DocumentWidgetDataSource.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/dashboard/DocumentWidgetDataSource.kt
@@ -148,8 +148,7 @@ class DocumentWidgetDataSource(
         EntityAuthorizationRequest(
             JsonSchemaDocument::class.java,
             VIEW_LIST
-        ),
-        null
+        )
     )
 
     private fun <T> getPathExpression(

--- a/backend/case/src/main/kotlin/com/ritense/document/dashboard/DocumentWidgetDataSource.kt
+++ b/backend/case/src/main/kotlin/com/ritense/document/dashboard/DocumentWidgetDataSource.kt
@@ -16,14 +16,18 @@
 
 package com.ritense.document.dashboard
 
+import com.ritense.authorization.AuthorizationService
+import com.ritense.authorization.request.EntityAuthorizationRequest
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
 import com.ritense.document.repository.impl.specification.JsonSchemaDocumentSpecificationHelper.Companion.byDocumentDefinitionIdName
+import com.ritense.document.service.JsonSchemaDocumentActionProvider.VIEW_LIST
 import com.ritense.valtimo.contract.conditions.Condition
 import com.ritense.valtimo.contract.dashboard.WidgetDataSource
 import com.ritense.valtimo.contract.database.QueryDialectHelper
 import com.ritense.valtimo.contract.repository.ExpressionOperator
 import jakarta.persistence.EntityManager
+import jakarta.persistence.criteria.AbstractQuery
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.Expression
 import jakarta.persistence.criteria.Path
@@ -32,12 +36,14 @@ import jakarta.persistence.criteria.Root
 class DocumentWidgetDataSource(
     private val documentRepository: JsonSchemaDocumentRepository,
     private val queryDialectHelper: QueryDialectHelper,
-    private val entityManager: EntityManager
+    private val entityManager: EntityManager,
+    private val authorizationService: AuthorizationService
 ) {
 
     @WidgetDataSource("case-count", "Case count")
     fun getCaseCount(caseCountDataSourceProperties: DocumentCountDataSourceProperties): DocumentCountDataResult {
-        val byCaseSpec = byDocumentDefinitionIdName(caseCountDataSourceProperties.documentDefinition)
+        val byCaseSpec = getAuthorizationSpecification()
+            .and(byDocumentDefinitionIdName(caseCountDataSourceProperties.documentDefinition))
         val spec = byCaseSpec.and { root, _, criteriaBuilder ->
             criteriaBuilder.and(
                 *caseCountDataSourceProperties.queryConditions?.map {
@@ -53,8 +59,10 @@ class DocumentWidgetDataSource(
 
     @WidgetDataSource("case-counts", "Case counts")
     fun getCaseCounts(caseCountsDataSourceProperties: DocumentCountsDataSourceProperties): DocumentCountsDataResult {
+        val authorizationSpec = getAuthorizationSpecification()
         val items: List<DocumentCountsItem> = caseCountsDataSourceProperties.queryItems.map { queryItem ->
-            val spec = byDocumentDefinitionIdName(caseCountsDataSourceProperties.documentDefinition)
+            val spec = authorizationSpec
+                .and(byDocumentDefinitionIdName(caseCountsDataSourceProperties.documentDefinition))
                 .and { root, _, criteriaBuilder ->
                     criteriaBuilder.and(
                         *queryItem.queryConditions.map {
@@ -96,8 +104,15 @@ class DocumentWidgetDataSource(
         val conditionPredicates = caseGroupByDataSourceProperties.queryConditions?.map {
             it.toPredicate(root, criteriaBuilder, this::getPathExpression)
         }?.toTypedArray() ?: arrayOf()
-        val combinedPredicates =
-            arrayOf(docPredicate, pathIsNotNullPredicate, pathIsNotNullStringPredicate, *conditionPredicates)
+        val authorizationPredicate = getAuthorizationSpecification()
+            .toPredicate(root, query as AbstractQuery<*>, criteriaBuilder)
+        val combinedPredicates = arrayOf(
+            authorizationPredicate,
+            docPredicate,
+            pathIsNotNullPredicate,
+            pathIsNotNullStringPredicate,
+            *conditionPredicates
+        )
         val groupByExpression =
             getPathExpression(String::class.java, caseGroupByDataSourceProperties.path, root, criteriaBuilder)
 
@@ -128,6 +143,14 @@ class DocumentWidgetDataSource(
 
         return DocumentGroupByDataResult(values = result)
     }
+
+    private fun getAuthorizationSpecification() = authorizationService.getAuthorizationSpecification(
+        EntityAuthorizationRequest(
+            JsonSchemaDocument::class.java,
+            VIEW_LIST
+        ),
+        null
+    )
 
     private fun <T> getPathExpression(
         valueClass: Class<T>,

--- a/backend/case/src/test/kotlin/com/ritense/document/dashboard/DocumentWidgetDataSourceIntTest.kt
+++ b/backend/case/src/test/kotlin/com/ritense/document/dashboard/DocumentWidgetDataSourceIntTest.kt
@@ -17,12 +17,19 @@
 package com.ritense.document.dashboard
 
 import com.ritense.BaseIntegrationTest
+import com.ritense.BaseTest
 import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthorization
+import com.ritense.authorization.permission.ConditionContainer
+import com.ritense.authorization.permission.Permission
+import com.ritense.authorization.permission.condition.ExpressionPermissionCondition
+import com.ritense.authorization.permission.condition.PermissionConditionOperator
+import com.ritense.authorization.role.Role
 import com.ritense.document.domain.impl.JsonDocumentContent
+import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.domain.impl.JsonSchemaDocumentDefinition
 import com.ritense.document.domain.impl.request.NewDocumentRequest
+import com.ritense.document.service.JsonSchemaDocumentActionProvider
 import com.ritense.document.service.result.CreateDocumentResult
-import com.ritense.valtimo.contract.Constants
 import com.ritense.valtimo.contract.authorization.UserManagementServiceHolder
 import com.ritense.valtimo.contract.conditions.Condition
 import com.ritense.valtimo.contract.repository.ExpressionOperator
@@ -32,9 +39,15 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Pageable
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+private const val SESAME_STREET_ROLE = "sesame street role"
+private const val SESAME_STREET = "Sesame Street"
 
 @Transactional
+@WithMockUser(username = BaseTest.USERNAME, authorities = [BaseIntegrationTest.FULL_ACCESS_ROLE])
 class DocumentWidgetDataSourceIntTest @Autowired constructor(
     private val documentWidgetDataSource: DocumentWidgetDataSource
 ) : BaseIntegrationTest() {
@@ -95,7 +108,7 @@ class DocumentWidgetDataSourceIntTest @Autowired constructor(
                 Condition(
                     "case:createdBy",
                     ExpressionOperator.EQUAL_TO,
-                    Constants.SYSTEM_ACCOUNT
+                    USERNAME
                 ),
                 Condition(
                     "doc:street",
@@ -499,6 +512,117 @@ class DocumentWidgetDataSourceIntTest @Autowired constructor(
         val result = documentWidgetDataSource.getCaseCount(properties)
 
         assertThat(result.value).isEqualTo(1)
+    }
+
+    @Test
+    @WithMockUser(username = BaseTest.USERNAME, authorities = [SESAME_STREET_ROLE])
+    fun `should only count cases the user is allowed to view`() {
+        documentRepository.deleteAll()
+        val definition = definition()
+        createSesameStreetPermission()
+
+        repeat(2) {
+            createDocument(definition, SESAME_STREET)
+        }
+        repeat(3) {
+            createDocument(definition, "Main Street")
+        }
+
+        val properties = DocumentCountDataSourceProperties(definition.id().name())
+
+        val result = documentWidgetDataSource.getCaseCount(properties)
+
+        assertThat(result.value).isEqualTo(2)
+        assertThat(result.total).isEqualTo(2)
+    }
+
+    @Test
+    @WithMockUser(username = BaseTest.USERNAME, authorities = [SESAME_STREET_ROLE])
+    fun `should only resolve multiple case counts for cases the user is allowed to view`() {
+        documentRepository.deleteAll()
+        val definition = definition()
+        createSesameStreetPermission()
+
+        repeat(2) {
+            createDocument(definition, SESAME_STREET)
+        }
+        val street2 = "Main Street"
+        repeat(3) {
+            createDocument(definition, street2)
+        }
+
+        val properties = DocumentCountsDataSourceProperties(
+            definition.id().name(),
+            queryItems = listOf(
+                DocumentCountsQueryItem(
+                    SESAME_STREET,
+                    listOf(Condition("doc:street", ExpressionOperator.EQUAL_TO, SESAME_STREET))
+                ),
+                DocumentCountsQueryItem(
+                    street2,
+                    listOf(Condition("doc:street", ExpressionOperator.EQUAL_TO, street2))
+                )
+            )
+        )
+
+        val result = documentWidgetDataSource.getCaseCounts(properties)
+
+        assertThat(result.values).hasSize(2)
+        assertThat(result.values[0].value).isEqualTo(2)
+        assertThat(result.values[1].value).isEqualTo(0)
+    }
+
+    @Test
+    @WithMockUser(username = BaseTest.USERNAME, authorities = [SESAME_STREET_ROLE])
+    fun `should only group by cases the user is allowed to view`() {
+        documentRepository.deleteAll()
+        val definition = definition()
+        createSesameStreetPermission()
+
+        repeat(2) {
+            createDocument(definition, SESAME_STREET)
+        }
+        repeat(3) {
+            createDocument(definition, "Main Street")
+        }
+
+        val properties = DocumentGroupByDataSourceProperties(
+            definition.id().name(),
+            path = "doc:street",
+            queryConditions = null,
+            enum = null
+        )
+
+        val result = documentWidgetDataSource.getCaseGroupBy(properties)
+
+        assertThat(result.values).hasSize(1)
+        assertThat(result.values[0].label).isEqualTo(SESAME_STREET)
+        assertThat(result.values[0].value).isEqualTo(2)
+    }
+
+    private fun createSesameStreetPermission() {
+        val role = roleRepository.findByKey(SESAME_STREET_ROLE)
+            ?: roleRepository.save(Role(UUID.randomUUID(), SESAME_STREET_ROLE))
+
+        permissionRepository.save(
+            Permission(
+                UUID.randomUUID(),
+                JsonSchemaDocument::class.java,
+                mutableListOf(JsonSchemaDocumentActionProvider.VIEW_LIST),
+                ConditionContainer(
+                    listOf(
+                        ExpressionPermissionCondition(
+                            "content.content",
+                            "$.street",
+                            PermissionConditionOperator.EQUAL_TO,
+                            SESAME_STREET,
+                            String::class.java
+                        )
+                    )
+                ),
+                role
+            )
+        )
     }
 
     private fun createDocument(

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -12,9 +12,10 @@
 
 ## Enhancements
 
-* **New enhancement title**
+* **Dashboard case widgets only count cases you are allowed to see**
 
-  New enhancement explanation.
+  Widgets that show case counts used to include every case in the system. They now count only the cases you may
+  view, so the numbers match what you see in the case list.
 
 ## Bugfixes
 


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/718

## Bug

Dashboard widgets showing case counts included every case in the system, so a user saw
numbers far higher than the cases they are actually allowed to open.

## Fix

Case count widgets now only count cases the user may view, matching the case list. Task
count widgets already worked this way.

Assumption: the ticket was reclassified as a feature request, so this is written up as an
enhancement rather than a bugfix in the release notes.
