### PR TITLE
Fix: no error logged when a process ends while a user task is open

### DIFF
--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/sse/autoconfigure/SseAutoConfiguration.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/sse/autoconfigure/SseAutoConfiguration.kt
@@ -20,6 +20,7 @@ import com.ritense.document.service.DocumentService
 import com.ritense.processdocument.service.ProcessDocumentService
 import com.ritense.processdocument.sse.domain.listener.TaskUpdateListener
 import com.ritense.valtimo.contract.document.CaseDocumentResolver
+import com.ritense.valtimo.service.OperatonProcessService
 import com.ritense.valtimo.service.OperatonTaskService
 import com.ritense.valtimo.web.sse.service.SseSubscriptionService
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -37,12 +38,14 @@ class SseAutoConfiguration {
         caseDocumentResolver: CaseDocumentResolver,
         documentService: DocumentService,
         operatonTaskService: OperatonTaskService,
+        operatonProcessService: OperatonProcessService,
     ) = TaskUpdateListener(
         sseSubscriptionService,
         processDocumentService,
         caseDocumentResolver,
         documentService,
         operatonTaskService,
+        operatonProcessService,
     )
 
 }

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListener.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListener.kt
@@ -51,16 +51,33 @@ class TaskUpdateListener(
         fallbackExecution = true
     )
     fun handle(taskEvent: TaskEvent) {
-        val document = processDocumentService.getDocument(OperatonProcessInstanceId(taskEvent.processInstanceId), null)
-        notifyTaskUpdate(taskEvent.id, document)
+        val document = resolveDocumentOrNull(taskEvent.id) {
+            processDocumentService.getDocument(OperatonProcessInstanceId(taskEvent.processInstanceId), null)
+        }
+        if (document != null) {
+            notifyTaskUpdate(taskEvent.id, document)
+        }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     fun handleTeamAssignment(event: TaskTeamAssignedEvent): Unit = runWithoutAuthorization {
-        val task = operatonTaskService.findTaskById(event.taskId)
-        val processInstanceId = OperatonProcessInstanceId(task.getProcessInstanceId())
-        val document = processDocumentService.getDocument(processInstanceId, task)
-        notifyTaskUpdate(event.taskId, document)
+        val document = resolveDocumentOrNull(event.taskId) {
+            val task = operatonTaskService.findTaskById(event.taskId)
+            processDocumentService.getDocument(OperatonProcessInstanceId(task.getProcessInstanceId()), task)
+        }
+        if (document != null) {
+            notifyTaskUpdate(event.taskId, document)
+        }
+    }
+
+    // Both listeners run after commit, so the process instance may already have ended and be gone.
+    private fun resolveDocumentOrNull(taskId: String, resolve: () -> Document): Document? {
+        return try {
+            resolve()
+        } catch (e: Exception) {
+            logger.debug(e) { "Could not resolve the document for task $taskId, skipping the task update notification" }
+            null
+        }
     }
 
     private fun notifyTaskUpdate(taskId: String, document: Document) {
@@ -79,7 +96,7 @@ class TaskUpdateListener(
                 )
             )
         } catch (e: Exception) {
-            logger.error(e) { "Failed to send SSE notification for team assignment on task $taskId" }
+            logger.error(e) { "Failed to send SSE notification for task update on task $taskId" }
         }
     }
 

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListener.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListener.kt
@@ -25,6 +25,8 @@ import com.ritense.processdocument.sse.event.TaskUpdateSseEvent
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.document.CaseDocumentResolver
 import com.ritense.valtimo.contract.event.TaskTeamAssignedEvent
+import com.ritense.valtimo.security.exceptions.TaskNotFoundException
+import com.ritense.valtimo.service.OperatonProcessService
 import com.ritense.valtimo.service.OperatonTaskService
 import com.ritense.valtimo.web.sse.service.SseSubscriptionService
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -41,6 +43,7 @@ class TaskUpdateListener(
     private val caseDocumentResolver: CaseDocumentResolver,
     private val documentService: DocumentService,
     private val operatonTaskService: OperatonTaskService,
+    private val operatonProcessService: OperatonProcessService,
 ) {
 
     @TransactionalEventListener(
@@ -51,34 +54,38 @@ class TaskUpdateListener(
         fallbackExecution = true
     )
     fun handle(taskEvent: TaskEvent) {
-        val document = resolveDocumentOrNull(taskEvent.id) {
+        resolveAndNotify(taskEvent.id, taskEvent.processInstanceId) {
             processDocumentService.getDocument(OperatonProcessInstanceId(taskEvent.processInstanceId), null)
-        }
-        if (document != null) {
-            notifyTaskUpdate(taskEvent.id, document)
         }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     fun handleTeamAssignment(event: TaskTeamAssignedEvent): Unit = runWithoutAuthorization {
-        val document = resolveDocumentOrNull(event.taskId) {
-            val task = operatonTaskService.findTaskById(event.taskId)
-            processDocumentService.getDocument(OperatonProcessInstanceId(task.getProcessInstanceId()), task)
+        val task = try {
+            operatonTaskService.findTaskById(event.taskId)
+        } catch (e: TaskNotFoundException) {
+            logger.debug(e) { "Task ${event.taskId} no longer exists, skipping the task update notification" }
+            return@runWithoutAuthorization
         }
-        if (document != null) {
-            notifyTaskUpdate(event.taskId, document)
+        resolveAndNotify(event.taskId, task.getProcessInstanceId()) {
+            processDocumentService.getDocument(OperatonProcessInstanceId(task.getProcessInstanceId()), task)
         }
     }
 
-    // Both listeners run after commit, so the process instance may already have ended and be gone.
-    private fun resolveDocumentOrNull(taskId: String, resolve: () -> Document): Document? {
-        return try {
-            resolve()
+    // Both listeners run after commit, so the process instance may have ended in the very transaction that fired the event.
+    private fun resolveAndNotify(taskId: String, processInstanceId: String, resolveDocument: () -> Document) {
+        val document = try {
+            resolveDocument()
         } catch (e: Exception) {
-            logger.debug(e) { "Could not resolve the document for task $taskId, skipping the task update notification" }
-            null
+            if (processInstanceExists(processInstanceId)) throw e
+            logger.debug(e) { "Process instance $processInstanceId has ended, skipping the task update notification for task $taskId" }
+            return
         }
+        notifyTaskUpdate(taskId, document)
     }
+
+    private fun processInstanceExists(processInstanceId: String) =
+        runWithoutAuthorization { operatonProcessService.findProcessInstanceById(processInstanceId).isPresent }
 
     private fun notifyTaskUpdate(taskId: String, document: Document) {
         try {

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListenerTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListenerTest.kt
@@ -24,10 +24,13 @@ import com.ritense.processdocument.sse.event.TaskUpdateSseEvent
 import com.ritense.valtimo.contract.document.CaseDocumentResolver
 import com.ritense.valtimo.contract.event.TaskTeamAssignedEvent
 import com.ritense.valtimo.operaton.domain.OperatonTask
+import com.ritense.valtimo.security.exceptions.TaskNotFoundException
+import com.ritense.valtimo.service.OperatonProcessService
 import com.ritense.valtimo.service.OperatonTaskService
 import com.ritense.valtimo.web.sse.service.SseSubscriptionService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
@@ -35,7 +38,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.operaton.bpm.engine.runtime.ProcessInstance
 import org.operaton.bpm.spring.boot.starter.event.TaskEvent
+import java.util.Optional
 import java.util.UUID
 import kotlin.test.assertEquals
 
@@ -46,6 +51,7 @@ class TaskUpdateListenerTest {
     lateinit var caseDocumentResolver: CaseDocumentResolver
     lateinit var documentService: DocumentService
     lateinit var operatonTaskService: OperatonTaskService
+    lateinit var operatonProcessService: OperatonProcessService
     lateinit var taskUpdateListener: TaskUpdateListener
 
     @BeforeEach
@@ -55,12 +61,14 @@ class TaskUpdateListenerTest {
         caseDocumentResolver = mock()
         documentService = mock()
         operatonTaskService = mock()
+        operatonProcessService = mock()
         taskUpdateListener = TaskUpdateListener(
             sseSubscriptionService,
             processDocumentService,
             caseDocumentResolver,
             documentService,
             operatonTaskService,
+            operatonProcessService,
         )
     }
 
@@ -185,8 +193,27 @@ class TaskUpdateListenerTest {
 
         whenever(processDocumentService.getDocument(any(), anyOrNull()))
             .thenThrow(RuntimeException("Process instance not found by id $processInstanceId"))
+        whenever(operatonProcessService.findProcessInstanceById(processInstanceId)).thenReturn(Optional.empty())
 
         taskUpdateListener.handle(taskEvent)
+
+        verify(sseSubscriptionService, never()).notifySubscribers(any())
+    }
+
+    @Test
+    fun `should rethrow when the document cannot be resolved for a running process instance`() {
+        val taskId = UUID.randomUUID().toString()
+        val processInstanceId = UUID.randomUUID().toString()
+
+        val taskEvent = mock<TaskEvent>()
+        whenever(taskEvent.id).thenReturn(taskId)
+        whenever(taskEvent.processInstanceId).thenReturn(processInstanceId)
+
+        whenever(processDocumentService.getDocument(any(), anyOrNull())).thenThrow(RuntimeException("Something broke"))
+        whenever(operatonProcessService.findProcessInstanceById(processInstanceId))
+            .thenReturn(Optional.of(mock<ProcessInstance>()))
+
+        assertThrows<RuntimeException> { taskUpdateListener.handle(taskEvent) }
 
         verify(sseSubscriptionService, never()).notifySubscribers(any())
     }
@@ -195,7 +222,7 @@ class TaskUpdateListenerTest {
     fun `should not notify when the team assigned task can no longer be found`() {
         val taskId = UUID.randomUUID().toString()
 
-        whenever(operatonTaskService.findTaskById(taskId)).thenThrow(RuntimeException("Task not found by id $taskId"))
+        whenever(operatonTaskService.findTaskById(taskId)).thenThrow(TaskNotFoundException(taskId))
 
         taskUpdateListener.handleTeamAssignment(TaskTeamAssignedEvent(taskId, null, null, "INTAKE_TEAM", "Intake Team"))
 

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListenerTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/sse/domain/listener/TaskUpdateListenerTest.kt
@@ -32,6 +32,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.operaton.bpm.spring.boot.starter.event.TaskEvent
@@ -171,6 +172,34 @@ class TaskUpdateListenerTest {
         assertEquals(taskId, sseEvent.taskId)
         assertEquals(caseDocumentId.toString(), sseEvent.documentId)
         assertEquals(caseDefinitionKey, sseEvent.caseDefinitionKey)
+    }
+
+    @Test
+    fun `should not notify when the process instance has already ended`() {
+        val taskId = UUID.randomUUID().toString()
+        val processInstanceId = UUID.randomUUID().toString()
+
+        val taskEvent = mock<TaskEvent>()
+        whenever(taskEvent.id).thenReturn(taskId)
+        whenever(taskEvent.processInstanceId).thenReturn(processInstanceId)
+
+        whenever(processDocumentService.getDocument(any(), anyOrNull()))
+            .thenThrow(RuntimeException("Process instance not found by id $processInstanceId"))
+
+        taskUpdateListener.handle(taskEvent)
+
+        verify(sseSubscriptionService, never()).notifySubscribers(any())
+    }
+
+    @Test
+    fun `should not notify when the team assigned task can no longer be found`() {
+        val taskId = UUID.randomUUID().toString()
+
+        whenever(operatonTaskService.findTaskById(taskId)).thenThrow(RuntimeException("Task not found by id $taskId"))
+
+        taskUpdateListener.handleTeamAssignment(TaskTeamAssignedEvent(taskId, null, null, "INTAKE_TEAM", "Intake Team"))
+
+        verify(sseSubscriptionService, never()).notifySubscribers(any())
     }
 
     private fun mockDocument(documentId: UUID, definitionName: String): Document {

--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -28,4 +28,4 @@ New enhancement explanation.
 | Case migration | The source and target version dropdowns offer every version of the selected case again, instead of only one |
 | Plugins | The verzoek plugin offers every case version again when picking one, instead of only the active one |
 | Case definitions | Versions are ordered by version number rather than alphabetically, so 1.0.10 comes after 1.0.9 |
-| Processes | Completing or cancelling a process with a message no longer logs an error, even though the process ended correctly |
+| Processes | Completing or cancelling a process with a message no longer logs an error when the process ends while a user task is still open |

--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -28,3 +28,4 @@ New enhancement explanation.
 | Case migration | The source and target version dropdowns offer every version of the selected case again, instead of only one |
 | Plugins | The verzoek plugin offers every case version again when picking one, instead of only the active one |
 | Case definitions | Versions are ordered by version number rather than alphabetically, so 1.0.10 comes after 1.0.9 |
+| Processes | Completing or cancelling a process with a message no longer logs an error, even though the process ended correctly |


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/859
Also solves: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/838

## Bug

When a process was completed or cancelled by a message while a user task on it was still open, the
application log filled with an error and a full stack trace — even though the process had ended exactly
as intended.

## Fix

A process ending while a task is still open no longer logs an error. Anything that genuinely goes wrong
while sending the task update is still reported as before.
