### PR TITLE
Harden test environment management GH workflows

### DIFF
--- a/.github/workflows/handle_test_env_pr_close.yml
+++ b/.github/workflows/handle_test_env_pr_close.yml
@@ -12,8 +12,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  delete_test_env_if_labeled:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test env') }}
+  delete_test_env:
     uses: ./.github/workflows/delete_test_env.yml
     secrets: inherit
     with:


### PR DESCRIPTION
GH actions has a severe limit on the PR events it's emitting.
More specific, it won't emit events in case the PR is in
merge-conflict. This PR makes a change to cater for this.

We're removing the condition earlier set up to check for the
existence of a 'test env' label. We now do a final cleanup
regardless of any labels being there or not.

This covers the following scenario:
1. PR created
2. 'test env' label added
3. test env has been created
4. merge conflict happens
5. test env label is removed
6. GitHub action with trigger pull_request: unlabeled aren't ran
7. merge conflict is resolved
8. PR is closed
9. GitHub action to cleanup isn't ran since there's no 'test env' label

More on this issue here:
https://github.com/orgs/community/discussions/26304
and here (2nd bullet in note section):
https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
