### PR TITLE
Speed up case and document handling

### DIFF
--- a/backend/case/src/main/java/com/ritense/document/domain/impl/JsonSchema.java
+++ b/backend/case/src/main/java/com/ritense/document/domain/impl/JsonSchema.java
@@ -118,11 +118,19 @@ public final class JsonSchema {
         if (cached != null) {
             return cached;
         }
+        // Built outside the lock, so a cold start never serialises builds on one thread. Only admission
+        // is atomic: concurrent callers converge on one schema and the cap cannot be overshot.
         final Schema built = buildSchema();
-        if (BUILT_SCHEMAS.size() >= MAX_BUILT_SCHEMAS) {
-            evictOne();
+        synchronized (BUILT_SCHEMAS) {
+            final Schema raced = BUILT_SCHEMAS.get(schema);
+            if (raced != null) {
+                return raced;
+            }
+            if (BUILT_SCHEMAS.size() >= MAX_BUILT_SCHEMAS) {
+                evictOne();
+            }
+            BUILT_SCHEMAS.put(schema, built);
         }
-        BUILT_SCHEMAS.put(schema, built);
         return built;
     }
 

--- a/backend/case/src/main/java/com/ritense/document/domain/impl/JsonSchema.java
+++ b/backend/case/src/main/java/com/ritense/document/domain/impl/JsonSchema.java
@@ -31,7 +31,6 @@ import jakarta.persistence.Embeddable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -118,27 +117,10 @@ public final class JsonSchema {
         if (cached != null) {
             return cached;
         }
-        // Built outside the lock, so a cold start never serialises builds on one thread. Only admission
-        // is atomic: concurrent callers converge on one schema and the cap cannot be overshot.
-        final Schema built = buildSchema();
-        synchronized (BUILT_SCHEMAS) {
-            final Schema raced = BUILT_SCHEMAS.get(schema);
-            if (raced != null) {
-                return raced;
-            }
-            if (BUILT_SCHEMAS.size() >= MAX_BUILT_SCHEMAS) {
-                evictOne();
-            }
-            BUILT_SCHEMAS.put(schema, built);
+        if (BUILT_SCHEMAS.size() >= MAX_BUILT_SCHEMAS) {
+            BUILT_SCHEMAS.clear();
         }
-        return built;
-    }
-
-    private static void evictOne() {
-        final Iterator<String> keys = BUILT_SCHEMAS.keySet().iterator();
-        if (keys.hasNext()) {
-            BUILT_SCHEMAS.remove(keys.next());
-        }
+        return BUILT_SCHEMAS.computeIfAbsent(schema, ignored -> buildSchema());
     }
 
     private Schema buildSchema() {

--- a/backend/case/src/main/java/com/ritense/document/domain/impl/JsonSchema.java
+++ b/backend/case/src/main/java/com/ritense/document/domain/impl/JsonSchema.java
@@ -31,7 +31,10 @@ import jakarta.persistence.Embeddable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import org.everit.json.schema.ReadWriteContext;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.Validator;
@@ -54,6 +57,12 @@ public final class JsonSchema {
     private static final Validator VALIDATOR = Validator.builder()
         .readWriteContext(ReadWriteContext.WRITE)
         .build();
+
+    @Transient
+    private static final Map<String, Schema> BUILT_SCHEMAS = new ConcurrentHashMap<>();
+
+    @Transient
+    private static final int MAX_BUILT_SCHEMAS = 100;
 
     @Type(value = JsonType.class)
     @Column(name = "json_schema", columnDefinition = "json")
@@ -105,6 +114,26 @@ public final class JsonSchema {
 
     @JsonIgnore
     public Schema getSchema() {
+        final Schema cached = BUILT_SCHEMAS.get(schema);
+        if (cached != null) {
+            return cached;
+        }
+        final Schema built = buildSchema();
+        if (BUILT_SCHEMAS.size() >= MAX_BUILT_SCHEMAS) {
+            evictOne();
+        }
+        BUILT_SCHEMAS.put(schema, built);
+        return built;
+    }
+
+    private static void evictOne() {
+        final Iterator<String> keys = BUILT_SCHEMAS.keySet().iterator();
+        if (keys.hasNext()) {
+            BUILT_SCHEMAS.remove(keys.next());
+        }
+    }
+
+    private Schema buildSchema() {
         final SchemaLoader schemaLoader = getSchemaLoaderBuilder()
             .schemaJson(new JSONObject(new JSONTokener(schema)))
             .build();

--- a/backend/case/src/test/java/com/ritense/document/domain/impl/JsonSchemaTest.java
+++ b/backend/case/src/test/java/com/ritense/document/domain/impl/JsonSchemaTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.document.domain.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ritense.valtimo.contract.json.MapperSingleton;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.everit.json.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+/** Caching a built schema is only observable as identity: an uncached build returns an equal schema. */
+class JsonSchemaTest {
+
+    private static final URI HOUSE = URI.create("config/unit-test/document/definition/house.schema.json");
+    private static final URI PERSON = URI.create("config/unit-test/document/definition/person.schema.json");
+
+    @Test
+    void shouldBuildTheSchemaOnceForRepeatedCalls() {
+        var jsonSchema = JsonSchema.fromResourceUri(HOUSE);
+
+        var first = jsonSchema.getSchema();
+
+        assertThat(jsonSchema.getSchema()).isSameAs(first);
+        assertThat(jsonSchema.getSchema()).isSameAs(first);
+    }
+
+    /** Keyed by the schema JSON, not per instance: Hibernate hands back a fresh definition each time. */
+    @Test
+    void shouldShareABuiltSchemaBetweenSeparateInstancesOfTheSameSchema() {
+        var one = JsonSchema.fromResourceUri(HOUSE);
+        var other = JsonSchema.fromResourceUri(HOUSE);
+
+        assertThat(other.getSchema()).isSameAs(one.getSchema());
+    }
+
+    @Test
+    void shouldNotShareABuiltSchemaBetweenDifferentSchemas() {
+        var house = JsonSchema.fromResourceUri(HOUSE);
+        var person = JsonSchema.fromResourceUri(PERSON);
+
+        assertThat(person.getSchema()).isNotSameAs(house.getSchema());
+        assertThat(person.getSchema().getId()).isNotEqualTo(house.getSchema().getId());
+    }
+
+    /** An edited schema is a different key, which is why the cache cannot go stale. */
+    @Test
+    void shouldBuildAgainWhenTheSchemaJsonDiffers() {
+        var original = JsonSchema.fromResourceUri(HOUSE);
+        var edited = JsonSchema.fromString(
+            original.asJson().toString().replace("\"maxLength\":100", "\"maxLength\":99")
+        );
+
+        assertThat(edited.asJson()).isNotEqualTo(original.asJson()); // the edit really took
+        assertThat(edited.getSchema()).isNotSameAs(original.getSchema());
+    }
+
+    @Test
+    void shouldStillValidateDocumentsAgainstACachedSchema() {
+        var jsonSchema = JsonSchema.fromResourceUri(HOUSE);
+        jsonSchema.getSchema(); // prime the cache
+
+        var content = JsonDocumentContent.build(
+            MapperSingleton.INSTANCE.get().createObjectNode().put("street", "Funenpark")
+        );
+
+        assertThat(jsonSchema.validateDocument(content).asJson().get("street").asText())
+            .isEqualTo("Funenpark");
+    }
+
+    /** Concurrent misses may build twice; every caller must still get an equivalent schema. */
+    @Test
+    void shouldSettleOnOneSchemaUnderConcurrentFirstUse() throws Exception {
+        var schemas = IntStream.range(0, 8)
+            .mapToObj(i -> JsonSchema.fromResourceUri(HOUSE))
+            .toList();
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            List<Callable<Schema>> calls = schemas.stream()
+                .map(s -> (Callable<Schema>) s::getSchema)
+                .collect(Collectors.toList());
+
+            Set<Schema> distinct = executor.invokeAll(calls).stream()
+                .map(JsonSchemaTest::get)
+                .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+
+            assertThat(distinct).hasSize(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static Schema get(Future<Schema> future) {
+        try {
+            return future.get();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/backend/case/src/test/java/com/ritense/document/domain/impl/JsonSchemaTest.java
+++ b/backend/case/src/test/java/com/ritense/document/domain/impl/JsonSchemaTest.java
@@ -25,19 +25,22 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.everit.json.schema.Schema;
 import org.junit.jupiter.api.Test;
 
-/** Caching a built schema is only observable as identity: an uncached build returns an equal schema. */
 class JsonSchemaTest {
 
     private static final URI HOUSE = URI.create("config/unit-test/document/definition/house.schema.json");
     private static final URI PERSON = URI.create("config/unit-test/document/definition/person.schema.json");
+
+    private static final int CONCURRENT_CALLERS = 8;
 
     @Test
     void shouldBuildTheSchemaOnceForRepeatedCalls() {
@@ -49,7 +52,6 @@ class JsonSchemaTest {
         assertThat(jsonSchema.getSchema()).isSameAs(first);
     }
 
-    /** Keyed by the schema JSON, not per instance: Hibernate hands back a fresh definition each time. */
     @Test
     void shouldShareABuiltSchemaBetweenSeparateInstancesOfTheSameSchema() {
         var one = JsonSchema.fromResourceUri(HOUSE);
@@ -67,7 +69,6 @@ class JsonSchemaTest {
         assertThat(person.getSchema().getId()).isNotEqualTo(house.getSchema().getId());
     }
 
-    /** An edited schema is a different key, which is why the cache cannot go stale. */
     @Test
     void shouldBuildAgainWhenTheSchemaJsonDiffers() {
         var original = JsonSchema.fromResourceUri(HOUSE);
@@ -75,14 +76,14 @@ class JsonSchemaTest {
             original.asJson().toString().replace("\"maxLength\":100", "\"maxLength\":99")
         );
 
-        assertThat(edited.asJson()).isNotEqualTo(original.asJson()); // the edit really took
+        assertThat(edited.asJson()).isNotEqualTo(original.asJson());
         assertThat(edited.getSchema()).isNotSameAs(original.getSchema());
     }
 
     @Test
     void shouldStillValidateDocumentsAgainstACachedSchema() {
         var jsonSchema = JsonSchema.fromResourceUri(HOUSE);
-        jsonSchema.getSchema(); // prime the cache
+        jsonSchema.getSchema();
 
         var content = JsonDocumentContent.build(
             MapperSingleton.INSTANCE.get().createObjectNode().put("street", "Funenpark")
@@ -92,25 +93,61 @@ class JsonSchemaTest {
             .isEqualTo("Funenpark");
     }
 
-    /** Concurrent misses may build more than once, but every caller must end up on one instance. */
     @Test
     void shouldSettleOnOneSchemaUnderConcurrentFirstUse() throws Exception {
-        var schemas = IntStream.range(0, 8)
-            .mapToObj(i -> JsonSchema.fromResourceUri(HOUSE))
+        var neverBuiltBefore = uniqueSchemaJson("concurrent-first-use");
+        var schemas = IntStream.range(0, CONCURRENT_CALLERS)
+            .mapToObj(i -> JsonSchema.fromString(neverBuiltBefore))
             .toList();
-        ExecutorService executor = Executors.newFixedThreadPool(8);
+        var startTogether = new CyclicBarrier(CONCURRENT_CALLERS);
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_CALLERS);
         try {
             List<Callable<Schema>> calls = schemas.stream()
-                .map(s -> (Callable<Schema>) s::getSchema)
+                .map(jsonSchema -> (Callable<Schema>) () -> {
+                    startTogether.await(10, TimeUnit.SECONDS);
+                    return jsonSchema.getSchema();
+                })
                 .collect(Collectors.toList());
 
             Set<Schema> byIdentity = Collections.newSetFromMap(new IdentityHashMap<>());
             executor.invokeAll(calls).stream().map(JsonSchemaTest::get).forEach(byIdentity::add);
 
             assertThat(byIdentity).hasSize(1);
+            assertThat(JsonSchema.fromString(neverBuiltBefore).getSchema())
+                .isSameAs(byIdentity.iterator().next());
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    /** The cap is a backstop against unforeseen growth, so passing it drops what was built before. */
+    @Test
+    void shouldNotHoldOnToSchemasPastTheCap() {
+        var jsonSchema = JsonSchema.fromString(uniqueSchemaJson("dropped-past-the-cap"));
+        var builtOnce = jsonSchema.getSchema();
+
+        IntStream.rangeClosed(0, 100)
+            .forEach(i -> JsonSchema.fromString(uniqueSchemaJson("filler-" + i)).getSchema());
+
+        assertThat(jsonSchema.getSchema()).isNotSameAs(builtOnce);
+    }
+
+    private static String uniqueSchemaJson(String name) {
+        return """
+            {
+              "$id": "%s.schema",
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "title": "%s",
+              "type": "object",
+              "properties": {
+                "street": {
+                  "type": "string",
+                  "maxLength": 100
+                }
+              },
+              "additionalProperties": false
+            }
+            """.formatted(name, name);
     }
 
     private static Schema get(Future<Schema> future) {

--- a/backend/case/src/test/java/com/ritense/document/domain/impl/JsonSchemaTest.java
+++ b/backend/case/src/test/java/com/ritense/document/domain/impl/JsonSchemaTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ritense.valtimo.contract.json.MapperSingleton;
 import java.net.URI;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -90,7 +92,7 @@ class JsonSchemaTest {
             .isEqualTo("Funenpark");
     }
 
-    /** Concurrent misses may build twice; every caller must still get an equivalent schema. */
+    /** Concurrent misses may build more than once, but every caller must end up on one instance. */
     @Test
     void shouldSettleOnOneSchemaUnderConcurrentFirstUse() throws Exception {
         var schemas = IntStream.range(0, 8)
@@ -102,11 +104,10 @@ class JsonSchemaTest {
                 .map(s -> (Callable<Schema>) s::getSchema)
                 .collect(Collectors.toList());
 
-            Set<Schema> distinct = executor.invokeAll(calls).stream()
-                .map(JsonSchemaTest::get)
-                .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+            Set<Schema> byIdentity = Collections.newSetFromMap(new IdentityHashMap<>());
+            executor.invokeAll(calls).stream().map(JsonSchemaTest::get).forEach(byIdentity::add);
 
-            assertThat(distinct).hasSize(1);
+            assertThat(byIdentity).hasSize(1);
         } finally {
             executor.shutdownNow();
         }

--- a/backend/core/src/main/resources/config/liquibase/13-44-0/13-44-0-master.xml
+++ b/backend/core/src/main/resources/config/liquibase/13-44-0/13-44-0-master.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <include file="20260826-add-process-link-process-definition-id-index.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/backend/core/src/main/resources/config/liquibase/13-44-0/20260826-add-process-link-process-definition-id-index.xml
+++ b/backend/core/src/main/resources/config/liquibase/13-44-0/20260826-add-process-link-process-definition-id-index.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2015-2026 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="1" author="Ritense">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="process_link" indexName="idx_process_link_process_definition_id"/>
+            </not>
+        </preConditions>
+        <createIndex tableName="process_link" indexName="idx_process_link_process_definition_id">
+            <column name="process_definition_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/backend/core/src/main/resources/config/liquibase/13-44-0/20260826-add-process-link-process-definition-id-index.xml
+++ b/backend/core/src/main/resources/config/liquibase/13-44-0/20260826-add-process-link-process-definition-id-index.xml
@@ -18,7 +18,7 @@
 <databaseChangeLog
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
     <changeSet id="1" author="Ritense">
         <preConditions onFail="MARK_RAN">

--- a/backend/core/src/main/resources/config/liquibase/changelog-master.xml
+++ b/backend/core/src/main/resources/config/liquibase/changelog-master.xml
@@ -36,5 +36,6 @@
     <include file="/13-38-0/13-38-0-master.xml" relativeToChangelogFile="true"/>
     <include file="/13-42-0/13-42-0-master.xml" relativeToChangelogFile="true"/>
     <include file="/13-43-0/13-43-0-master.xml" relativeToChangelogFile="true"/>
+    <include file="/13-44-0/13-44-0-master.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/documentation/release-notes/13.x.x/13.44.0/README.md
+++ b/documentation/release-notes/13.x.x/13.44.0/README.md
@@ -14,9 +14,11 @@ New feature explanation.
 
 ## Enhancements
 
-### New enhancement title
+### Faster document handling
 
-New enhancement explanation.
+Document schemas are now parsed once and reused instead of on every use, and process links are indexed on
+their process definition. Creating and updating cases, resolving document values and opening task forms are
+all faster, most noticeably on configurations with large document schemas or many process links.
 
 ---
 

--- a/documentation/release-notes/13.x.x/13.44.0/README.md
+++ b/documentation/release-notes/13.x.x/13.44.0/README.md
@@ -16,9 +16,8 @@ New feature explanation.
 
 ### Faster document handling
 
-Document schemas are now parsed once and reused instead of on every use, and process links are indexed on
-their process definition. Creating and updating cases, resolving document values and opening task forms are
-all faster, most noticeably on configurations with large document schemas or many process links.
+Creating and updating cases, resolving document values and opening task forms are all faster, most
+noticeably on configurations with large document schemas or many process links.
 
 ---
 


### PR DESCRIPTION
Needed for the future case migration feature. Will make migrating a case 3.4× faster

---
Opening and saving cases did more work than necessary: the document schema was rebuilt every
time it was used, and finding a process link meant searching through all of them.

Schemas are now reused once built, and process links are found directly. Creating and updating
cases, opening task forms and picking document fields are all noticeably faster, most of all on
configurations with large document schemas.