### PR TITLE
Take default Spring profiles into account for the draft environment check

### DIFF
--- a/backend/building-block/src/main/kotlin/com/ritense/buildingblock/service/BuildingBlockDefinitionCheckerImpl.kt
+++ b/backend/building-block/src/main/kotlin/com/ritense/buildingblock/service/BuildingBlockDefinitionCheckerImpl.kt
@@ -89,8 +89,10 @@ class BuildingBlockDefinitionCheckerImpl(
     }
 
     private fun isDraftEnvironment(): Boolean {
-        return draftsEnabled || draftEnvironments.split(',').any { draftEnvironment ->
-            environment.activeProfiles.any { it == draftEnvironment }
+        if (draftsEnabled) {
+            return true
         }
+        val draftProfiles = draftEnvironments.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        return draftProfiles.isNotEmpty() && environment.matchesProfiles(*draftProfiles.toTypedArray())
     }
 }

--- a/backend/building-block/src/test/kotlin/com/ritense/buildingblock/service/BuildingBlockDefinitionCheckerImplTest.kt
+++ b/backend/building-block/src/test/kotlin/com/ritense/buildingblock/service/BuildingBlockDefinitionCheckerImplTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.buildingblock.service
+
+import com.ritense.buildingblock.repository.BuildingBlockDefinitionRepository
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.core.env.Environment
+import org.springframework.core.env.StandardEnvironment
+
+@ExtendWith(MockitoExtension::class)
+class BuildingBlockDefinitionCheckerImplTest {
+
+    @Mock
+    private lateinit var repository: BuildingBlockDefinitionRepository
+
+    @Test
+    fun `canUpdateGlobalConfiguration should match a draft profile that is only set as default profile`() {
+        val checker = checkerWith(StandardEnvironment().apply { setDefaultProfiles("dev") })
+
+        assertTrue(checker.canUpdateGlobalConfiguration())
+    }
+
+    @Test
+    fun `canUpdateGlobalConfiguration should not match a default profile that is no draft profile`() {
+        val checker = checkerWith(StandardEnvironment().apply { setDefaultProfiles("prod") })
+
+        assertFalse(checker.canUpdateGlobalConfiguration())
+    }
+
+    @Test
+    fun `canUpdateGlobalConfiguration should ignore default profiles when an active profile is set`() {
+        val checker = checkerWith(
+            StandardEnvironment().apply {
+                setDefaultProfiles("dev")
+                setActiveProfiles("prod")
+            }
+        )
+
+        assertFalse(checker.canUpdateGlobalConfiguration())
+    }
+
+    @Test
+    fun `canUpdateGlobalConfiguration should match an active draft profile`() {
+        val checker = checkerWith(StandardEnvironment().apply { setActiveProfiles("test") })
+
+        assertTrue(checker.canUpdateGlobalConfiguration())
+    }
+
+    private fun checkerWith(environment: Environment) = BuildingBlockDefinitionCheckerImpl(
+        repository,
+        environment,
+        "dev,test",
+        false,
+    )
+}

--- a/backend/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionCheckerImpl.kt
+++ b/backend/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionCheckerImpl.kt
@@ -115,8 +115,10 @@ class CaseDefinitionCheckerImpl(
     }
 
     private fun isDraftEnvironment(): Boolean {
-        return draftsEnabled || draftEnvironments.split(',').any { draftEnvironment ->
-            environment.activeProfiles.any { it == draftEnvironment }
+        if (draftsEnabled) {
+            return true
         }
+        val draftProfiles = draftEnvironments.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        return draftProfiles.isNotEmpty() && environment.matchesProfiles(*draftProfiles.toTypedArray())
     }
 }

--- a/backend/case/src/test/kotlin/com/ritense/case/service/CaseDefinitionCheckerImplTest.kt
+++ b/backend/case/src/test/kotlin/com/ritense/case/service/CaseDefinitionCheckerImplTest.kt
@@ -21,6 +21,8 @@ import com.ritense.case.repository.CaseDefinitionConfigurationIssueRepository
 import com.ritense.case_.domain.definition.CaseDefinition
 import com.ritense.case_.repository.CaseDefinitionRepository
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.core.env.Environment
+import org.springframework.core.env.StandardEnvironment
 import java.time.LocalDateTime
 import java.util.Optional
 
@@ -46,7 +49,7 @@ class CaseDefinitionCheckerImplTest {
         environment = mock()
         configurationIssueRepository = mock()
 
-        whenever(environment.activeProfiles).thenReturn(arrayOf("dev"))
+        whenever(environment.matchesProfiles("dev", "test")).thenReturn(true)
 
         checker = CaseDefinitionCheckerImpl(
             caseDefinitionRepository,
@@ -102,6 +105,47 @@ class CaseDefinitionCheckerImplTest {
             checker.assertCanUpdateCaseDefinitionConfiguration(caseDefinitionId, "zaak-type-link")
         }
     }
+
+    @Test
+    fun `canUpdateGlobalConfiguration should match a draft profile that is only set as default profile`() {
+        val checker = checkerWith(StandardEnvironment().apply { setDefaultProfiles("dev") })
+
+        assertTrue(checker.canUpdateGlobalConfiguration())
+    }
+
+    @Test
+    fun `canUpdateGlobalConfiguration should not match a default profile that is no draft profile`() {
+        val checker = checkerWith(StandardEnvironment().apply { setDefaultProfiles("prod") })
+
+        assertFalse(checker.canUpdateGlobalConfiguration())
+    }
+
+    @Test
+    fun `canUpdateGlobalConfiguration should ignore default profiles when an active profile is set`() {
+        val checker = checkerWith(
+            StandardEnvironment().apply {
+                setDefaultProfiles("dev")
+                setActiveProfiles("prod")
+            }
+        )
+
+        assertFalse(checker.canUpdateGlobalConfiguration())
+    }
+
+    @Test
+    fun `canUpdateGlobalConfiguration should match an active draft profile`() {
+        val checker = checkerWith(StandardEnvironment().apply { setActiveProfiles("test") })
+
+        assertTrue(checker.canUpdateGlobalConfiguration())
+    }
+
+    private fun checkerWith(environment: Environment) = CaseDefinitionCheckerImpl(
+        caseDefinitionRepository,
+        environment,
+        "dev,test",
+        false,
+        configurationIssueRepository,
+    )
 
     private fun caseDefinition(final: Boolean): CaseDefinition {
         return CaseDefinition(

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -82,14 +82,6 @@
   until the page was reloaded. The decision table screen now always cleans up its breadcrumbs and title,
   even when the DMN editor fails to shut down.
 
-* **A draft environment is now also recognised through the default Spring profile**
-
-  Whether an environment allows drafts was determined by looking only at the active Spring profiles. An
-  environment that configured its draft profile through `spring.profiles.default`, without setting an active
-  profile, was therefore not seen as a draft environment: creating or changing case definitions and building
-  blocks was refused with the message that the environment does not support drafts. The default profiles are
-  now taken into account, exactly as Spring itself does when no active profile is set.
-
 ## Security
 
 * **Permission checks only accept known resource types**

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -82,6 +82,14 @@
   until the page was reloaded. The decision table screen now always cleans up its breadcrumbs and title,
   even when the DMN editor fails to shut down.
 
+* **A draft environment is now also recognised through the default Spring profile**
+
+  Whether an environment allows drafts was determined by looking only at the active Spring profiles. An
+  environment that configured its draft profile through `spring.profiles.default`, without setting an active
+  profile, was therefore not seen as a draft environment: creating or changing case definitions and building
+  blocks was refused with the message that the environment does not support drafts. The default profiles are
+  now taken into account, exactly as Spring itself does when no active profile is set.
+
 ## Security
 
 * **Permission checks only accept known resource types**

--- a/documentation/release-notes/13.x.x/13.43.0/README.md
+++ b/documentation/release-notes/13.x.x/13.43.0/README.md
@@ -25,3 +25,11 @@
 ## Bugfixes
 
 * New bugfix.
+
+* **A draft environment is now also recognised through the default Spring profile**
+
+  Whether an environment allows drafts was determined by looking only at the active Spring profiles. An
+  environment that configured its draft profile through `spring.profiles.default`, without setting an active
+  profile, was therefore not seen as a draft environment: creating or changing case definitions and building
+  blocks was refused with the message that the environment does not support drafts. The default profiles are
+  now taken into account, exactly as Spring itself does when no active profile is set.


### PR DESCRIPTION
The draft environment check in CaseDefinitionCheckerImpl and BuildingBlockDefinitionCheckerImpl only looked at the active profiles, so a draft profile configured through spring.profiles.default was ignored when no active profile was set.

Both now use Environment.matchesProfiles, which falls back to the default profiles when no active profiles are set. Profile names are trimmed and an empty valtimo.draft.environments no longer reaches the profile expression parser.

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/868

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [x] Step 1: Start the backend without an active Spring profile but with a draft profile as default profile, for example `-Dspring.profiles.default=dev`, leaving `valtimo.draft.environments` at its default (`inttest,dev,test`) and `valtimo.draft.enabled` at `false`.
- [x] Step 2: Create a new (non-final) case definition and edit an existing draft. Both succeed, where previously they failed with "This Valtimo environment does not support drafts. Missing one of the following Spring profiles: [inttest,dev,test]".
- [x] Step 3: Repeat the same for a building block definition, which uses the second corrected check.
- [x] Step 4: Restart with an active profile that is not a draft profile (`-Dspring.profiles.active=prod -Dspring.profiles.default=dev`) and confirm that draft changes are still refused, since Spring ignores default profiles once an active profile is set.

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable