### PR TITLE
871 Created formIO component for email previews

### DIFF
--- a/frontend/apps/dev/src/app/app.module.ts
+++ b/frontend/apps/dev/src/app/app.module.ts
@@ -58,6 +58,7 @@ import {
   registerFormioCurrentUserComponent,
   registerFormioFileSelectorComponent,
   registerFormioIbanComponent,
+  registerFormioMailPreviewComponent,
   registerFormioUploadComponent,
   registerFormioValueResolverSelectorComponent,
   registerObjectManagementSelectFormioComponent,
@@ -273,5 +274,6 @@ export class AppModule {
     registerDocumentenApiFormioUploadComponent(injector);
     registerIkoSearchFormioComponent(injector);
     registerObjectManagementSelectFormioComponent(injector);
+    registerFormioMailPreviewComponent(injector);
   }
 }

--- a/frontend/apps/evenementenvergunning/src/app/app.module.ts
+++ b/frontend/apps/evenementenvergunning/src/app/app.module.ts
@@ -19,8 +19,9 @@ import {
   registerFormioCurrentUserComponent,
   registerFormioFileSelectorComponent,
   registerFormioIbanComponent,
+  registerFormioMailPreviewComponent,
   registerFormioUploadComponent,
-  registerFormioValueResolverSelectorComponent,
+  registerFormioValueResolverSelectorComponent
 } from '@valtimo/components';
 import {
   CaseDetailTabAuditComponent,
@@ -218,5 +219,6 @@ export class AppModule {
     registerFormioIbanComponent(injector);
     registerFormioValueResolverSelectorComponent(injector);
     registerIkoSearchFormioComponent(injector);
+    registerFormioMailPreviewComponent(injector);
   }
 }

--- a/frontend/apps/gzac/src/app/app.module.ts
+++ b/frontend/apps/gzac/src/app/app.module.ts
@@ -57,6 +57,7 @@ import {
   registerFormioCurrentUserComponent,
   registerFormioFileSelectorComponent,
   registerFormioIbanComponent,
+  registerFormioMailPreviewComponent,
   registerFormioUploadComponent,
   registerFormioValueResolverSelectorComponent,
   WidgetModule,
@@ -247,13 +248,14 @@ export function tabsFactory() {
 export class AppModule {
   constructor(injector: Injector) {
     enableCustomFormioComponents(injector);
-    registerFormioCurrencyComponent(injector);
     registerFormioCurrentUserComponent(injector);
     registerFormioFileSelectorComponent(injector);
     registerFormioUploadComponent(injector);
     registerFormioValueResolverSelectorComponent(injector);
     registerFormioIbanComponent(injector);
+    registerFormioCurrencyComponent(injector);
     registerDocumentenApiFormioUploadComponent(injector);
     registerIkoSearchFormioComponent(injector);
+    registerFormioMailPreviewComponent(injector);
   }
 }

--- a/frontend/apps/valtimo/src/app/app.module.ts
+++ b/frontend/apps/valtimo/src/app/app.module.ts
@@ -16,10 +16,11 @@ import {
   MenuModule,
   WidgetModule,
   enableCustomFormioComponents,
-  registerFormioCurrencyComponent,
+  registerFormioMailPreviewComponent,
   registerFormioCurrentUserComponent,
   registerFormioFileSelectorComponent,
   registerFormioIbanComponent,
+  registerFormioCurrencyComponent,
   registerFormioUploadComponent,
   registerFormioValueResolverSelectorComponent,
 } from '@valtimo/components';
@@ -184,5 +185,6 @@ export class AppModule {
     registerFormioIbanComponent(injector);
     registerFormioValueResolverSelectorComponent(injector);
     registerIkoSearchFormioComponent(injector);
+    registerFormioMailPreviewComponent(injector);
   }
 }

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview-edit-form.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview-edit-form.ts
@@ -22,14 +22,8 @@ export const mailPreviewEditForm = () => ({
         },
         {
             key: 'label',
-            type: 'textfield',
-            input: true,
-            label: 'Label',
-            placeholder: 'Label',
+            type: 'hidden',
             defaultValue: 'E-mail preview',
-            validate: {
-                required: true,
-            },
         },
         {
             key: 'customOptions.variableKey',

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview-edit-form.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview-edit-form.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const mailPreviewEditForm = () => ({
+    components: [
+        {
+            key: 'type',
+            type: 'hidden',
+        },
+        {
+            key: 'label',
+            type: 'textfield',
+            input: true,
+            label: 'Label',
+            placeholder: 'Label',
+            defaultValue: 'E-mail preview',
+            validate: {
+                required: true,
+            },
+        },
+        {
+            key: 'customOptions.variableKey',
+            type: 'textfield',
+            input: true,
+            label: 'Variabele sleutel',
+            placeholder: 'bijv. mailPreview.ontvangstbevestiging',
+            tooltip: 'Het data-pad van de variabele die de e-mailinhoud bevat.',
+            validate: {
+                required: true,
+            },
+        },
+        {
+            key: 'key',
+            type: 'hidden',
+            calculateValue: "value = (data.customOptions && data.customOptions.variableKey) ? data.customOptions.variableKey : value",
+        },
+        {
+            key: 'tableView',
+            type: 'checkbox',
+            label: 'Table View',
+            tooltip: 'If checked, this value will show up in the table view of the submissions list.',
+        },
+    ],
+});

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview.component.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview.component.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { FormioCustomComponent } from '../../../../modules';
+
+@Component({
+    selector: 'valtimo-mail-preview',
+    template: `
+    <div style="text-align:center">
+      <p style="font-size:24px;color:darkgrey">E-MAILVOORBEELD</p>
+      <p class="mail-preview-key">{{ variableKey }}</p>
+    </div>
+    <div style="border:1px solid darkgrey;padding:10px" [innerHTML]="safeValue"></div>
+  `,
+    styles: [`
+    .mail-preview-key { display: none; font-size: 12px; color: #b0b0b0; }
+    :host-context(.builder-component) .mail-preview-key { display: block; }
+  `],
+    standalone: false,
+})
+export class FormIoMailPreviewComponent implements FormioCustomComponent<string> {
+    @Input() public disabled = false;
+    @Input() public variableKey = '';
+    @Output() public readonly valueChange = new EventEmitter<string>();
+
+    public safeValue: SafeHtml = '';
+
+    private _value = '';
+
+    @Input() public set value(v: string) {
+        this._value = v;
+        this.safeValue = this.sanitizer.bypassSecurityTrustHtml(v ?? "Hier wordt het e-mailvoorbeeld getoond.");
+    }
+
+    public get value(): string {
+        return this._value;
+    }
+
+    constructor(private readonly sanitizer: DomSanitizer) { }
+}

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview.formio.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/components/form-io-mail-preview/mail-preview.formio.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injector} from '@angular/core';
+import {FormioCustomComponentInfo, registerCustomFormioComponent} from '../../../../modules';
+import {mailPreviewEditForm} from './mail-preview-edit-form';
+import {FormIoMailPreviewComponent} from './mail-preview.component';
+
+const COMPONENT_OPTIONS: FormioCustomComponentInfo = {
+  type: 'valtimo-mail-preview',
+  selector: 'valtimo-mail-preview',
+  title: 'E-mail preview',
+  group: 'advanced',
+  icon: 'envelope',
+  editForm: mailPreviewEditForm,
+  schema: {
+    label: 'E-mail preview',
+    key: '',
+    hideLabel: true,
+  },
+};
+
+export function registerFormioMailPreviewComponent(injector: Injector) {
+  registerCustomFormioComponent(COMPONENT_OPTIONS, FormIoMailPreviewComponent, injector);
+}

--- a/frontend/projects/valtimo/components/src/lib/components/form-io/form-io.module.ts
+++ b/frontend/projects/valtimo/components/src/lib/components/form-io/form-io.module.ts
@@ -37,6 +37,7 @@ import {LayerModule} from 'carbon-components-angular';
 import {FormIoCurrencyComponent} from './components/form-io-currency/currency.component';
 import {applyDataGridPatch} from './patches/patched-datagrid';
 import {registerFormioFlatpickr, setFormioFlatpickrLocale} from './formio-flatpickr';
+import { FormIoMailPreviewComponent } from './components/form-io-mail-preview/mail-preview.component';
 
 // Apply FormIO patches before any form renders
 applyDataGridPatch();
@@ -62,6 +63,7 @@ applyDataGridPatch();
     FormIoCurrentUserComponent,
     FormIoIbanComponent,
     FormIoCurrencyComponent,
+    FormIoMailPreviewComponent,
     FormioDummyComponent,
   ],
   exports: [
@@ -71,6 +73,7 @@ applyDataGridPatch();
     FormIoCurrentUserComponent,
     FormIoIbanComponent,
     FormIoCurrencyComponent,
+    FormIoMailPreviewComponent,
     FormioDummyComponent,
   ],
   providers: [

--- a/frontend/projects/valtimo/components/src/public_api.ts
+++ b/frontend/projects/valtimo/components/src/public_api.ts
@@ -120,6 +120,9 @@ export * from './lib/components/form-io/components/form-io-iban/iban.formio';
 export * from './lib/components/form-io/components/form-io-currency/currency.component';
 export * from './lib/components/form-io/components/form-io-currency/currency.formio';
 
+export * from './lib/components/form-io/components/form-io-mail-preview/mail-preview.component';
+export * from './lib/components/form-io/components/form-io-mail-preview/mail-preview.formio';
+
 export * from './lib/components/form-io/components/form-io-resource-selector/form-io-resource-selector.formio';
 
 export * from './lib/components/form-io/components/object-management-select/object-management-select.component';


### PR DESCRIPTION
### Describe the changes
Link to the related Github issue: http://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/871

From within the TBC guild we have the wish to have an formIO component to display email previews which have been generated. This component makes it easier to use this, instead of having to configure multiple formIO components.


### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
