### PR TITLE
GHi-595: Searching on achternaam and geboortedatum gives no result

### DIFF
--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -26,11 +26,6 @@
   for example, could no longer be opened at all. A name that can no longer be found is now simply left out
   instead of causing an error, and tasks are no longer automatically assigned to a user that no longer exists.
 
-* **Searching on a date returns results again**
-
-  Picking a date in a search field, such as **Geboortedatum** under **Achternaam en geboortedatum** in a Beelden
-  search, passed the date on in a format the external source did not accept, so the search stayed empty.
-
 * **A form flow can now be used as the start form of a building block**
 
   Starting a building block from the actions of a case now opens its form flow start form, and submitting that

--- a/documentation/release-notes/13.x.x/13.42.0/README.md
+++ b/documentation/release-notes/13.x.x/13.42.0/README.md
@@ -26,6 +26,11 @@
   for example, could no longer be opened at all. A name that can no longer be found is now simply left out
   instead of causing an error, and tasks are no longer automatically assigned to a user that no longer exists.
 
+* **Searching on a date returns results again**
+
+  Picking a date in a search field, such as **Geboortedatum** under **Achternaam en geboortedatum** in a Beelden
+  search, passed the date on in a format the external source did not accept, so the search stayed empty.
+
 * **A form flow can now be used as the start form of a building block**
 
   Starting a building block from the actions of a case now opens its form flow start form, and submitting that

--- a/documentation/release-notes/13.x.x/13.43.0/README.md
+++ b/documentation/release-notes/13.x.x/13.43.0/README.md
@@ -18,4 +18,7 @@
 
 ## Bugfixes
 
-* New bugfix.
+* **Searching on a date returns results again**
+
+  Picking a date in a search field, such as **Geboortedatum** under **Achternaam en geboortedatum** in a Beelden
+  search, passed the date on in a format the external source did not accept, so the search stayed empty.

--- a/frontend/projects/valtimo/components/src/lib/components/date-time-picker/date-time-picker.component.html
+++ b/frontend/projects/valtimo/components/src/lib/components/date-time-picker/date-time-picker.component.html
@@ -34,7 +34,7 @@
     [placeholder]="datePlaceholder || 'dd-mm-yyyy'"
     [dateFormat]="dateFormat"
     [disabled]="disabled"
-    [ngModel]="dateValue$ | async"
+    [ngModel]="pickerDates$ | async"
     (ngModelChange)="onDateSelected($event)"
   ></cds-date-picker>
 

--- a/frontend/projects/valtimo/components/src/lib/components/date-time-picker/date-time-picker.component.spec.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/date-time-picker/date-time-picker.component.spec.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TranslateService} from '@ngx-translate/core';
+import {MockTranslateService} from '@valtimo/shared';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {Subject, take} from 'rxjs';
+import {DateTimePickerComponent} from './date-time-picker.component';
+
+describe('DateTimePickerComponent', () => {
+  let component: DateTimePickerComponent;
+  let fixture: ComponentFixture<DateTimePickerComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [DateTimePickerComponent],
+      providers: [{provide: TranslateService, useClass: MockTranslateService}],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DateTimePickerComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    component.ngOnDestroy();
+  });
+
+  const emittedValues = (): Array<string> => {
+    const values: Array<string> = [];
+    component.valueChange.subscribe(value => values.push(value));
+    return values;
+  };
+
+  describe('emitted value with the default valueFormat', () => {
+    beforeEach(() => {
+      component.ngAfterViewInit();
+    });
+
+    it('should emit a selected date in the localised format', () => {
+      const values = emittedValues();
+
+      component.onDateSelected([new Date(2012, 2, 12)]);
+
+      expect(values.pop()).toBe('12-3-2012');
+    });
+
+    it('should emit a selected date and time in the localised format', () => {
+      component.enableTime = true;
+      const values = emittedValues();
+
+      component.onDateSelected([new Date(2012, 2, 12)]);
+      component.onTimeSelected('09:30');
+
+      expect(values.pop()).toBe('12-3-2012 09:30');
+    });
+
+    it('should emit an iso default date in the localised format', () => {
+      const values = emittedValues();
+
+      component.defaultDate = '2012-03-12';
+
+      expect(values.pop()).toBe('12-3-2012');
+    });
+
+    it('should emit a day-first default date unchanged', () => {
+      const values = emittedValues();
+
+      component.defaultDate = '12-03-2012';
+
+      expect(values.pop()).toBe('12-3-2012');
+    });
+  });
+
+  describe('emitted value with valueFormat iso', () => {
+    beforeEach(() => {
+      component.valueFormat = 'iso';
+      component.ngAfterViewInit();
+    });
+
+    it('should emit a selected date as yyyy-mm-dd', () => {
+      const values = emittedValues();
+
+      component.onDateSelected([new Date(2012, 2, 12)]);
+
+      expect(values.pop()).toBe('2012-03-12');
+    });
+
+    it('should emit a selected date and time separated by a space', () => {
+      component.enableTime = true;
+      const values = emittedValues();
+
+      component.onDateSelected([new Date(2012, 2, 12)]);
+      component.onTimeSelected('09:30');
+
+      expect(values.pop()).toBe('2012-03-12 09:30');
+    });
+
+    it('should emit an empty value when no date is selected', () => {
+      const values = emittedValues();
+
+      component.onDateSelected([]);
+
+      expect(values.pop()).toBe('');
+    });
+
+    it('should emit a day-first default date as yyyy-mm-dd', () => {
+      const values = emittedValues();
+
+      component.defaultDate = '12-03-2012';
+
+      expect(values.pop()).toBe('2012-03-12');
+    });
+
+    it('should keep an iso default date unchanged', () => {
+      const values = emittedValues();
+
+      component.defaultDate = '2012-03-12';
+
+      expect(values.pop()).toBe('2012-03-12');
+    });
+
+    it('should split a default date and time', () => {
+      component.enableTime = true;
+      const values = emittedValues();
+
+      component.defaultDate = '2012-03-12 09:30';
+
+      expect(values.pop()).toBe('2012-03-12 09:30');
+    });
+
+    it('should pass the date to the date picker as a date object', () => {
+      let pickerDates: Array<Date> = [];
+
+      component.defaultDate = '2012-03-12';
+      component.pickerDates$.pipe(take(1)).subscribe(dates => (pickerDates = dates));
+
+      expect(pickerDates.length).toBe(1);
+      expect(pickerDates[0].getFullYear()).toBe(2012);
+      expect(pickerDates[0].getMonth()).toBe(2);
+      expect(pickerDates[0].getDate()).toBe(12);
+    });
+  });
+
+  describe('rendered input', () => {
+    const settle = (): Promise<void> =>
+      new Promise(resolve =>
+        setTimeout(() => {
+          fixture.detectChanges();
+          resolve();
+        }, 100)
+      );
+
+    const renderedDate = (): string =>
+      (fixture.nativeElement.querySelector('cds-date-picker input') as HTMLInputElement).value;
+
+    it('should render an iso date in the default display format', async () => {
+      component.defaultDate = '2012-03-12';
+      fixture.detectChanges();
+      await settle();
+
+      expect(renderedDate()).toBe('12-03-2012');
+    });
+
+    it('should render a day-first date in the default display format', async () => {
+      component.defaultDate = '12-03-2012';
+      fixture.detectChanges();
+      await settle();
+
+      expect(renderedDate()).toBe('12-03-2012');
+    });
+
+    it('should render a date in the display format of an overridden dateFormat', async () => {
+      component.dateFormat = 'Y-m-d';
+      component.defaultDate = '2012-03-12';
+      fixture.detectChanges();
+      await settle();
+
+      expect(renderedDate()).toBe('2012-03-12');
+    });
+
+    it('should empty the input when the picker is cleared', async () => {
+      const clear$ = new Subject<null>();
+      component.clear$ = clear$;
+      component.defaultDate = '2012-03-12';
+      fixture.detectChanges();
+      await settle();
+      expect(renderedDate()).toBe('12-03-2012');
+
+      clear$.next(null);
+      fixture.detectChanges();
+      await settle();
+
+      expect(renderedDate()).toBe('');
+    });
+
+    it('should render an iso date and time in the default display format', async () => {
+      component.enableTime = true;
+      component.defaultDate = '2012-03-12 09:30';
+      fixture.detectChanges();
+      await settle();
+
+      expect(renderedDate()).toBe('12-03-2012');
+      expect(
+        (fixture.nativeElement.querySelector('cds-timepicker input') as HTMLInputElement).value
+      ).toBe('09:30');
+    });
+  });
+});

--- a/frontend/projects/valtimo/components/src/lib/components/date-time-picker/date-time-picker.component.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/date-time-picker/date-time-picker.component.ts
@@ -32,7 +32,7 @@ import {
   LayerModule,
   TimePickerModule,
 } from 'carbon-components-angular';
-import {BehaviorSubject, combineLatest, Observable, Subscription} from 'rxjs';
+import {BehaviorSubject, combineLatest, map, Observable, Subscription} from 'rxjs';
 import {InputLabelModule} from '../input-label/input-label.module';
 
 @Component({
@@ -79,6 +79,12 @@ export class DateTimePickerComponent implements AfterViewInit, OnDestroy {
   @Input() timePlaceholder = 'hh:mm';
   @Input() labelText = '';
 
+  /**
+   * Format of the emitted value. Use `iso` when the value is passed on to an API. Defaults to the
+   * localised format the input shows, which is what existing consumers expect.
+   */
+  @Input() valueFormat: 'display' | 'iso' = 'display';
+
   @Input() set defaultDate(value: string | null) {
     const dateTimeValue = value ?? '';
     const {date, time} = this.splitDateTime(dateTimeValue);
@@ -91,8 +97,17 @@ export class DateTimePickerComponent implements AfterViewInit, OnDestroy {
 
   @Output() valueChange = new EventEmitter<string>();
 
+  /** Holds the date as `yyyy-mm-dd`, independent of how `dateFormat` renders it. */
   public readonly dateValue$ = new BehaviorSubject<string>('');
   public readonly timeValue$ = new BehaviorSubject<string>('');
+
+  /** The Carbon date picker parses strings with `dateFormat`, so it is fed a date object instead. */
+  public readonly pickerDates$: Observable<Array<Date>> = this.dateValue$.pipe(
+    map(date => (date ? [new Date(`${date}T00:00:00`)] : []))
+  );
+
+  private readonly ISO_DATE_PATTERN = /^(\d{4})-(\d{1,2})-(\d{1,2})$/;
+  private readonly DAY_FIRST_DATE_PATTERN = /^(\d{1,2})[-/](\d{1,2})[-/](\d{4})$/;
 
   private readonly subscriptions = new Subscription();
 
@@ -117,7 +132,8 @@ export class DateTimePickerComponent implements AfterViewInit, OnDestroy {
           this.valueChange.emit('');
           return;
         }
-        const fullValue = this.enableTime && time ? `${date} ${time}` : date;
+        const emittedDate = this.valueFormat === 'iso' ? date : this.formatDisplayDate(date);
+        const fullValue = this.enableTime && time ? `${emittedDate} ${time}` : emittedDate;
         this.valueChange.emit(fullValue);
       })
     );
@@ -149,20 +165,43 @@ export class DateTimePickerComponent implements AfterViewInit, OnDestroy {
     const trimmed = (value ?? '').trim();
     if (!trimmed) return {date: '', time: ''};
 
-    const parts = trimmed.split(' ');
+    const parts = trimmed.split(/[ T]/);
     if (parts.length >= 2) {
-      return {date: parts[0] ?? '', time: parts.slice(1).join(' ') ?? ''};
+      return {date: this.normalizeDate(parts[0]), time: parts.slice(1).join(' ') ?? ''};
     }
-    return {date: trimmed, time: ''};
+    return {date: this.normalizeDate(trimmed), time: ''};
   }
 
   private normalizeDate(date: unknown): string {
-    if (typeof date === 'string') return date;
     if (date instanceof Date) return this.formatDate(date);
+    if (typeof date !== 'string') return '';
+
+    const trimmed = date.trim();
+    const isoMatch = this.ISO_DATE_PATTERN.exec(trimmed);
+    if (isoMatch) {
+      const [, year, month, day] = isoMatch;
+      return this.joinDate(year, month, day);
+    }
+
+    const dayFirstMatch = this.DAY_FIRST_DATE_PATTERN.exec(trimmed);
+    if (dayFirstMatch) {
+      const [, day, month, year] = dayFirstMatch;
+      return this.joinDate(year, month, day);
+    }
+
     return '';
   }
 
   private formatDate(date: Date): string {
-    return date.toLocaleDateString('nl-NL');
+    return this.joinDate(`${date.getFullYear()}`, `${date.getMonth() + 1}`, `${date.getDate()}`);
+  }
+
+  private formatDisplayDate(isoDate: string): string {
+    const [year, month, day] = isoDate.split('-').map(Number);
+    return new Date(year, month - 1, day).toLocaleDateString('nl-NL');
+  }
+
+  private joinDate(year: string, month: string, day: string): string {
+    return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
   }
 }

--- a/frontend/projects/valtimo/iko/src/lib/components/iko-search/iko-search.component.html
+++ b/frontend/projects/valtimo/iko/src/lib/components/iko-search/iko-search.component.html
@@ -163,6 +163,7 @@
                       [defaultDate]="formValues[field.key] ?? ''"
                       [enableTime]="false"
                       [showFieldLabel]="false"
+                      valueFormat="iso"
                       (valueChange)="singleValueChange(field.key, $event, field.dataType)"
                     ></valtimo-date-time-picker>
                   } @else if (field.dataType === 'date' && field.fieldType === 'range') {
@@ -174,6 +175,7 @@
                         name="start"
                         [enableTime]="false"
                         [showFieldLabel]="false"
+                        valueFormat="iso"
                       ></valtimo-date-time-picker>
 
                       <div class="to-text">
@@ -184,12 +186,14 @@
                         name="end"
                         [enableTime]="false"
                         [showFieldLabel]="false"
+                        valueFormat="iso"
                       ></valtimo-date-time-picker>
                     </v-form>
                   } @else if (field.dataType === 'datetime' && field.fieldType === 'single') {
                     <valtimo-date-time-picker
                       [enableTime]="true"
                       [showFieldLabel]="false"
+                      valueFormat="iso"
                       (valueChange)="singleValueChange(field.key, $event, field.dataType)"
                     ></valtimo-date-time-picker>
                   } @else if (field.dataType === 'datetime' && field.fieldType === 'range') {
@@ -201,6 +205,7 @@
                         name="start"
                         [enableTime]="true"
                         [showFieldLabel]="false"
+                        valueFormat="iso"
                       ></valtimo-date-time-picker>
 
                       <div class="to-text">
@@ -211,6 +216,7 @@
                         name="end"
                         [enableTime]="true"
                         [showFieldLabel]="false"
+                        valueFormat="iso"
                       ></valtimo-date-time-picker>
                     </v-form>
                   }

--- a/frontend/projects/valtimo/layout/src/lib/components/widget-interactive-table/widget-interactive-table-search/widget-interactive-table-search.component.html
+++ b/frontend/projects/valtimo/layout/src/lib/components/widget-interactive-table/widget-interactive-table-search/widget-interactive-table-search.component.html
@@ -141,6 +141,7 @@
             [clear$]="clear$"
             [enableTime]="false"
             [showFieldLabel]="false"
+            valueFormat="iso"
             (valueChange)="singleValueChange(filter.key, $event)"
           ></valtimo-date-time-picker>
         }
@@ -151,6 +152,7 @@
               [clear$]="clear$"
               [enableTime]="false"
               [showFieldLabel]="false"
+              valueFormat="iso"
               (valueChange)="singleValueChange(filter.key + '_start', $event)"
             ></valtimo-date-time-picker>
 
@@ -163,6 +165,7 @@
               [clear$]="clear$"
               [enableTime]="false"
               [showFieldLabel]="false"
+              valueFormat="iso"
               (valueChange)="singleValueChange(filter.key + '_end', $event)"
             ></valtimo-date-time-picker>
           </div>
@@ -173,6 +176,7 @@
             [clear$]="clear$"
             [enableTime]="true"
             [showFieldLabel]="false"
+            valueFormat="iso"
             (valueChange)="singleValueChange(filter.key, $event)"
           ></valtimo-date-time-picker>
         }
@@ -183,6 +187,7 @@
               [clear$]="clear$"
               [enableTime]="true"
               [showFieldLabel]="false"
+              valueFormat="iso"
               (valueChange)="singleValueChange(filter.key + '_start', $event)"
             ></valtimo-date-time-picker>
 
@@ -195,6 +200,7 @@
               [clear$]="clear$"
               [enableTime]="true"
               [showFieldLabel]="false"
+              valueFormat="iso"
               (valueChange)="singleValueChange(filter.key + '_end', $event)"
             ></valtimo-date-time-picker>
           </div>


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/595

## Bug

Searching a person on last name and date of birth in an IKO view stayed empty. The date
was handed to the external source in a format it rejects, so no result ever came back.

## Fix

A date picked in a search field is now passed on as a date the source accepts, and the
search returns the matching person. The field itself still shows the date as dd-mm-yyyy.

Assumptions: the shared date field keeps its current output for existing users and the two
search screens ask for the new format, so nothing else changes; the same field is used by
the interactive table widget search, so that search is fixed along with it.
