### PR TITLE
[DRAFT] Configure whether a list column is visible by default

### DIFF
--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-list-columns/case-management-list-columns.component.html
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-list-columns/case-management-list-columns.component.html
@@ -343,6 +343,20 @@
         [attr.data-test-id]="testIds.exportable"
       ></cds-toggle>
     </cds-label>
+
+    <div class="checkbox-with-tooltip">
+      <cds-checkbox
+        formControlName="defaultVisible"
+        [disabled]="modalObs.disableInput"
+        [attr.data-test-id]="testIds.defaultVisibleCheckbox"
+        >{{ 'listColumn.defaultVisibleField' | translate }}
+      </cds-checkbox>
+
+      <v-tooltip-icon
+        [tooltip]="'listColumn.defaultVisibleTooltip' | translate"
+        [disabled]="modalObs.disableInput"
+      ></v-tooltip-icon>
+    </div>
   </form>
 </ng-template>
 

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-list-columns/case-management-list-columns.component.scss
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-list-columns/case-management-list-columns.component.scss
@@ -36,6 +36,11 @@
   align-items: center;
 }
 
+.checkbox-with-tooltip {
+  display: flex;
+  align-items: center;
+}
+
 .display-type-dropdown {
   width: 300px;
 }

--- a/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-list-columns/case-management-list-columns.component.ts
+++ b/frontend/projects/valtimo/case-management/src/lib/components/case-management-detail/tabs/case-management-list-columns/case-management-list-columns.component.ts
@@ -87,6 +87,12 @@ export class CaseManagementListColumnsComponent implements AfterViewInit, OnDest
     {viewType: 'string', sortable: false, key: 'sortable', label: 'listColumn.sortable'},
     {viewType: 'string', sortable: false, key: 'defaultSort', label: 'listColumn.defaultSort'},
     {viewType: 'boolean', sortable: false, key: 'exportable', label: 'listColumn.exportField'},
+    {
+      viewType: 'string',
+      sortable: false,
+      key: 'defaultVisible',
+      label: 'listColumn.defaultVisibleField',
+    },
   ];
 
   public readonly disableInput$ = new BehaviorSubject<boolean>(false);
@@ -146,6 +152,10 @@ export class CaseManagementListColumnsComponent implements AfterViewInit, OnDest
         displayTypeParameters: getDisplayTypeParametersView(
           column.displayType.displayTypeParameters
         ),
+        defaultVisible:
+          column.defaultVisible === false
+            ? this.translateService.instant('listColumn.sortableNo')
+            : this.translateService.instant('listColumn.sortableYes'),
       }))
     )
   );
@@ -169,6 +179,7 @@ export class CaseManagementListColumnsComponent implements AfterViewInit, OnDest
     enum: new FormControl([]),
     tagAmount: new FormControl(1),
     exportable: new FormControl(false),
+    defaultVisible: new FormControl(true),
   });
 
   public readonly disableDefaultSort$ = new BehaviorSubject<boolean>(false);
@@ -454,6 +465,7 @@ export class CaseManagementListColumnsComponent implements AfterViewInit, OnDest
           ...(columnDateFormat && {dateFormat: columnDateFormat}),
           ...(tagAmount && {tagAmount: tagAmount}),
           exportable: column?.exportable,
+          defaultVisible: column?.defaultVisible ?? true,
         });
 
         this.openModal('edit');
@@ -582,6 +594,7 @@ export class CaseManagementListColumnsComponent implements AfterViewInit, OnDest
 
   private resetFormGroup(): void {
     this.formGroup.reset();
+    this.formGroup.patchValue({defaultVisible: true});
     combineLatest([this.sortItems$, this.viewTypeItems$])
       .pipe(take(1))
       .subscribe(([sortItems, viewTypeItems]) => {
@@ -617,6 +630,7 @@ export class CaseManagementListColumnsComponent implements AfterViewInit, OnDest
         },
       },
       exportable: this.displayExportButton ? formValue.exportable : false,
+      defaultVisible: formValue.defaultVisible ?? true,
     };
   }
 

--- a/frontend/projects/valtimo/case-management/src/lib/constants/case-management.test-ids.ts
+++ b/frontend/projects/valtimo/case-management/src/lib/constants/case-management.test-ids.ts
@@ -91,6 +91,7 @@ export const CASE_MANAGEMENT_LIST_COLUMNS_TEST_IDS = {
   sortableCheckbox: 'listColumnSortableCheckbox',
   defaultSort: 'listColumnDefaultSort',
   exportable: 'listColumnExportable',
+  defaultVisibleCheckbox: 'listColumnDefaultVisibleCheckbox',
   cancelButton: 'listColumnCancelButton',
   saveButton: 'listColumnSaveButton',
   confirmationModal: 'listColumnConfirmationModal',

--- a/frontend/projects/valtimo/document/src/lib/models/document.model.ts
+++ b/frontend/projects/valtimo/document/src/lib/models/document.model.ts
@@ -354,6 +354,7 @@ interface CaseListColumn {
   defaultSort: string;
   uuid?: string;
   exportable?: boolean;
+  defaultVisible?: boolean;
 }
 
 interface CaseListColumnView {
@@ -366,6 +367,7 @@ interface CaseListColumnView {
   defaultSort: string;
   uuid?: string;
   exportable?: boolean;
+  defaultVisible?: string;
 }
 
 interface DocumentDefinitionVersionsResult {

--- a/frontend/projects/valtimo/shared/assets/core/en.json
+++ b/frontend/projects/valtimo/shared/assets/core/en.json
@@ -2362,6 +2362,8 @@
     "sortableNo": "No",
     "exportField": "Exportable",
     "exportTooltip": "Only fields from the document or the case can be exported. If another type of field is selected, the export button will be set to ‘disabled’.",
+    "defaultVisibleField": "Visible by default",
+    "defaultVisibleTooltip": "Determines whether this column is shown in the list by default. If it is switched off, the column stays available and users can show it themselves through the column selection. Users who already made a column selection keep their own choice.",
     "sortableAsc": "Ascending",
     "sortableDesc": "Descending",
     "hasEnvConfigWarningTitle": "Case type already has a column configuration",

--- a/frontend/projects/valtimo/shared/assets/core/nl.json
+++ b/frontend/projects/valtimo/shared/assets/core/nl.json
@@ -2389,6 +2389,8 @@
     "sortableNo": "Nee",
     "exportField": "Exporteerbaar",
     "exportTooltip": "Alleen velden van het document of het dossier kunnen geëxporteerd worden. Als er een ander type veld wordt gekozen, dan wordt de export knop op 'disabled' staat gezet.",
+    "defaultVisibleField": "Standaard zichtbaar",
+    "defaultVisibleTooltip": "Bepaalt of deze kolom standaard in de lijst wordt getoond. Staat dit uit, dan blijft de kolom beschikbaar en kunnen gebruikers deze zelf aanzetten via de kolomselectie. Gebruikers die al een kolomselectie hebben gemaakt, behouden hun eigen keuze.",
     "sortableAsc": "Oplopend",
     "sortableDesc": "Aflopend",
     "hasEnvConfigWarningTitle": "Dit dossiertype heeft al een kolom-configuratie",

--- a/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.html
+++ b/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.html
@@ -209,6 +209,22 @@
           </cds-dropdown>
         </cds-label>
       </div>
+
+      <div class="cds--text-input__field-wrapper">
+        <div class="checkbox-with-tooltip">
+          <cds-checkbox
+            data-testid="task-management-column-defaultVisible"
+            formControlName="defaultVisible"
+            [disabled]="obs.disabled"
+            >{{ 'listColumn.defaultVisibleField' | translate }}
+          </cds-checkbox>
+
+          <v-tooltip-icon
+            [tooltip]="'listColumn.defaultVisibleTooltip' | translate"
+            [disabled]="obs.disabled"
+          ></v-tooltip-icon>
+        </div>
+      </div>
     </form>
 
     <cds-modal-footer>

--- a/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.scss
+++ b/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.scss
@@ -33,6 +33,11 @@
   align-items: center;
 }
 
+.checkbox-with-tooltip {
+  display: flex;
+  align-items: center;
+}
+
 .select-label {
   padding-bottom: 8px;
 }

--- a/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.ts
+++ b/frontend/projects/valtimo/task-management/src/lib/components/task-management-column-modal/task-management-column-modal.component.ts
@@ -184,6 +184,7 @@ export class TaskManagementColumnModalComponent {
       this.getInvalidListItem(`listColumn.selectDefaultSort`),
       [Validators.required]
     ),
+    defaultVisible: new FormControl<boolean>(true),
   });
 
   public get title(): AbstractControl<string | null> | null {
@@ -209,6 +210,9 @@ export class TaskManagementColumnModalComponent {
   }
   public get defaultSort(): AbstractControl<TaskListColumnListItem | null> | null {
     return this.formGroup.get('defaultSort');
+  }
+  public get defaultVisible(): AbstractControl<boolean | null> | null {
+    return this.formGroup.get('defaultVisible');
   }
 
   private get _SORT_ASC_ITEM() {
@@ -433,6 +437,7 @@ export class TaskManagementColumnModalComponent {
       displayType: this.getInvalidListItem('listColumnDisplayType.select'),
       sortable: false,
       defaultSort: this.getInvalidListItem(`listColumn.selectDefaultSort`),
+      defaultVisible: true,
     });
   }
 
@@ -484,6 +489,7 @@ export class TaskManagementColumnModalComponent {
         formValue?.defaultSort?.key !== this._INVALID_KEY && {
           defaultSort: formValue?.defaultSort?.key as TaskListColumnDefaultSort,
         }),
+      defaultVisible: formValue.defaultVisible ?? true,
     };
 
     return taskListColumn;
@@ -540,6 +546,7 @@ export class TaskManagementColumnModalComponent {
       key: column.key,
       path: column.path,
       sortable: column.sortable,
+      defaultVisible: column.defaultVisible ?? true,
       displayType: this.getListItemFromViewType(column.displayType.type),
       ...(column.title && {title: column.title}),
       ...(!column.defaultSort && {

--- a/frontend/projects/valtimo/task-management/src/lib/components/task-management-columns/task-management-columns.component.ts
+++ b/frontend/projects/valtimo/task-management/src/lib/components/task-management-columns/task-management-columns.component.ts
@@ -106,6 +106,10 @@ export class TaskManagementColumnsComponent {
         displayTypeParameters: this.getDisplayTypeParametersView(
           column?.displayType?.displayTypeParameters
         ),
+        defaultVisible:
+          column.defaultVisible === false
+            ? this.translateService.instant('listColumn.sortableNo')
+            : this.translateService.instant('listColumn.sortableYes'),
       }))
     ),
     tap(() => {
@@ -161,6 +165,12 @@ export class TaskManagementColumnsComponent {
       sortable: false,
       key: 'defaultSort',
       label: 'listColumn.defaultSort',
+    },
+    {
+      viewType: 'string',
+      sortable: false,
+      key: 'defaultVisible',
+      label: 'listColumn.defaultVisibleField',
     },
   ];
 

--- a/frontend/projects/valtimo/task/src/lib/models/task-list.model.ts
+++ b/frontend/projects/valtimo/task/src/lib/models/task-list.model.ts
@@ -51,6 +51,7 @@ interface TaskListColumn {
   sortable: boolean;
   defaultSort?: TaskListColumnDefaultSort;
   order?: number;
+  defaultVisible?: boolean;
 }
 
 type TaskListColumnModalType = 'edit' | 'add';


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/421

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: story/421-default-visible-columns

**Relevant comments:** FE supported. BE has to be done
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [ ] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [ ] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Describe the testing steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [ ] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [ ] Not applicable
