### PR TITLE
GH-849: Fixed deprecated choice fields not being hidden

### DIFF
--- a/backend/core/src/main/java/com/ritense/valtimo/choicefield/repository/ChoiceFieldValueRepository.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/choicefield/repository/ChoiceFieldValueRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,4 +37,6 @@ public interface ChoiceFieldValueRepository extends JpaRepository<ChoiceFieldVal
     ChoiceFieldValue findTop1ByChoiceField_KeyNameAndValue(@Param("key_name") String choiceFieldName, @Param("value") String value);
 
     List<ChoiceFieldValue> findByChoiceField_IdAndDeprecatedIsFalse(@Param("choice_field_id") Long choiceFieldId);
+
+    Page<ChoiceFieldValue> findByChoiceField_KeyNameAndDeprecatedIsFalse(Pageable pageable, @Param("choice_field_name") String choiceFieldName);
 }

--- a/backend/core/src/main/java/com/ritense/valtimo/service/ChoiceFieldValueService.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/service/ChoiceFieldValueService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,12 +143,16 @@ public class ChoiceFieldValueService {
      * Get all the choiceFieldValues.
      *
      * @param pageable the pagination information
+     * @param includeDeprecated whether to include deprecated values
      * @return the list of entities
      */
     @Transactional(readOnly = true)
-    public Page<ChoiceFieldValue> findAllByChoiceFieldKeyName(Pageable pageable, String choiceFieldName) {
-        logger.debug("Request to get all ChoiceFieldValues for choiceField witd name {}", choiceFieldName);
-        return choiceFieldValueRepository.findByChoiceField_KeyName(pageable, choiceFieldName);
+    public Page<ChoiceFieldValue> findAllByChoiceFieldKeyName(Pageable pageable, String choiceFieldName, boolean includeDeprecated) {
+        logger.debug("Request to get ChoiceFieldValues for choiceField with name {}, includeDeprecated={}", choiceFieldName, includeDeprecated);
+        if (includeDeprecated) {
+            return choiceFieldValueRepository.findByChoiceField_KeyName(pageable, choiceFieldName);
+        }
+        return choiceFieldValueRepository.findByChoiceField_KeyNameAndDeprecatedIsFalse(pageable, choiceFieldName);
     }
 
     /**

--- a/backend/core/src/main/java/com/ritense/valtimo/web/rest/ChoiceFieldValueResource.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/web/rest/ChoiceFieldValueResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,7 +142,7 @@ public class ChoiceFieldValueResource {
         @PathVariable(name = "choice_field_name") String choiceFieldName
     ) {
         logger.debug("REST request to get ChoiceField : {}", choiceFieldName);
-        final Page<ChoiceFieldValue> page = choiceFieldValueService.findAllByChoiceFieldKeyName(pageable, choiceFieldName);
+        final Page<ChoiceFieldValue> page = choiceFieldValueService.findAllByChoiceFieldKeyName(pageable, choiceFieldName, true);
         final HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/v1/choice-field-values");
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
@@ -150,10 +150,11 @@ public class ChoiceFieldValueResource {
     @GetMapping("/v2/choice-field-values/{choice_field_name}/values")
     public ResponseEntity<Page<ChoiceFieldValue>> getChoiceFieldValuesByChoiceFieldPaged(
         Pageable pageable,
-        @PathVariable(name = "choice_field_name") String choiceFieldName
+        @PathVariable(name = "choice_field_name") String choiceFieldName,
+        @RequestParam(defaultValue = "false") boolean includeDeprecated
     ) {
-        logger.debug("REST request to get ChoiceField : {}", choiceFieldName);
-        final Page<ChoiceFieldValue> page = choiceFieldValueService.findAllByChoiceFieldKeyName(pageable, choiceFieldName);
+        logger.debug("REST request to get ChoiceField : {}, includeDeprecated={}", choiceFieldName, includeDeprecated);
+        final Page<ChoiceFieldValue> page = choiceFieldValueService.findAllByChoiceFieldKeyName(pageable, choiceFieldName, includeDeprecated);
         return ResponseEntity.ok(page);
     }
 

--- a/backend/core/src/test/java/com/ritense/valtimo/web/rest/ChoiceFieldValueResourceIntTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/web/rest/ChoiceFieldValueResourceIntTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,5 +85,68 @@ class ChoiceFieldValueResourceIntTest extends BaseIntegrationTest {
         .andExpect(jsonPath("$[0].choiceField.id").isNumber())
         .andExpect(jsonPath("$[0].choiceField.keyName").value("keyName"))
         .andExpect(jsonPath("$[0].choiceField.title").value("title"));
+    }
+
+    @Test
+    void shouldExcludeDeprecatedValuesFromV2ByDefault() throws Exception {
+        ChoiceField choiceField = new ChoiceField();
+        choiceField.setKeyName("test-field");
+        choiceField.setTitle("Test Field");
+        choiceFieldRepository.save(choiceField);
+
+        ChoiceFieldValue activeValue = new ChoiceFieldValue();
+        activeValue.setChoiceField(choiceField);
+        activeValue.setValue("active-value");
+        activeValue.setName("Active");
+        activeValue.setDeprecated(false);
+        choiceFieldValueRepository.save(activeValue);
+
+        ChoiceFieldValue deprecatedValue = new ChoiceFieldValue();
+        deprecatedValue.setChoiceField(choiceField);
+        deprecatedValue.setValue("deprecated-value");
+        deprecatedValue.setName("Deprecated");
+        deprecatedValue.setDeprecated(true);
+        choiceFieldValueRepository.save(deprecatedValue);
+
+        mockMvc.perform(
+            get("/api/v2/choice-field-values/{choice_field_name}/values", "test-field")
+                .accept(APPLICATION_JSON_VALUE)
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].value").value("active-value"))
+        .andExpect(jsonPath("$.content[0].deprecated").value(false));
+    }
+
+    @Test
+    void shouldIncludeDeprecatedValuesWhenRequested() throws Exception {
+        ChoiceField choiceField = new ChoiceField();
+        choiceField.setKeyName("test-field-2");
+        choiceField.setTitle("Test Field 2");
+        choiceFieldRepository.save(choiceField);
+
+        ChoiceFieldValue activeValue = new ChoiceFieldValue();
+        activeValue.setChoiceField(choiceField);
+        activeValue.setValue("active-value");
+        activeValue.setName("Active");
+        activeValue.setDeprecated(false);
+        choiceFieldValueRepository.save(activeValue);
+
+        ChoiceFieldValue deprecatedValue = new ChoiceFieldValue();
+        deprecatedValue.setChoiceField(choiceField);
+        deprecatedValue.setValue("deprecated-value");
+        deprecatedValue.setName("Deprecated");
+        deprecatedValue.setDeprecated(true);
+        choiceFieldValueRepository.save(deprecatedValue);
+
+        mockMvc.perform(
+            get("/api/v2/choice-field-values/{choice_field_name}/values", "test-field-2")
+                .param("includeDeprecated", "true")
+                .accept(APPLICATION_JSON_VALUE)
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(2));
     }
 }

--- a/backend/core/src/test/java/com/ritense/valtimo/web/rest/ChoiceFieldValueResourceTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/web/rest/ChoiceFieldValueResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ class ChoiceFieldValueResourceTest {
 
         Pageable pageable = PageRequest.of(1, 1);
 
-        when(choiceFieldValueService.findAllByChoiceFieldKeyName(any(), eq("some-name"))).thenReturn(new PageImpl<>(List.of(choiceFieldValue), pageable, 5L));
+        when(choiceFieldValueService.findAllByChoiceFieldKeyName(any(), eq("some-name"), eq(false))).thenReturn(new PageImpl<>(List.of(choiceFieldValue), pageable, 5L));
 
         mvc.perform(get("/api/v2/choice-field-values/some-name/values"))
             .andExpect(status().isOk())

--- a/documentation/release-notes/13.x.x/13.43.0/README.md
+++ b/documentation/release-notes/13.x.x/13.43.0/README.md
@@ -56,6 +56,7 @@ The metadata tab of the case inspection page now displays the case definition ke
 | Case widgets | Long texts wrap correctly without overlapping other content |
 | Cases | A case that cannot be found no longer stops a process, an assignment, or a note |
 | Cases | A case with building blocks can be deleted again |
+| Choice fields | Deprecated choice field values no longer appear in form dropdowns |
 | Dashboard | Donut charts with many categories display the circle correctly |
 | Document schemas | Recursive schema references no longer crash the server |
 | Draft environments | Default Spring profiles now correctly enable draft mode |

--- a/frontend/projects/valtimo/choice-field/src/lib/choice-field-value-list/choice-field-value-list.component.ts
+++ b/frontend/projects/valtimo/choice-field/src/lib/choice-field-value-list/choice-field-value-list.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ export class ChoiceFieldValueListComponent implements OnInit {
         .queryValuesPage(this.choiceField.keyName, {
           page: this.pageParam,
           size: this.$pagination().size,
+          includeDeprecated: true,
         })
         .subscribe(page => {
           this.$pagination.update(pagination => ({

--- a/frontend/projects/valtimo/components/src/lib/components/camunda/form/generated/formfield/choicefield/camunda-choicefield-formfield.component.html
+++ b/frontend/projects/valtimo/components/src/lib/components/camunda/form/generated/formfield/choicefield/camunda-choicefield-formfield.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2015-2025 Ritense BV, the Netherlands.
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
   ~
   ~ Licensed under EUPL, Version 1.2 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -21,15 +21,13 @@
   <div class="col-12 col-sm-8 col-lg-6">
     <select class="form-control" id="{{ formField.id }}" [formControlName]="formField.id">
       <option selected="selected" value=""></option>
-      <ng-container *ngFor="let choicefieldValue of choicefieldValues">
-        <option
-          *ngIf="!choicefieldValue.deprecated"
-          [value]="choicefieldValue.value"
-          id="option_{{ choicefieldValue.value }}"
-        >
-          {{ choicefieldValue.name }}
-        </option>
-      </ng-container>
+      <option
+        *ngFor="let choicefieldValue of choicefieldValues"
+        [value]="choicefieldValue.value"
+        id="option_{{ choicefieldValue.value }}"
+      >
+        {{ choicefieldValue.name }}
+      </option>
     </select>
     <valtimo-camunda-formfield-validation [formGroup]="formGroup" [formField]="formField">
     </valtimo-camunda-formfield-validation>


### PR DESCRIPTION
Kept v1 endpoint the same since it's deprecated, only v2 contains this new functionality.

Solves https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/849