### PR TITLE
Restore the endpoint descriptions dropped by the next-minor merge

### DIFF
--- a/backend/core/src/main/kotlin/com/ritense/valtimo/processbean/web/rest/ProcessBeanResource.kt
+++ b/backend/core/src/main/kotlin/com/ritense/valtimo/processbean/web/rest/ProcessBeanResource.kt
@@ -18,6 +18,7 @@ package com.ritense.valtimo.processbean.web.rest
 
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.domain.ValtimoMediaType.APPLICATION_JSON_UTF8_VALUE
+import com.ritense.valtimo.contract.endpoint.EndpointDescription
 import com.ritense.valtimo.processbean.ProcessBeanService
 import com.ritense.valtimo.processbean.dto.ProcessBeanDto
 import org.springframework.http.ResponseEntity
@@ -32,11 +33,19 @@ import org.springframework.web.bind.annotation.RestController
 class ProcessBeanResource(
     private val processBeanService: ProcessBeanService
 ) {
+    @EndpointDescription(
+        en = "List process beans",
+        nl = "Procesbeans ophalen",
+    )
     @GetMapping("/management/v1/process-bean")
     fun getProcessBeans(): ResponseEntity<List<ProcessBeanDto>> {
         return ResponseEntity.ok(processBeanService.getProcessBeans())
     }
 
+    @EndpointDescription(
+        en = "Get process bean by name",
+        nl = "Procesbean ophalen per naam",
+    )
     @GetMapping("/management/v1/process-bean/{beanName}")
     fun getProcessBean(
         @PathVariable beanName: String

--- a/backend/process-link/src/main/kotlin/com/ritense/processlink/web/rest/CaseProcessDefinitionManagementResource.kt
+++ b/backend/process-link/src/main/kotlin/com/ritense/processlink/web/rest/CaseProcessDefinitionManagementResource.kt
@@ -28,6 +28,7 @@ import com.ritense.valtimo.operaton.domain.OperatonProcessDefinition
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
 import com.ritense.valtimo.contract.domain.ValtimoMediaType.APPLICATION_JSON_UTF8_VALUE
+import com.ritense.valtimo.contract.endpoint.EndpointDescription
 import com.ritense.valtimo.service.OperatonProcessService
 import com.ritense.valtimo.web.rest.dto.ProcessDefinitionWithPropertiesDto
 import org.springframework.http.HttpStatus
@@ -61,6 +62,10 @@ class CaseProcessDefinitionManagementResource(
     private val assembler: ProcessDefinitionResponseAssembler,
 ) {
 
+    @EndpointDescription(
+        en = "List process definitions with links by case definition",
+        nl = "Procesdefinities met koppelingen per dossierdefinitie ophalen",
+    )
     @GetMapping(
         value = ["/management/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/process-definition"],
     )
@@ -93,6 +98,10 @@ class CaseProcessDefinitionManagementResource(
         return ResponseEntity.ok(definitions)
     }
 
+    @EndpointDescription(
+        en = "Get process definition by key with links",
+        nl = "Procesdefinitie per sleutel met koppelingen ophalen",
+    )
     @GetMapping(
         value = ["/management/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/process-definition/key/{processDefinitionKey}"]
     )
@@ -125,6 +134,10 @@ class CaseProcessDefinitionManagementResource(
         return ResponseEntity.ok(responseDto)
     }
 
+    @EndpointDescription(
+        en = "Delete process definitions and links by key",
+        nl = "Procesdefinities en koppelingen per sleutel verwijderen",
+    )
     @DeleteMapping(
         value = ["/management/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/process-definition/key/{processDefinitionKey}"],
     )
@@ -152,6 +165,10 @@ class CaseProcessDefinitionManagementResource(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
+    @EndpointDescription(
+        en = "Deploy process definition and links for case definition",
+        nl = "Procesdefinitie en koppelingen voor dossierdefinitie uitrollen",
+    )
     @PostMapping(
         value = ["/management/v1/case-definition/{caseDefinitionKey}/version/{caseDefinitionVersionTag}/process-definition"],
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
@@ -186,6 +203,10 @@ class CaseProcessDefinitionManagementResource(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
+    @EndpointDescription(
+        en = "Update process definition and links for case definition",
+        nl = "Procesdefinitie en koppelingen voor dossierdefinitie bijwerken",
+    )
     @PutMapping(
         value = ["/management/v1/case-definition/{caseDefinitionKey}/version/{caseDefinitionVersionTag}/process-definition"],
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],

--- a/backend/process-link/src/main/kotlin/com/ritense/processlink/web/rest/ProcessDefinitionManagementResource.kt
+++ b/backend/process-link/src/main/kotlin/com/ritense/processlink/web/rest/ProcessDefinitionManagementResource.kt
@@ -40,6 +40,7 @@ import com.ritense.processlink.web.rest.dto.ProcessDefinitionValidateResponseDto
 import com.ritense.valtimo.operaton.domain.OperatonProcessDefinition
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.domain.ValtimoMediaType.APPLICATION_JSON_UTF8_VALUE
+import com.ritense.valtimo.contract.endpoint.EndpointDescription
 import com.ritense.valtimo.processautofill.service.ProcessDefinitionAutofillService
 import com.ritense.valtimo.service.OperatonProcessService
 import com.ritense.valtimo.service.ProcessPropertyService
@@ -88,6 +89,10 @@ class ProcessDefinitionManagementResource(
     private val assembler: ProcessDefinitionResponseAssembler,
 ) {
 
+    @EndpointDescription(
+        en = "List unlinked process definitions with links",
+        nl = "Ongekoppelde procesdefinities met koppelingen ophalen",
+    )
     @GetMapping("/management/v1/process-definition")
     @Transactional
     fun getUnlinkedProcessDefinitionsAndProcessLinks(): ResponseEntity<List<ProcessDefinitionResponseDto>> {
@@ -110,6 +115,10 @@ class ProcessDefinitionManagementResource(
         return ResponseEntity.ok(definitions)
     }
 
+    @EndpointDescription(
+        en = "List unlinked process definitions by key",
+        nl = "Ongekoppelde procesdefinities per sleutel ophalen",
+    )
     @GetMapping("/management/v1/process-definition/key/{processDefinitionKey}")
     @Transactional
     fun getUnlinkedProcessDefinitionsByKeyList(
@@ -132,6 +141,10 @@ class ProcessDefinitionManagementResource(
         return ResponseEntity.ok(responseDtos)
     }
 
+    @EndpointDescription(
+        en = "List global process definitions with links by key",
+        nl = "Globale procesdefinities met koppelingen per sleutel ophalen",
+    )
     @GetMapping("/management/v1/process-definition/{processDefinitionKey}")
     @Transactional
     fun getUnlinkedProcessDefinitionsWithLinks(
@@ -151,6 +164,10 @@ class ProcessDefinitionManagementResource(
         return ResponseEntity.ok(responseDto)
     }
 
+    @EndpointDescription(
+        en = "Delete unlinked process definitions and links by key",
+        nl = "Ongekoppelde procesdefinities en koppelingen per sleutel verwijderen",
+    )
     @DeleteMapping("/management/v1/process-definition/key/{processDefinitionKey}")
     @Transactional
     fun deleteUnlinkedProcessDefinitionsAndLinksByKey(
@@ -167,6 +184,10 @@ class ProcessDefinitionManagementResource(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
+    @EndpointDescription(
+        en = "Deploy unlinked process definition and links",
+        nl = "Ongekoppelde procesdefinitie en koppelingen uitrollen",
+    )
     @PostMapping(
         value = ["/management/v1/process-definition"],
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
@@ -194,6 +215,10 @@ class ProcessDefinitionManagementResource(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
+    @EndpointDescription(
+        en = "Update unlinked process definition and links",
+        nl = "Ongekoppelde procesdefinitie en koppelingen bijwerken",
+    )
     @PutMapping(
         value = ["/management/v1/process-definition"],
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
@@ -215,6 +240,10 @@ class ProcessDefinitionManagementResource(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
+    @EndpointDescription(
+        en = "Validate a BPMN process definition and its process links",
+        nl = "Een BPMN-procesdefinitie en de bijbehorende proceskoppelingen valideren",
+    )
     @PostMapping(
         value = ["/management/v1/process-definition/validate"],
         consumes = [MediaType.APPLICATION_JSON_VALUE],
@@ -238,6 +267,10 @@ class ProcessDefinitionManagementResource(
         )
     }
 
+    @EndpointDescription(
+        en = "Export process definition and referenced elements",
+        nl = "Procesdefinitie en gerefereerde elementen exporteren",
+    )
     @GetMapping(
         value = ["/management/v1/process-definition/{processDefinitionId}/export"],
         produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE]
@@ -258,6 +291,10 @@ class ProcessDefinitionManagementResource(
         }
     }
 
+    @EndpointDescription(
+        en = "Preview process definition import",
+        nl = "Import van procesdefinitie vooraf bekijken",
+    )
     @PostMapping("/management/v1/process-definition/import/preview")
     fun previewProcessDefinitionImport(
         @RequestParam("file") file: MultipartFile
@@ -270,6 +307,10 @@ class ProcessDefinitionManagementResource(
         }
     }
 
+    @EndpointDescription(
+        en = "Import process definition and referenced elements",
+        nl = "Procesdefinitie en gerefereerde elementen importeren",
+    )
     @PostMapping("/management/v1/process-definition/import")
     fun importProcessDefinition(
         @RequestParam("file") file: MultipartFile,
@@ -304,6 +345,10 @@ class ProcessDefinitionManagementResource(
         }
     }
 
+    @EndpointDescription(
+        en = "Delete autofill of a process definition activity",
+        nl = "Automatisch invullen van procesdefinitie-activiteit verwijderen",
+    )
     @DeleteMapping("/management/v1/process-definition/{processDefinitionId}/autofill/{activityId}")
     fun deleteAutofill(
         @LoggableResource(resourceType = OperatonProcessDefinition::class) @PathVariable processDefinitionId: String,

--- a/backend/process-link/src/main/kotlin/com/ritense/processlink/web/rest/ProcessLinkResource.kt
+++ b/backend/process-link/src/main/kotlin/com/ritense/processlink/web/rest/ProcessLinkResource.kt
@@ -29,6 +29,7 @@ import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import com.ritense.valtimo.operaton.domain.OperatonProcessDefinition
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.domain.ValtimoMediaType.APPLICATION_JSON_UTF8_VALUE
+import com.ritense.valtimo.contract.endpoint.EndpointDescription
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -55,6 +56,10 @@ class ProcessLinkResource(
     private val processLinkService: ProcessLinkService,
 ) {
 
+    @EndpointDescription(
+        en = "List process links",
+        nl = "Proceskoppelingen ophalen",
+    )
     @GetMapping("/v1/process-link")
     fun getProcessLinks(
         @LoggableResource(resourceType = OperatonProcessDefinition::class) @RequestParam("processDefinitionId") processDefinitionId: String,
@@ -69,6 +74,10 @@ class ProcessLinkResource(
         return ResponseEntity.ok(list)
     }
 
+    @EndpointDescription(
+        en = "List supported process link types",
+        nl = "Ondersteunde proceskoppelingstypen ophalen",
+    )
     @GetMapping("/v1/process-link/types")
     fun getSupportedProcessLinkTypes(
         @RequestParam(name = "activityType") activityType: String
@@ -76,6 +85,10 @@ class ProcessLinkResource(
         return ResponseEntity.ok(processLinkService.getSupportedProcessLinkTypes(activityType))
     }
 
+    @EndpointDescription(
+        en = "Create process link",
+        nl = "Proceskoppeling aanmaken",
+    )
     @PostMapping("/v1/process-link")
     fun createProcessLink(
         @Valid @RequestBody processLink: ProcessLinkCreateRequestDto
@@ -86,6 +99,10 @@ class ProcessLinkResource(
         }
     }
 
+    @EndpointDescription(
+        en = "Update process link",
+        nl = "Proceskoppeling bijwerken",
+    )
     @PutMapping("/v1/process-link")
     fun updateProcessLink(
         @Valid @RequestBody processLink: ProcessLinkUpdateRequestDto
@@ -96,6 +113,10 @@ class ProcessLinkResource(
         }
     }
 
+    @EndpointDescription(
+        en = "Delete process link",
+        nl = "Proceskoppeling verwijderen",
+    )
     @DeleteMapping("/v1/process-link/{processLinkId}")
     fun deleteProcessLink(
         @LoggableResource(resourceType = ProcessLink::class) @PathVariable(name = "processLinkId") processLinkId: UUID
@@ -105,6 +126,10 @@ class ProcessLinkResource(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
+    @EndpointDescription(
+        en = "Export process links",
+        nl = "Proceskoppelingen exporteren",
+    )
     @Deprecated("Since 12.7.0")
     @GetMapping("/v1/process-link/export")
     fun exportProcessLinks(


### PR DESCRIPTION
### Describe the changes

Restores the `@EndpointDescription` annotations that were silently dropped when `next-minor` was merged into `feature/external-plugin-system`.
