### PR TITLE
feat: external plugin token authorities

### DIFF
--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginEndpointAllowlistFilter.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginEndpointAllowlistFilter.kt
@@ -33,16 +33,20 @@ import java.util.concurrent.ConcurrentHashMap
  * configuration. Applies to **both** token kinds:
  *
  * - [ExternalPluginServicePrincipal] — the host's system credential. Reach is *only* the allowlist
- *   (PBAC is bypassed for the service token).
+ *   (PBAC is bypassed for the service token). Its authentication carries fixed `ROLE_ADMIN` +
+ *   `ROLE_USER` authorities purely to pass the coarse per-URL `hasAuthority` rules that run *after*
+ *   this filter — because this filter decides first, those authorities never widen reach beyond
+ *   the granted set, but they do make the denylist below the sole guard for sensitive surfaces.
  * - [ExternalPluginUserPrincipal] — the downscoped user token used by the iframe parent-proxy. Reach
  *   is **PBAC ∩ allowlist**: PBAC is enforced upstream (the recognising filter does not run without
  *   authorization) and this filter narrows it further to the granted set.
  *
  * Other authenticated principals (interactive Keycloak users, etc.) are unaffected.
  *
- * On top of the grants, a hard denylist ([DENYLIST_PATTERNS]) shields sensitive surfaces — external-
- * plugin management (incl. host registration), user-token minting and role/permission management —
- * from plugin tokens **regardless of what was granted**. One narrow exception: a **user** token may
+ * On top of the grants, a hard denylist ([DENYLIST_PATTERNS] plus the method-specific
+ * [DENYLIST_METHOD_PATTERNS]) shields sensitive surfaces — external-plugin management (incl. host
+ * registration), user-token minting, role/permission management and user-account mutations — from
+ * plugin tokens **regardless of what was granted**. One narrow exception: a **user** token may
  * always `GET` the user-token introspection endpoint, which the plugin host needs to validate the
  * token before executing Wasm (see the carve-out in [doFilterInternal]).
  *
@@ -157,7 +161,17 @@ class ExternalPluginEndpointAllowlistFilter(
             "/api/management/v1/permissions/**",
         )
 
-        private val DENYLIST_MATCHERS = DENYLIST_PATTERNS.map { AntPathRequestMatcher(it) }
+        /**
+         * Method-specific denylist entries: user-account mutations. A plugin that can create or
+         * alter user accounts can escalate to a real admin login, so writes are blocked regardless
+         * of grants — reads (e.g. `GET /api/v1/users/{userId}` for assignee lookups) stay grantable.
+         */
+        val DENYLIST_METHOD_PATTERNS: List<Pair<String, String>> =
+            listOf("POST", "PUT", "PATCH", "DELETE").map { it to "/api/v1/users/**" }
+
+        private val DENYLIST_MATCHERS =
+            DENYLIST_PATTERNS.map { AntPathRequestMatcher(it) } +
+                DENYLIST_METHOD_PATTERNS.map { (method, pattern) -> AntPathRequestMatcher(pattern, method) }
 
         /** Exact-path, GET-only carve-out for user-token introspection (see [doFilterInternal]). */
         private val USER_TOKEN_INTROSPECT_MATCHER =

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginServicePrincipal.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginServicePrincipal.kt
@@ -20,8 +20,11 @@ import com.ritense.valtimo.contract.authentication.SystemPrincipal
 import java.util.UUID
 
 /**
- * Spring Security principal representing an external plugin service-token caller. Carries no roles —
- * endpoint access is enforced by [ExternalPluginEndpointAllowlistFilter]. Marked as a
+ * Spring Security principal representing an external plugin service-token caller. Endpoint access
+ * is enforced by [ExternalPluginEndpointAllowlistFilter]; the authentication carries the fixed
+ * `ROLE_ADMIN` + `ROLE_USER` authorities only so that *granted* endpoints behind the platform's
+ * coarse per-URL `hasAuthority` rules (the entire management API) are reachable — the allowlist
+ * filter runs before those rules and remains the gate that decides reach. Marked as a
  * [SystemPrincipal] so user-scoped operations it triggers (e.g. creating a note) attribute to the
  * system user rather than failing on a user lookup — the token has no Keycloak user.
  */

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenAuthenticator.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenAuthenticator.kt
@@ -21,10 +21,12 @@ import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Comp
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_VERSION_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.TOKEN_GENERATION_CLAIM
+import com.ritense.valtimo.contract.authentication.AuthoritiesConstants
 import com.ritense.valtimo.contract.security.jwt.TokenAuthenticator
 import io.jsonwebtoken.Claims
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import java.util.UUID
 
 class ExternalPluginServiceTokenAuthenticator(
@@ -50,7 +52,20 @@ class ExternalPluginServiceTokenAuthenticator(
             pluginId = pluginId,
             pluginVersion = pluginVersion,
         )
-        return UsernamePasswordAuthenticationToken(principal, jwt, emptyList())
+        // The ADMIN+USER authorities exist solely to pass the coarse per-URL `hasAuthority` rules
+        // (Spring Security's AuthorizationFilter, at the end of the chain) on endpoints the
+        // administrator explicitly granted. They do not widen reach: the allowlist filter runs
+        // earlier in the chain and 403s anything outside the granted set (and its hard denylist),
+        // so the effective surface stays grants minus denylist. Without them, every
+        // `hasAuthority`-gated endpoint — all of `/api/management/**` — would 403 even when granted.
+        return UsernamePasswordAuthenticationToken(
+            principal,
+            jwt,
+            listOf(
+                SimpleGrantedAuthority(AuthoritiesConstants.ADMIN),
+                SimpleGrantedAuthority(AuthoritiesConstants.USER),
+            ),
+        )
     }
 
     companion object {

--- a/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginServiceTokenService.kt
+++ b/backend/external-plugin/src/main/kotlin/com/ritense/externalplugin/service/ExternalPluginServiceTokenService.kt
@@ -30,7 +30,9 @@ import java.util.Date
  * Issues short-lived JWTs that authenticate the plugin host (or a URL plugin) when calling back
  * into GZAC on behalf of a specific external plugin configuration.
  *
- * The token carries no roles. Endpoint access is gated by [com.ritense.externalplugin.security.ExternalPluginEndpointAllowlistFilter].
+ * The token carries no roles claim; the authenticator attaches fixed `ROLE_ADMIN` + `ROLE_USER`
+ * authorities so granted endpoints behind coarse `hasAuthority` URL rules are reachable. Endpoint
+ * reach is gated by [com.ritense.externalplugin.security.ExternalPluginEndpointAllowlistFilter].
  *
  * The default TTL is deliberately a small multiple of the discovery polling rate (60s): the poll
  * re-pushes a fresh token to the host on every cycle, so a leaked token is only usable for minutes

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginEndpointAllowlistFilterTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginEndpointAllowlistFilterTest.kt
@@ -214,6 +214,38 @@ class ExternalPluginEndpointAllowlistFilterTest {
     }
 
     @Test
+    fun `denylist blocks user-account mutations even when a catch-all endpoint is granted`() {
+        val configId = UUID.randomUUID()
+        authenticateAsPlugin(configId)
+        whenever(grantedEndpointRepository.findAllByConfigurationId(configId))
+            .thenReturn(listOf(grantedEndpoint(configId, "POST", "/**")))
+        val request = request("POST", "/api/v1/users")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(response.status).isEqualTo(403)
+        assertThat(chain.request).isNull()
+    }
+
+    @Test
+    fun `user-account reads are not denylisted and follow the grants`() {
+        val configId = UUID.randomUUID()
+        authenticateAsPlugin(configId)
+        whenever(grantedEndpointRepository.findAllByConfigurationId(configId))
+            .thenReturn(listOf(grantedEndpoint(configId, "GET", "/api/v1/users/**")))
+        val request = request("GET", "/api/v1/users/123")
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertThat(response.status).isEqualTo(200)
+        assertThat(chain.request).isNotNull()
+    }
+
+    @Test
     fun `denylist blocks permission management endpoints for user principals too`() {
         val configId = UUID.randomUUID()
         authenticateAsUser(configId)

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenFilterTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/security/ExternalPluginServiceTokenFilterTest.kt
@@ -22,6 +22,7 @@ import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Comp
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_ID_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.PLUGIN_VERSION_CLAIM
 import com.ritense.externalplugin.service.ExternalPluginServiceTokenService.Companion.TOKEN_GENERATION_CLAIM
+import com.ritense.valtimo.contract.authentication.AuthoritiesConstants
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import jakarta.servlet.http.HttpServletRequest
@@ -125,6 +126,10 @@ class ExternalPluginServiceTokenFilterTest {
         assertThat(principal.pluginConfigId).isEqualTo(configId)
         assertThat(principal.pluginId).isEqualTo("case-summary")
         assertThat(principal.pluginVersion).isEqualTo("0.1.0")
+        // ADMIN+USER let a *granted* endpoint pass the coarse per-URL hasAuthority rules; reach
+        // stays bounded by the allowlist filter, which runs before those rules.
+        assertThat(authentication.authorities.map { it.authority })
+            .containsExactlyInAnyOrder(AuthoritiesConstants.ADMIN, AuthoritiesConstants.USER)
 
         assertThat(chain.request).isNotNull()
         assertThat((chain.request as HttpServletRequest).getHeader("Authorization")).isNull()

--- a/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginServiceTokenAccessIntTest.kt
+++ b/backend/external-plugin/src/test/kotlin/com/ritense/externalplugin/web/rest/ExternalPluginServiceTokenAccessIntTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.externalplugin.web.rest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ritense.externalplugin.BaseIntegrationTest
+import com.ritense.externalplugin.domain.EventQueueMode
+import com.ritense.externalplugin.domain.ExternalPluginConfiguration
+import com.ritense.externalplugin.domain.ExternalPluginDefinition
+import com.ritense.externalplugin.domain.ExternalPluginDefinitionStatus
+import com.ritense.externalplugin.domain.ExternalPluginGrantedEndpoint
+import com.ritense.externalplugin.domain.ExternalPluginHost
+import com.ritense.externalplugin.domain.ExternalPluginHostKind
+import com.ritense.externalplugin.domain.ExternalPluginHostStatus
+import com.ritense.externalplugin.repository.ExternalPluginConfigurationRepository
+import com.ritense.externalplugin.repository.ExternalPluginDefinitionRepository
+import com.ritense.externalplugin.repository.ExternalPluginGrantedEndpointRepository
+import com.ritense.externalplugin.repository.ExternalPluginHostRepository
+import com.ritense.externalplugin.service.ExternalPluginServiceTokenService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * Sends a *real* service token through the *full* security filter chain — the coverage the filter
+ * unit tests and the mock-user reachability tests ([ExternalPluginEndpointAccessIntTest]) cannot
+ * express, because the decisive interaction only exists in the assembled chain: the allowlist
+ * filter decides first, and Spring Security's `AuthorizationFilter` applies the coarse per-URL
+ * rules (`.authenticated()` / `hasAuthority(...)`) at the very end.
+ *
+ * The regression this guards: the service-token authentication used to carry no authorities, so
+ * every `hasAuthority`-gated endpoint — the entire management API — answered 403 even when the
+ * administrator had explicitly granted it, contradicting the module's "reach is the allowlist"
+ * design. The counterpart guarantees matter just as much: with ADMIN+USER authorities on the
+ * token, the denylist is the only thing between a grant and the sensitive surfaces, so this test
+ * also pins that the denylist holds in the full chain.
+ *
+ * Like [ExternalPluginEndpointAccessIntTest], reachability asserts "not 401/403" (a reachable
+ * handler may legitimately answer 200/400/404); denials assert exactly 403.
+ */
+@AutoConfigureMockMvc
+@Transactional
+class ExternalPluginServiceTokenAccessIntTest @Autowired constructor(
+    private val mockMvc: MockMvc,
+    private val hostRepository: ExternalPluginHostRepository,
+    private val definitionRepository: ExternalPluginDefinitionRepository,
+    private val configurationRepository: ExternalPluginConfigurationRepository,
+    private val grantedEndpointRepository: ExternalPluginGrantedEndpointRepository,
+    private val serviceTokenService: ExternalPluginServiceTokenService,
+    private val objectMapper: ObjectMapper,
+) : BaseIntegrationTest() {
+
+    private lateinit var definition: ExternalPluginDefinition
+    private lateinit var configuration: ExternalPluginConfiguration
+    private lateinit var token: String
+
+    @BeforeEach
+    fun seed() {
+        val host = hostRepository.saveAndFlush(
+            ExternalPluginHost(
+                id = UUID.randomUUID(),
+                name = "host-${UUID.randomUUID()}",
+                baseUrl = "https://plugin-host:8090",
+                secret = "encrypted-secret",
+                status = ExternalPluginHostStatus.CONNECTED,
+                kind = ExternalPluginHostKind.PLUGIN_HOST,
+                gzacCallbackBaseUrl = "http://gzac:8080",
+                eventBrokerAmqpUrl = "amqp://guest:guest@rabbit:5672",
+                eventBrokerExchange = "valtimo-events",
+                eventQueueMode = EventQueueMode.DURABLE,
+                eventQueueTtlMs = 259_200_000,
+            )
+        )
+        definition = definitionRepository.saveAndFlush(
+            ExternalPluginDefinition(
+                id = UUID.randomUUID(),
+                pluginId = "case-summary-${UUID.randomUUID()}",
+                version = "0.1.0",
+                name = "Case Summary",
+                description = "Shows a summary",
+                provider = "Ritense",
+                minGzacVersion = "12.0.0",
+                maxGzacVersion = "12.1.0",
+                manifestJson = objectMapper.createObjectNode().put("pluginId", "case-summary"),
+                hostId = host.id,
+                baseUrl = "${host.baseUrl}/plugins/case-summary",
+                status = ExternalPluginDefinitionStatus.AVAILABLE,
+                contentHash = "sha256:accepted",
+                pendingContentHash = null,
+            )
+        )
+        configuration = configurationRepository.saveAndFlush(
+            ExternalPluginConfiguration(
+                id = UUID.randomUUID(),
+                definitionId = definition.id,
+                title = "My configuration",
+                properties = objectMapper.createObjectNode(),
+                tokenGeneration = 0,
+            )
+        )
+        token = serviceTokenService.issue(configuration, definition)
+    }
+
+    private fun grant(method: String, pattern: String) {
+        grantedEndpointRepository.saveAndFlush(
+            ExternalPluginGrantedEndpoint(
+                id = UUID.randomUUID(),
+                configurationId = configuration.id,
+                httpMethod = method,
+                endpointPattern = pattern,
+            )
+        )
+    }
+
+    private fun perform(method: HttpMethod, path: String): Int =
+        mockMvc.perform(
+            MockMvcRequestBuilders.request(method, path)
+                .header("Authorization", "Bearer $token")
+                .contentType("application/json")
+                .content("{}")
+                .accept("*/*")
+        ).andReturn().response.status
+
+    @Test
+    fun `a granted hasAuthority-gated management endpoint is reachable with a service token`() {
+        // GET /api/management/v1/document-definition is gated hasAuthority(ADMIN)
+        // (DocumentDefinitionHttpSecurityConfigurer) — the shape of endpoint the bug made
+        // unreachable despite a grant.
+        grant("GET", "/api/management/v1/document-definition")
+
+        val status = perform(HttpMethod.GET, "/api/management/v1/document-definition")
+
+        assertThat(status)
+            .withFailMessage(
+                "granted ADMIN-gated endpoint was denied with $status — are the service-token " +
+                    "authorities missing?"
+            )
+            .isNotIn(HttpStatus.UNAUTHORIZED.value(), HttpStatus.FORBIDDEN.value())
+    }
+
+    @Test
+    fun `a granted authenticated-only endpoint is reachable with a service token`() {
+        // GET /api/v1/case-definition is gated .authenticated() (CaseHttpSecurityConfigurer) —
+        // the shape that already worked before the fix and must keep working.
+        grant("GET", "/api/v1/case-definition")
+
+        val status = perform(HttpMethod.GET, "/api/v1/case-definition")
+
+        assertThat(status).isNotIn(HttpStatus.UNAUTHORIZED.value(), HttpStatus.FORBIDDEN.value())
+    }
+
+    @Test
+    fun `an endpoint outside the granted set stays forbidden`() {
+        grant("GET", "/api/management/v1/document-definition")
+
+        assertThat(perform(HttpMethod.GET, "/api/v1/case-definition"))
+            .isEqualTo(HttpStatus.FORBIDDEN.value())
+    }
+
+    @Test
+    fun `a denylisted management endpoint stays forbidden even when granted`() {
+        // With ADMIN on the token, the allowlist filter's denylist is the only guard left for
+        // external-plugin management — this pins that it holds in the assembled chain.
+        grant("GET", "/api/management/v1/external-plugin/host")
+
+        assertThat(perform(HttpMethod.GET, "/api/management/v1/external-plugin/host"))
+            .isEqualTo(HttpStatus.FORBIDDEN.value())
+    }
+
+    @Test
+    fun `a user-account mutation stays forbidden even when granted`() {
+        // POST /api/v1/users is gated hasAuthority(ADMIN); without the method-specific denylist
+        // entry the token's ADMIN authority would let a grant reach it.
+        grant("POST", "/api/v1/users")
+
+        assertThat(perform(HttpMethod.POST, "/api/v1/users"))
+            .isEqualTo(HttpStatus.FORBIDDEN.value())
+    }
+
+    @Test
+    fun `a revoked token is rejected on a granted endpoint`() {
+        grant("GET", "/api/v1/case-definition")
+        configuration.tokenGeneration = configuration.tokenGeneration + 1
+        configurationRepository.saveAndFlush(configuration)
+
+        assertThat(perform(HttpMethod.GET, "/api/v1/case-definition"))
+            .isIn(HttpStatus.UNAUTHORIZED.value(), HttpStatus.FORBIDDEN.value())
+    }
+}

--- a/plugin-host/docs/external-plugin-system-plan.md
+++ b/plugin-host/docs/external-plugin-system-plan.md
@@ -115,7 +115,8 @@ callbacks.
 **3.2 Token (`service/ExternalPluginServiceTokenService.kt`)** — HS256 JWT:
 `sub=external-plugin:{pluginId}:{configId}`, `type=external_plugin_service`, `plugin_config_id`,
 `plugin_id`, `plugin_version`, `token_generation` (the configuration's revocation counter —
-§3.6), `iss=valtimo-gzac`, `exp=now+ttl`. **No roles.** Signed with
+§3.6), `iss=valtimo-gzac`, `exp=now+ttl`. **No roles claim** — the authenticator attaches fixed
+`ROLE_ADMIN` + `ROLE_USER` authorities at authentication time instead (§3.3). Signed with
 `SHA-256(valtimo.plugin.encryption-secret + "|service")` — the shared
 `security/ExternalPluginTokenKeyProvider.kt` base derives a **domain-separated** key per token
 kind (`|service` here, `|user` for the iframe token, §13.3), so a token of one kind can never
@@ -134,9 +135,16 @@ discovery poll (default 60s) re-pushes a fresh token every cycle (§3.6); it onl
 signature or `type` claim don't match (Keycloak tokens untouched); on match the authenticator
 first checks the token's `token_generation` claim against the configuration's current counter
 (§3.6) — a mismatch, a missing claim, or a configuration that no longer exists rejects the token —
-then sets an `ExternalPluginServicePrincipal`, **strips the `Authorization` header**, and runs the
-rest of the chain inside `AuthorizationContext.runWithoutAuthorization` (PBAC is intentionally
-bypassed for service tokens — the allowlist is the sole gate). The service- and user-token filters share the
+then sets an `ExternalPluginServicePrincipal` carrying fixed `ROLE_ADMIN` + `ROLE_USER`
+authorities, **strips the `Authorization` header**, and runs the rest of the chain inside
+`AuthorizationContext.runWithoutAuthorization` (PBAC is intentionally bypassed for service tokens —
+the allowlist is the sole gate). The authorities are not trust in the plugin: Spring Security's
+`AuthorizationFilter` applies the platform's coarse per-URL rules (`.authenticated()` /
+`hasAuthority(…)`) at the *end* of the chain, after the allowlist filter (§3.4) has already 403'd
+anything outside the granted set. Without them, every `hasAuthority`-gated endpoint — all of
+`/api/management/**` — would 403 even when explicitly granted; with them, reach is still exactly
+grants ∖ denylist (`ExternalPluginServiceTokenAccessIntTest` pins both directions through the full
+chain). The service- and user-token filters share the
 `AbstractExternalPluginTokenFilter` base, and all three plugin filters are excluded from servlet
 auto-registration (disabled `FilterRegistrationBean`s in the autoconfiguration) so they run only
 inside the Spring Security chain, never a second time as bare servlet filters.
@@ -149,7 +157,12 @@ inside the Spring Security chain, never a second time as bare servlet filters.
    can never reach `/api/management/v1/external-plugin/**` and `/api/v1/external-plugin/**`
    (external-plugin management incl. host registration, plus user-token minting — a plugin must
    not mint tokens for arbitrary users) or `/api/management/v1/roles/**` and
-   `/api/management/v1/permissions/**` (role/permission management — privilege escalation). One
+   `/api/management/v1/permissions/**` (role/permission management — privilege escalation), nor
+   issue non-`GET` requests to `/api/v1/users/**` (`DENYLIST_METHOD_PATTERNS` — user-account
+   mutations: a plugin that can create or alter accounts can escalate to a real admin login, and
+   with the ADMIN authority on the service principal (§3.3) this denylist is the only guard
+   between a grant and these surfaces; user *reads* like `GET /api/v1/users/{userId}` stay
+   grantable). One
    narrow carve-out precedes the denylist: a **user**-token principal may always `GET
    /api/v1/external-plugin/user-token/introspect` (exact path, GET only — the plugin host must be
    able to introspect the token before serving `/data`, §13.5; the endpoint is read-only and


### PR DESCRIPTION
What was wrong: A service token's endpoint grants only worked on endpoints secured with .authenticated(). The token's authentication carried no authorities (by design — "reach is the allowlist"), but Spring Security's AuthorizationFilter still applies the platform's coarse per-URL rules at the end of the chain, so every hasAuthority(ADMIN)-gated endpoint — the entire /api/management/** API — answered 403 even when an admin had explicitly granted it. This contradicted the module's documented design and was never caught because no test sent a real service token through the full security chain.

What was fixed: The service-token authenticator now attaches fixed ROLE_ADMIN+ROLE_USER authorities. This is safe because the allowlist filter runs before the authorization rules: anything outside the granted set (or on the hard denylist) still 403s first, so effective reach stays exactly grants minus denylist — the authorities only let granted endpoints pass the coarse URL gate. PBAC remains bypassed as before; user tokens (own authenticator, real user roles) are untouched. Because the denylist is now the sole guard for sensitive surfaces, it was extended with method-aware entries blocking user-account mutations (POST/PUT/PATCH/DELETE /api/v1/users/**) — account creation is privilege escalation — while user reads stay grantable. A new integration test (ExternalPluginServiceTokenAccessIntTest) pins all of this through the fully assembled filter chain; kdocs and the plan doc (§3.2–3.4) were updated to match.