### PR TITLE
GHi-665: Check object permissions before calling the Objecten API

### DIFF
--- a/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/client/ObjectenApiClient.kt
+++ b/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/client/ObjectenApiClient.kt
@@ -52,13 +52,15 @@ class ObjectenApiClient(
         authentication: ObjectenApiAuthentication,
         objectUrl: URI
     ): ObjectWrapper {
-        authorizationService.requirePermission(
-            EntityAuthorizationRequest(
-                Object::class.java,
-                ObjectActionProvider.VIEW,
-                Object()
+        if (authorizationEnabled) {
+            authorizationService.requirePermission(
+                EntityAuthorizationRequest(
+                    Object::class.java,
+                    ObjectActionProvider.VIEW,
+                    Object()
+                )
             )
-        )
+        }
 
         val result = buildRestClient(authentication)
             .get()

--- a/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/client/ObjectenApiClient.kt
+++ b/backend/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/client/ObjectenApiClient.kt
@@ -52,21 +52,19 @@ class ObjectenApiClient(
         authentication: ObjectenApiAuthentication,
         objectUrl: URI
     ): ObjectWrapper {
+        authorizationService.requirePermission(
+            EntityAuthorizationRequest(
+                Object::class.java,
+                ObjectActionProvider.VIEW,
+                Object()
+            )
+        )
+
         val result = buildRestClient(authentication)
             .get()
             .uri(objectUrl)
             .retrieve()
             .body<ObjectWrapper>()!!
-
-        if (authorizationEnabled) {
-            authorizationService.requirePermission(
-                EntityAuthorizationRequest(
-                    Object::class.java,
-                    ObjectActionProvider.VIEW,
-                    Object()
-                )
-            )
-        }
 
         outboxService.send {
             ObjectViewed(
@@ -82,6 +80,16 @@ class ObjectenApiClient(
         objectUrl: URI,
         index: Int
     ): ObjectRecord {
+        if (authorizationEnabled) {
+            authorizationService.requirePermission(
+                EntityAuthorizationRequest(
+                    Object::class.java,
+                    ObjectActionProvider.VIEW,
+                    Object()
+                )
+            )
+        }
+
         val recordUrl = UriComponentsBuilder
             .fromUri(objectUrl)
             .pathSegment(index.toString())
@@ -93,16 +101,6 @@ class ObjectenApiClient(
             .uri(recordUrl)
             .retrieve()
             .body<ObjectRecord>()!!
-
-        if (authorizationEnabled) {
-            authorizationService.requirePermission(
-                EntityAuthorizationRequest(
-                    Object::class.java,
-                    ObjectActionProvider.VIEW,
-                    Object()
-                )
-            )
-        }
 
         outboxService.send {
             ObjectViewed(
@@ -121,6 +119,16 @@ class ObjectenApiClient(
         ordering: String? = "",
         pageable: Pageable
     ): ObjectsList {
+        if (authorizationEnabled) {
+            authorizationService.requirePermission(
+                EntityAuthorizationRequest(
+                    Object::class.java,
+                    ObjectActionProvider.VIEW_LIST,
+                    Object()
+                )
+            )
+        }
+
         val objectTypeUrl = UriComponentsBuilder.newInstance()
             .uri(objecttypesApiUrl)
             .host(objecttypesApiUrl.host)
@@ -142,16 +150,6 @@ class ObjectenApiClient(
             .retrieve()
             .body<ObjectsList>()!!
 
-        if (authorizationEnabled) {
-            authorizationService.requirePermission(
-                EntityAuthorizationRequest(
-                    Object::class.java,
-                    ObjectActionProvider.VIEW_LIST,
-                    Object()
-                )
-            )
-        }
-
         outboxService.send {
             ObjectsListed(
                 objectMapper.valueToTree(result.results)
@@ -169,6 +167,16 @@ class ObjectenApiClient(
         ordering: String? = "",
         pageable: Pageable
     ): ObjectsList {
+        if (authorizationEnabled) {
+            authorizationService.requirePermission(
+                EntityAuthorizationRequest(
+                    Object::class.java,
+                    ObjectActionProvider.VIEW_LIST,
+                    Object()
+                )
+            )
+        }
+
         val objectTypeUrl = UriComponentsBuilder.newInstance()
             .uri(objecttypesApiUrl)
             .host(objecttypesApiUrl.host)
@@ -190,16 +198,6 @@ class ObjectenApiClient(
             .header(ACCEPT_CRS, EPSG_4326)
             .retrieve()
             .body<ObjectsList>()!!
-
-        if (authorizationEnabled) {
-            authorizationService.requirePermission(
-                EntityAuthorizationRequest(
-                    Object::class.java,
-                    ObjectActionProvider.VIEW_LIST,
-                    Object()
-                )
-            )
-        }
 
         outboxService.send {
             ObjectsListed(

--- a/backend/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/client/ObjectenApiClientTest.kt
+++ b/backend/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/client/ObjectenApiClientTest.kt
@@ -45,8 +45,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
@@ -54,6 +55,7 @@ import org.mockito.kotlin.verify
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.data.domain.PageRequest
 import org.springframework.web.client.HttpClientErrorException
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.client.RestClient
 import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ClientResponse
@@ -304,6 +306,27 @@ internal class ObjectenApiClientTest {
     }
 
     @Test
+    fun `should throw exception and not call api when not authorized to get object`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObject(
+                TestAuthentication(),
+                deniedApi.url("/some-object").toUri()
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception and not call api when not authorized to get objectrecord`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObjectRecord(
+                TestAuthentication(),
+                deniedApi.url("/some-object").toUri(),
+                2
+            )
+        }
+    }
+
+    @Test
     fun `should get objectslist`() {
         val client = ObjectenApiClient(restClientBuilder, outboxService, objectMapper, authorizationService, false)
 
@@ -471,6 +494,20 @@ internal class ObjectenApiClientTest {
     }
 
     @Test
+    fun `should throw exception and not call api when not authorized to get objects by object type url`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObjectsByObjecttypeUrl(
+                TestAuthentication(),
+                deniedApi.url("/some-object").toUri(),
+                deniedApi.url("/some-objectTypesApi").toUri(),
+                "typeId",
+                "",
+                PageRequest.of(0, 10)
+            )
+        }
+    }
+
+    @Test
     fun `should send outbox message when getting objects by object type url with search params`() {
         val client = ObjectenApiClient(restClientBuilder, outboxService, objectMapper, authorizationService, false)
 
@@ -561,6 +598,21 @@ internal class ObjectenApiClientTest {
         mockApi.takeRequest()
 
         verify(outboxService, times(0)).send(eventCapture.capture())
+    }
+
+    @Test
+    fun `should throw exception and not call api when not authorized to get objects by object type url with search params`() {
+        assertReadDeniedWithoutCallingApi { client, deniedApi ->
+            client.getObjectsByObjecttypeUrlWithSearchParams(
+                authentication = TestAuthentication(),
+                objecttypesApiUrl = deniedApi.url("/some-object").toUri(),
+                objectsApiUrl = deniedApi.url("/some-objectTypesApi").toUri(),
+                objectypeId = "typeId",
+                searchString = "test",
+                ordering = "ordering",
+                pageable = PageRequest.of(0, 10)
+            )
+        }
     }
 
     @Test
@@ -1116,6 +1168,29 @@ internal class ObjectenApiClientTest {
         return MockResponse()
             .addHeader("Content-Type", "application/json")
             .setBody(body)
+    }
+
+    private fun assertReadDeniedWithoutCallingApi(invoke: (ObjectenApiClient, MockWebServer) -> Unit) {
+        val deniedApi = MockWebServer()
+        deniedApi.start()
+        try {
+            deniedApi.enqueue(mockResponse("").setResponseCode(404))
+
+            val deniedAuthorizationService: AuthorizationService = mock {
+                on { this.requirePermission<Any>(any()) } doThrow org.springframework.security.access.AccessDeniedException(
+                    "Unauthorized"
+                )
+            }
+            val client =
+                ObjectenApiClient(restClientBuilder, outboxService, objectMapper, deniedAuthorizationService, true)
+
+            assertThrows<AccessDeniedException> { invoke(client, deniedApi) }
+
+            assertEquals(0, deniedApi.requestCount)
+            verify(outboxService, times(0)).send(any())
+        } finally {
+            deniedApi.shutdown()
+        }
     }
 
     class TestAuthentication : ObjectenApiAuthentication {

--- a/documentation/release-notes/12.x.x/12.44.0/README.md
+++ b/documentation/release-notes/12.x.x/12.44.0/README.md
@@ -14,4 +14,6 @@
 
 ## Bugfixes
 
-* New bugfix.
+* **Object permissions are checked before the object is retrieved**
+
+  A user without permission to view objects is now refused before anything is requested from the Objecten API.


### PR DESCRIPTION
Solves https://github.com/generiekzaakafhandelcomponent/atlas-internal/issues/665