### PR TITLE
Show the correct name of the active case version in Case details

### DIFF
--- a/documentation/release-notes/13.x.x/13.43.0/README.md
+++ b/documentation/release-notes/13.x.x/13.43.0/README.md
@@ -56,6 +56,7 @@ The metadata tab of the case inspection page now displays the case definition ke
 | Case widgets | Long texts wrap correctly without overlapping other content |
 | Cases | A case that cannot be found no longer stops a process, an assignment, or a note |
 | Cases | A case with building blocks can be deleted again |
+| Cases | The case list title and breadcrumb show the name of the active case version, matching the menu |
 | Dashboard | Donut charts with many categories display the circle correctly |
 | Document schemas | Recursive schema references no longer crash the server |
 | Draft environments | Default Spring profiles now correctly enable draft mode |

--- a/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.ts
+++ b/frontend/projects/valtimo/case/src/lib/components/case-detail/case-detail.component.ts
@@ -61,6 +61,7 @@ import {
   combineLatest,
   debounceTime,
   filter,
+  forkJoin,
   map,
   merge,
   Observable,
@@ -666,9 +667,12 @@ export class CaseDetailComponent implements AfterViewInit, OnDestroy {
   }
 
   private initBreadcrumb(): void {
-    this.documentService.getDocumentDefinition(this.caseDefinitionKey).subscribe(definition => {
-      this.documentDefinitionTitle = definition.schema.title;
-      this.caseDefinitionVersionTag = definition.id.blueprintId.blueprintVersionTag;
+    forkJoin({
+      documentDefinition: this.documentService.getDocumentDefinition(this.caseDefinitionKey),
+      activeCaseDefinition: this.documentService.getActiveCaseDefinition(this.caseDefinitionKey),
+    }).subscribe(({documentDefinition, activeCaseDefinition}) => {
+      this.documentDefinitionTitle = activeCaseDefinition?.name || documentDefinition.schema.title;
+      this.caseDefinitionVersionTag = documentDefinition.id.blueprintId.blueprintVersionTag;
       this.setBreadcrumb();
     });
   }

--- a/frontend/projects/valtimo/case/src/lib/services/case-list-orchestration.service.ts
+++ b/frontend/projects/valtimo/case/src/lib/services/case-list-orchestration.service.ts
@@ -143,13 +143,20 @@ export class CaseListOrchestrationService {
 
   public readonly schema$ = this.listService.caseDefinitionKey$.pipe(
     filter(caseDefinitionKey => !!caseDefinitionKey),
-    switchMap(caseDefinitionKey => this.documentService.getDocumentDefinition(caseDefinitionKey)),
-    map(caseDefinition => caseDefinition?.schema),
-    tap(schema => {
-      if (schema?.title) {
-        this.pageTitleService.setCustomPageTitle(schema?.title, true);
+    switchMap((caseDefinitionKey: string) =>
+      forkJoin({
+        documentDefinition: this.documentService.getDocumentDefinition(caseDefinitionKey),
+        activeCaseDefinition: this.documentService.getActiveCaseDefinition(caseDefinitionKey),
+      })
+    ),
+    tap(({documentDefinition, activeCaseDefinition}) => {
+      const pageTitle = activeCaseDefinition?.name || documentDefinition?.schema?.title;
+
+      if (pageTitle) {
+        this.pageTitleService.setCustomPageTitle(pageTitle, true);
       }
-    })
+    }),
+    map(({documentDefinition}) => documentDefinition?.schema)
   );
 
   public readonly canCreateCase$: Observable<boolean> = this.caseDefinitionKey$.pipe(

--- a/frontend/projects/valtimo/document/src/lib/services/document.service.ts
+++ b/frontend/projects/valtimo/document/src/lib/services/document.service.ts
@@ -26,7 +26,7 @@ import {
   SearchOperator,
   TeamResponseDto,
 } from '@valtimo/shared';
-import {BehaviorSubject, catchError, Observable, of, switchMap, tap} from 'rxjs';
+import {BehaviorSubject, catchError, map, Observable, of, switchMap, tap} from 'rxjs';
 
 import {
   AssignHandlerToDocumentResult,
@@ -370,6 +370,25 @@ export class DocumentService {
     return this.http.get<CaseDefinition[]>(`${this.valtimoEndpointUri}v1/case-definition`, {
       params,
     });
+  }
+
+  /**
+   * The globally active case definition of a key. Its `name` is what the left menu and the
+   * user-facing case pages are labelled with, so it should be preferred over the document
+   * definition schema title, which is not kept in sync with it. Resolves to `null` when there is
+   * no active version, so consumers can fall back to the schema title.
+   */
+  public getActiveCaseDefinition(caseDefinitionKey: string): Observable<CaseDefinition | null> {
+    return this.getCaseDefinitions({caseDefinitionKey, active: true}).pipe(
+      map(
+        (caseDefinitions: CaseDefinition[]) =>
+          caseDefinitions.find(
+            (caseDefinition: CaseDefinition) =>
+              caseDefinition.caseDefinitionKey === caseDefinitionKey
+          ) ?? null
+      ),
+      catchError(() => of(null))
+    );
   }
 
   public getCaseDefinitionsManagement(params: any): Observable<Page<CaseDefinition>> {


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/685

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->

Specify the code branch location: story/685-fix-case-details-name

**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be added to the Valtimo documentation under `documentation/release-notes/` within this pull request.  -->
- [x] Release notes have been written for these changes.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Describe the testing steps
- [ ] Go to Admin → Case Management and open an existing case
- [ ] Create a new draft version of it and give it a different name
- [ ] Finalize the draft and set it as the globally active version
- [ ] Verify the left menu now shows Cases > New case (without reloading the page)
- [ ] Click Cases > New case and verify the page header reads "New case", not "Old name"
- [ ] Open a case from that list and verify the breadcrumb reads Cases > New  case > <case>
- [ ] In Admin → Case Management → New Case → Document tab, change the schema `title` and save; verify the menu, the case list header and the breadcrumb all still read "New Case"

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
