### PR TITLE
Fix: non-portable vendor stylesheet import in @valtimo/components

### DIFF
--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -28,4 +28,3 @@ New enhancement explanation.
 | Case migration | The source and target version dropdowns offer every version of the selected case again, instead of only one |
 | Plugins | The verzoek plugin offers every case version again when picking one, instead of only the active one |
 | Case definitions | Versions are ordered by version number rather than alphabetically, so 1.0.10 comes after 1.0.9 |
-| Frontend libraries | Applications built on the Valtimo frontend packages now compile no matter which package manager or project layout they use |

--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -28,3 +28,4 @@ New enhancement explanation.
 | Case migration | The source and target version dropdowns offer every version of the selected case again, instead of only one |
 | Plugins | The verzoek plugin offers every case version again when picking one, instead of only the active one |
 | Case definitions | Versions are ordered by version number rather than alphabetically, so 1.0.10 comes after 1.0.9 |
+| Frontend libraries | Applications built on the Valtimo frontend packages now compile no matter which package manager or project layout they use |

--- a/frontend/projects/valtimo/components/assets/css/carbon.scss
+++ b/frontend/projects/valtimo/components/assets/css/carbon.scss
@@ -109,11 +109,7 @@ $darkThemeOverwriteVariables: (
 
 @use '@carbon/styles';
 @use '@carbon/grid';
-/* Loaded as a module, so the specifier is resolved against this file's own location
-   at compile time. A plain CSS @import is instead emitted verbatim and left to the
-   consuming app's bundler, which resolves it from that app's stylesheet and cannot
-   reach this package's dependencies. The alias is required: the namespace derived
-   from the filename would collide with '@carbon/styles' above. */
+/* @use so the path resolves here, not in the consuming app; aliased to avoid a namespace clash */
 @use '@carbon/charts-angular/styles.min.css' as chart-styles;
 @include grid.flex-grid();
 

--- a/frontend/projects/valtimo/components/assets/css/carbon.scss
+++ b/frontend/projects/valtimo/components/assets/css/carbon.scss
@@ -109,6 +109,12 @@ $darkThemeOverwriteVariables: (
 
 @use '@carbon/styles';
 @use '@carbon/grid';
+/* Loaded as a module, so the specifier is resolved against this file's own location
+   at compile time. A plain CSS @import is instead emitted verbatim and left to the
+   consuming app's bundler, which resolves it from that app's stylesheet and cannot
+   reach this package's dependencies. The alias is required: the namespace derived
+   from the filename would collide with '@carbon/styles' above. */
+@use '@carbon/charts-angular/styles.min.css' as chart-styles;
 @include grid.flex-grid();
 
 /* Extended tag colours, beyond the ten colours Carbon ships for tags. They follow Carbon's own tag
@@ -200,8 +206,6 @@ $extendedTagColors: (
     @include extended-tag-tokens(dark);
   }
 }
-
-@import 'node_modules/@carbon/charts-angular/styles.min.css';
 
 /* default Valtimo colors */
 


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/757

## Bug

Teams building their own Angular application on top of the published Valtimo frontend packages
could not compile it. Pulling in the Valtimo stylesheet failed with an error about a Carbon
chart stylesheet that could not be found, so the build stopped.

## Fix

The stylesheet now loads its Carbon chart styles in a way that works from any project, so those
applications build again. There is no visual change.

Assumption: the ticket suggested keeping this as a plain stylesheet import with a shortened path.
That form still fails for pnpm-based projects, which the ticket also asks to support, so the
stylesheet is loaded as a module instead.

Not verified: the repository has no automated check for this, so it is covered by building real
consumer applications rather than by a test in this branch.
