### PR TITLE
Fix: deleting a case whose zaak is already gone from the Zaken API

### DIFF
--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/listener/ZakenApiDocumentDeletedEventListener.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/listener/ZakenApiDocumentDeletedEventListener.kt
@@ -26,7 +26,9 @@ import com.ritense.zakenapi.link.ZaakInstanceLinkService
 import com.ritense.zakenapi.service.ZaakDocumentService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.event.EventListener
+import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.HttpClientErrorException
 
 @AllOpen
 class ZakenApiDocumentDeletedEventListener(
@@ -55,7 +57,18 @@ class ZakenApiDocumentDeletedEventListener(
                     ZakenApiPlugin::class.java,
                     ZakenApiPlugin.findConfigurationByUrl(link.zaakInstanceUrl)
                 )
-                plugin?.deleteZaak(link.zaakInstanceUrl)
+                try {
+                    plugin?.deleteZaak(link.zaakInstanceUrl)
+                } catch (e: HttpClientErrorException) {
+                    if (e.statusCode == HttpStatus.NOT_FOUND) {
+                        logger.warn(e) {
+                            "Skipping deletion of zaak '${link.zaakInstanceUrl}' of case " +
+                                "'${event.caseDocumentId}': it was not found in the Zaken API"
+                        }
+                    } else {
+                        throw e
+                    }
+                }
             }
 
         }

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
@@ -155,7 +155,24 @@ class ZaakDocumentService(
             )
         ) { "Could not find ${ZakenApiPlugin::class.simpleName} configuration for zaak with url: $zaakInstanceUrl" }
 
-        zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakInstanceUrl).forEach { zaakInformatieobject ->
+        val zaakInformatieObjecten = try {
+            zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakInstanceUrl)
+        } catch (e: HttpClientErrorException) {
+            if (e.statusCode == HttpStatus.NOT_FOUND) {
+                // The catch belongs here rather than in the caller: this class is @Transactional,
+                // so an exception crossing its proxy would have marked the transaction
+                // rollback-only and the case deletion could no longer be saved.
+                logger.warn(e) {
+                    "Skipping cleanup of the informatieobjecten of case '$caseDocumentId': " +
+                        "zaak '$zaakInstanceUrl' was not found in the Zaken API"
+                }
+                return
+            } else {
+                throw e
+            }
+        }
+
+        zaakInformatieObjecten.forEach { zaakInformatieobject ->
             if (zakenApiPlugin.getZaakInformatieObjectenByInformatieobjectUrl(
                     caseDocumentId,
                     zaakInformatieobject.informatieobject

--- a/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
+++ b/backend/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/service/ZaakDocumentService.kt
@@ -159,9 +159,6 @@ class ZaakDocumentService(
             zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakInstanceUrl)
         } catch (e: HttpClientErrorException) {
             if (e.statusCode == HttpStatus.NOT_FOUND) {
-                // The catch belongs here rather than in the caller: this class is @Transactional,
-                // so an exception crossing its proxy would have marked the transaction
-                // rollback-only and the case deletion could no longer be saved.
                 logger.warn(e) {
                     "Skipping cleanup of the informatieobjecten of case '$caseDocumentId': " +
                         "zaak '$zaakInstanceUrl' was not found in the Zaken API"

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/listener/ZakenApiDocumentDeletedEventListenerTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/listener/ZakenApiDocumentDeletedEventListenerTest.kt
@@ -23,6 +23,8 @@ import com.ritense.zakenapi.domain.ZaakInstanceLink
 import com.ritense.zakenapi.link.ZaakInstanceLinkNotFoundException
 import com.ritense.zakenapi.link.ZaakInstanceLinkService
 import com.ritense.zakenapi.service.ZaakDocumentService
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -30,6 +32,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
 import java.net.URI
 import java.util.UUID
 
@@ -58,6 +62,42 @@ class ZakenApiDocumentDeletedEventListenerTest {
 
         verify(zaakDocumentService).deleteRelatedInformatieObjecten(caseDocumentId, zaakInstanceUrl)
         verify(pluginInstance).deleteZaak(zaakInstanceUrl)
+    }
+
+    @Test
+    fun `should not throw exception when the zaak was already deleted in the Zaken API`() {
+        val caseDocumentId = UUID.fromString("d1f1b3ed-7575-45bb-a02b-18f378ddc34d")
+        val zaakInstanceUrl = URI("http://zaaak.url")
+        val zaakInstanceLink = mock<ZaakInstanceLink>()
+
+        whenever(zaakInstanceService.getByDocumentId(caseDocumentId)).thenReturn(zaakInstanceLink)
+        whenever(zaakInstanceLink.zaakInstanceUrl).thenReturn(zaakInstanceUrl)
+
+        val pluginInstance = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any())).thenReturn(pluginInstance)
+        whenever(pluginInstance.deleteZaak(zaakInstanceUrl)).thenThrow(HttpClientErrorException(HttpStatus.NOT_FOUND))
+
+        assertThatCode { listener.handle(DocumentDeletedEvent(caseDocumentId)) }.doesNotThrowAnyException()
+
+        verify(zaakDocumentService).deleteRelatedInformatieObjecten(caseDocumentId, zaakInstanceUrl)
+        verify(pluginInstance).deleteZaak(zaakInstanceUrl)
+    }
+
+    @Test
+    fun `should throw exception when the Zaken API refuses to delete the zaak`() {
+        val caseDocumentId = UUID.fromString("d1f1b3ed-7575-45bb-a02b-18f378ddc34d")
+        val zaakInstanceUrl = URI("http://zaaak.url")
+        val zaakInstanceLink = mock<ZaakInstanceLink>()
+
+        whenever(zaakInstanceService.getByDocumentId(caseDocumentId)).thenReturn(zaakInstanceLink)
+        whenever(zaakInstanceLink.zaakInstanceUrl).thenReturn(zaakInstanceUrl)
+
+        val pluginInstance = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any())).thenReturn(pluginInstance)
+        whenever(pluginInstance.deleteZaak(zaakInstanceUrl)).thenThrow(HttpClientErrorException(HttpStatus.FORBIDDEN))
+
+        assertThatExceptionOfType(HttpClientErrorException::class.java)
+            .isThrownBy { listener.handle(DocumentDeletedEvent(caseDocumentId)) }
     }
 
     @Test

--- a/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
+++ b/backend/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakDocumentServiceTest.kt
@@ -719,6 +719,38 @@ class ZaakDocumentServiceTest {
         verify(documentenApiService).getInformatieObject(pluginConfigurationId.toString(), caseDocumentId, documentId)
     }
 
+    @Test
+    fun `should skip the informatieobjecten cleanup when the zaak no longer exists in the Zaken API`() {
+        val caseDocumentId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/zaken/$caseDocumentId")
+
+        val zakenApiPlugin = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .doReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakUrl))
+            .doAnswer { throw HttpClientErrorException(HttpStatus.NOT_FOUND, "Not Found") }
+
+        service.deleteRelatedInformatieObjecten(caseDocumentId, zaakUrl)
+
+        verify(zakenApiPlugin, times(0)).deleteZaakInformatieobject(any(), any())
+    }
+
+    @Test
+    fun `should throw when the Zaken API fails with an error other than not found during cleanup`() {
+        val caseDocumentId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/zaken/$caseDocumentId")
+
+        val zakenApiPlugin = mock<ZakenApiPlugin>()
+        whenever(pluginService.createInstance(eq(ZakenApiPlugin::class.java), any()))
+            .doReturn(zakenApiPlugin)
+        whenever(zakenApiPlugin.getZaakInformatieObjecten(caseDocumentId, zaakUrl))
+            .doAnswer { throw HttpClientErrorException(HttpStatus.FORBIDDEN, "Forbidden") }
+
+        assertThrows<HttpClientErrorException> {
+            service.deleteRelatedInformatieObjecten(caseDocumentId, zaakUrl)
+        }
+    }
+
     private fun createZaakInformatieObject(zaakUrl: URI, informatieobjectUrl: URI) = ZaakInformatieObject(
         url = URI("$zaakUrl/zaakinformatieobjecten/${UUID.randomUUID()}"),
         uuid = UUID.randomUUID(),

--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -26,5 +26,6 @@ New enhancement explanation.
 |------|-----|
 | Case definitions | The version picker lists every version of a case again, instead of only the active one, and its pagination works |
 | Case migration | The source and target version dropdowns offer every version of the selected case again, instead of only one |
+| Cases | A case can be deleted when the zaak it is linked to has already been removed in the Zaken API |
 | Plugins | The verzoek plugin offers every case version again when picking one, instead of only the active one |
 | Case definitions | Versions are ordered by version number rather than alphabetically, so 1.0.10 comes after 1.0.9 |


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/742

## Bug

Deleting a case failed with an error saying the zaak does not exist, when that zaak had
already been removed in the Zaken API. The case stayed behind in GZAC and could never be
deleted.

## Fix

The case is now deleted, and a warning is logged saying the zaak was already gone. When the
Zaken API refuses the deletion for another reason, the case is still kept.

Assumed the ticket's second scenario should keep blocking the deletion rather than become a
configurable option.
