### PR TITLE
GH-876: Plugin configurations that had properties from older settings now have those properties removed on re-save

### DIFF
--- a/backend/plugin/src/main/kotlin/com/ritense/plugin/domain/PluginConfiguration.kt
+++ b/backend/plugin/src/main/kotlin/com/ritense/plugin/domain/PluginConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,14 @@ class PluginConfiguration(
     }
 
     fun updateProperties(propertiesForUpdate: ObjectNode) {
+        val definedFieldNames = pluginDefinition.properties.map { it.fieldName }.toSet()
+
+        properties?.fieldNames()?.asSequence()?.toList()?.forEach { existingKey ->
+            if (existingKey !in definedFieldNames) {
+                properties?.remove(existingKey)
+            }
+        }
+
         pluginDefinition.properties.forEach {
             val updateValue = propertiesForUpdate.get(it.fieldName)
             if (!it.secret || !nodeIsEmpty(updateValue)) {

--- a/backend/plugin/src/test/kotlin/com/ritense/plugin/domain/PluginConfigurationTest.kt
+++ b/backend/plugin/src/test/kotlin/com/ritense/plugin/domain/PluginConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,6 +188,44 @@ internal class PluginConfigurationTest {
         configuration.updateProperties(MapperSingleton.get().readTree(input) as ObjectNode)
 
         assertTrue(configuration.properties?.get("property3")!!.isNull)
+    }
+
+    @Test
+    fun `should remove properties no longer defined by plugin`() {
+        val deprecatedPropertyJson = """
+            {
+                "property1": "value",
+                "property2": false,
+                "property3": 123,
+                "deprecatedProperty": "should-be-removed",
+                "anotherOldProperty": true
+            }
+        """.trimMargin()
+
+        val configWithDeprecatedProps = PluginConfiguration(
+            PluginConfigurationId.newId(),
+            "title",
+            MapperSingleton.get().readTree(deprecatedPropertyJson) as ObjectNode,
+            configuration.pluginDefinition
+        )
+        configWithDeprecatedProps.objectMapper = MapperSingleton.get()
+        configWithDeprecatedProps.encryptionService = configuration.encryptionService
+
+        val updateInput = """
+            {
+                "property1": "new-value",
+                "property2": true,
+                "property3": 456
+            }
+        """.trimMargin()
+
+        configWithDeprecatedProps.updateProperties(MapperSingleton.get().readTree(updateInput) as ObjectNode)
+
+        assertEquals("new-value", configWithDeprecatedProps.properties?.get("property1")?.textValue())
+        assertEquals(true, configWithDeprecatedProps.properties?.get("property2")?.booleanValue())
+        assertEquals(456, configWithDeprecatedProps.properties?.get("property3")?.intValue())
+        assertTrue(configWithDeprecatedProps.properties?.has("deprecatedProperty") == false)
+        assertTrue(configWithDeprecatedProps.properties?.has("anotherOldProperty") == false)
     }
 
 }

--- a/documentation/release-notes/13.x.x/13.44.0/README.md
+++ b/documentation/release-notes/13.x.x/13.44.0/README.md
@@ -26,4 +26,5 @@ New enhancement explanation.
 |------|-----|
 | Cases | The process selector on the Progress tab shows long process names in full instead of cutting them off |
 | Cases | The progress tab shows the name of every process, instead of leaving some blank |
+| Plugins | Re-saving a plugin configuration removes settings from older versions that are no longer used |
 | Plugins | Required fields such as the authentication configuration have to be filled in before a plugin configuration can be saved |


### PR DESCRIPTION
Re-saving a plugin configuration removes settings from older versions that are no longer used
Solves  https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/876