### PR TITLE
Fix: duplicate rows when paging a list sorted on a non-unique column

### DIFF
--- a/backend/case-opensearch/src/main/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchService.kt
+++ b/backend/case-opensearch/src/main/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchService.kt
@@ -414,6 +414,14 @@ class JsonSchemaDocumentOpenSearchService(
             }
         }
 
+        // Paging is only reproducible when the sort ends on a unique field, so ties never reshuffle.
+        // Without this, ties fall back to the Lucene doc id, which segment merges and updates reassign.
+        queryBuilder.withSorts(
+            SortBuilders.fieldSort(ID_SORT_FIELD)
+                .order(SortOrder.ASC)
+                .unmappedType("keyword")
+        )
+
         val dataQuery = queryBuilder.build()
         val hits = elasticsearchOperations.search(dataQuery, JsonSchemaDocumentOsDocument::class.java)
         val total = hits.totalHits
@@ -679,6 +687,10 @@ class JsonSchemaDocumentOpenSearchService(
         private const val CASE_PREFIX = "case:"
         private const val DEFINITION_NAME_FIELD = "definitionId.name"
         private const val BLUEPRINT_TYPE_FIELD = "definitionId.blueprintId.blueprintType"
+
+        // Keyword sub-field of the document id, so it is sortable. Dynamically mapped, so present on
+        // every existing index — no mapping change or reindex needed.
+        private const val ID_SORT_FIELD = "id.keyword"
         private val MATCH_NONE: QueryBuilder = QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery())
 
         private fun AdvancedSearchRequest.OtherFilter.rangeFromValue(): Any? =

--- a/backend/case-opensearch/src/test/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchServiceIntTest.kt
+++ b/backend/case-opensearch/src/test/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchServiceIntTest.kt
@@ -50,6 +50,10 @@ class JsonSchemaDocumentOpenSearchServiceIntTest : BaseOpenSearchIntegrationTest
     @Autowired
     lateinit var documentRepository: JsonSchemaDocumentRepository
 
+    // Bypasses DelegatingDocumentSearchService, so the engine toggle cannot route these assertions to JPA
+    @Autowired
+    lateinit var openSearchDocumentSearchService: JsonSchemaDocumentOpenSearchService
+
     @Test
     fun `globalSearchFilter returns matching document`() {
         seedDocument("Funenpark")
@@ -547,6 +551,23 @@ class JsonSchemaDocumentOpenSearchServiceIntTest : BaseOpenSearchIntegrationTest
         assertThat(pageDesc.content[1].id()).isEqualTo(docC.id())
         assertThat(pageDesc.content[2].id()).isEqualTo(docA.id())
     }
+
+    @Test
+    fun `search should return disjunct pages when all documents share the same assigneeFullName`() {
+        repeat(25) { seedDocumentWithAssignee("Funenpark", "Beth Xander") }
+
+        val sort = Sort.by(Sort.Direction.DESC, "assigneeFullName")
+        val firstPageIds = searchDocumentIds(PageRequest.of(0, 10, sort))
+        val secondPageIds = searchDocumentIds(PageRequest.of(1, 10, sort))
+
+        assertThat(firstPageIds).hasSize(10)
+        assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds)
+        assertThat(firstPageIds + secondPageIds).isSorted()
+    }
+
+    private fun searchDocumentIds(pageable: Pageable): List<String> =
+        openSearchDocumentSearchService.search("house", BlueprintType.CASE, AdvancedSearchRequest(), pageable)
+            .content.map { it.id().toString() }
 
     private fun seedDocumentWithContent(contentMap: Map<String, String>): JsonSchemaDocument {
         val content = objectMapper.createObjectNode().apply {

--- a/backend/case-opensearch/src/test/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchServiceIntTest.kt
+++ b/backend/case-opensearch/src/test/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchServiceIntTest.kt
@@ -559,10 +559,15 @@ class JsonSchemaDocumentOpenSearchServiceIntTest : BaseOpenSearchIntegrationTest
         val sort = Sort.by(Sort.Direction.DESC, "assigneeFullName")
         val firstPageIds = searchDocumentIds(PageRequest.of(0, 10, sort))
         val secondPageIds = searchDocumentIds(PageRequest.of(1, 10, sort))
+        val firstTwentyIds = searchDocumentIds(PageRequest.of(0, 20, sort))
 
         assertThat(firstPageIds).hasSize(10)
+        assertThat(secondPageIds).hasSize(10)
         assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds)
-        assertThat(firstPageIds + secondPageIds).isSorted()
+        val pagedIds = firstPageIds + secondPageIds
+        assertThat(pagedIds).doesNotHaveDuplicates()
+        assertThat(pagedIds).isSorted()
+        assertThat(pagedIds).isEqualTo(firstTwentyIds)
     }
 
     private fun searchDocumentIds(pageable: Pageable): List<String> =

--- a/backend/case-opensearch/src/test/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchServiceIntTest.kt
+++ b/backend/case-opensearch/src/test/kotlin/com/ritense/document/opensearch/service/JsonSchemaDocumentOpenSearchServiceIntTest.kt
@@ -559,15 +559,18 @@ class JsonSchemaDocumentOpenSearchServiceIntTest : BaseOpenSearchIntegrationTest
         val sort = Sort.by(Sort.Direction.DESC, "assigneeFullName")
         val firstPageIds = searchDocumentIds(PageRequest.of(0, 10, sort))
         val secondPageIds = searchDocumentIds(PageRequest.of(1, 10, sort))
-        val firstTwentyIds = searchDocumentIds(PageRequest.of(0, 20, sort))
+        val thirdPageIds = searchDocumentIds(PageRequest.of(2, 10, sort))
+        val allTwentyFiveIds = searchDocumentIds(PageRequest.of(0, 25, sort))
 
         assertThat(firstPageIds).hasSize(10)
         assertThat(secondPageIds).hasSize(10)
+        assertThat(thirdPageIds).hasSize(5)
         assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds)
-        val pagedIds = firstPageIds + secondPageIds
+        val pagedIds = firstPageIds + secondPageIds + thirdPageIds
+        assertThat(pagedIds).hasSize(25)
         assertThat(pagedIds).doesNotHaveDuplicates()
         assertThat(pagedIds).isSorted()
-        assertThat(pagedIds).isEqualTo(firstTwentyIds)
+        assertThat(pagedIds).isEqualTo(allTwentyFiveIds)
     }
 
     private fun searchDocumentIds(pageable: Pageable): List<String> =

--- a/backend/case/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchService.java
+++ b/backend/case/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchService.java
@@ -838,7 +838,7 @@ public class JsonSchemaDocumentSearchService implements DocumentSearchService {
         Sort sort,
         Map<String, Class<?>> sortTypeMap
     ) {
-        return sort.stream()
+        var orders = sort.stream()
             .map(order -> {
                 Expression<?> expression;
                 String property = order.getProperty();
@@ -876,19 +876,29 @@ public class JsonSchemaDocumentSearchService implements DocumentSearchService {
                     }
 
                     var path = stringToPath(parent, docProperty);
-                    // This groupBy workaround is needed because PBAC adds a groupBy on 'id' by default.
-                    // Since sorting columns should be added to the groupBy, we do that here
-                    if (!query.getGroupList().isEmpty() && !query.getGroupList().contains(path)) {
-                        ArrayList<Expression<?>> grouping = new ArrayList<>(query.getGroupList());
-                        grouping.add(path);
-                        query.groupBy(grouping);
-                    }
+                    addToGroupBy(query, path);
                     expression = path;
                 }
 
                 return order.getDirection().isAscending() ? cb.asc(expression) : cb.desc(expression);
             })
-            .collect(Collectors.toList());
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        // Paging is only reproducible when the ORDER BY ends on a unique column, so ties never reshuffle
+        Path<?> idPath = root.get(ID).get(ID);
+        addToGroupBy(query, idPath);
+        orders.add(cb.asc(idPath));
+        return orders;
+    }
+
+    // This groupBy workaround is needed because PBAC adds a groupBy on 'id' by default.
+    // Since sorting columns should be added to the groupBy, we do that here
+    private void addToGroupBy(CriteriaQuery<JsonSchemaDocument> query, Path<?> path) {
+        if (!query.getGroupList().isEmpty() && !query.getGroupList().contains(path)) {
+            ArrayList<Expression<?>> grouping = new ArrayList<>(query.getGroupList());
+            grouping.add(path);
+            query.groupBy(grouping);
+        }
     }
 
     private <T> Path<T> stringToPath(Path<?> parent, String path) {

--- a/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchServiceIntTest.java
+++ b/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchServiceIntTest.java
@@ -644,9 +644,14 @@ class JsonSchemaDocumentSearchServiceIntTest extends BaseIntegrationTest {
         var sort = Sort.by(Direction.DESC, "assigneeFullName");
         var firstPageIds = searchDocumentIds(PageRequest.of(0, 10, sort));
         var secondPageIds = searchDocumentIds(PageRequest.of(1, 10, sort));
+        var firstTwentyIds = searchDocumentIds(PageRequest.of(0, 20, sort));
 
+        assertThat(firstPageIds).hasSize(10);
+        assertThat(secondPageIds).hasSize(10);
         assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds);
-        assertThat(Stream.concat(firstPageIds.stream(), secondPageIds.stream())).isSorted();
+        var pagedIds = Stream.concat(firstPageIds.stream(), secondPageIds.stream()).collect(Collectors.toList());
+        assertThat(pagedIds).isSorted();
+        assertThat(pagedIds).isEqualTo(firstTwentyIds);
     }
 
     @Test

--- a/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchServiceIntTest.java
+++ b/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchServiceIntTest.java
@@ -631,6 +631,23 @@ class JsonSchemaDocumentSearchServiceIntTest extends BaseIntegrationTest {
         assertThat(content.get(2).assigneeFullName()).isEqualTo("Anna Yablon");
     }
 
+    @Test
+    @WithMockUser(username = USERNAME, authorities = FULL_ACCESS_ROLE)
+    void searchShouldReturnDisjunctPagesWhenAllDocumentsShareTheSameAssigneeFullName() {
+        documentRepository.deleteAllInBatch();
+        var documents = Stream.generate(() -> (JsonSchemaDocument) createDocument("{}").resultingDocument().orElseThrow())
+            .limit(25)
+            .collect(Collectors.toList());
+        documents.forEach(document -> document.setAssignee("1111", "Beth Xander"));
+        documentRepository.saveAll(documents);
+
+        var sort = Sort.by(Direction.DESC, "assigneeFullName");
+        var firstPageIds = searchDocumentIds(PageRequest.of(0, 10, sort));
+        var secondPageIds = searchDocumentIds(PageRequest.of(1, 10, sort));
+
+        assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds);
+        assertThat(Stream.concat(firstPageIds.stream(), secondPageIds.stream())).isSorted();
+    }
 
     @Test
     @WithMockUser(username = USERNAME, authorities = FULL_ACCESS_ROLE)
@@ -1709,6 +1726,14 @@ class JsonSchemaDocumentSearchServiceIntTest extends BaseIntegrationTest {
                 )
             )
         );
+    }
+
+    // Compared as text because UUID.compareTo treats the bits as signed, where the database orders them unsigned
+    private List<String> searchDocumentIds(Pageable pageable) {
+        return documentSearchService.search(new SearchRequest(), BlueprintType.CASE, pageable)
+            .getContent().stream()
+            .map(document -> document.id().getId().toString())
+            .collect(Collectors.toList());
     }
 
     private void mockTeamFindByKey(String key, String title) {

--- a/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchServiceIntTest.java
+++ b/backend/case/src/test/java/com/ritense/document/service/impl/JsonSchemaDocumentSearchServiceIntTest.java
@@ -644,14 +644,20 @@ class JsonSchemaDocumentSearchServiceIntTest extends BaseIntegrationTest {
         var sort = Sort.by(Direction.DESC, "assigneeFullName");
         var firstPageIds = searchDocumentIds(PageRequest.of(0, 10, sort));
         var secondPageIds = searchDocumentIds(PageRequest.of(1, 10, sort));
-        var firstTwentyIds = searchDocumentIds(PageRequest.of(0, 20, sort));
+        var thirdPageIds = searchDocumentIds(PageRequest.of(2, 10, sort));
+        var allTwentyFiveIds = searchDocumentIds(PageRequest.of(0, 25, sort));
 
         assertThat(firstPageIds).hasSize(10);
         assertThat(secondPageIds).hasSize(10);
+        assertThat(thirdPageIds).hasSize(5);
         assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds);
-        var pagedIds = Stream.concat(firstPageIds.stream(), secondPageIds.stream()).collect(Collectors.toList());
+        var pagedIds = Stream.of(firstPageIds, secondPageIds, thirdPageIds)
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+        assertThat(pagedIds).hasSize(25);
+        assertThat(pagedIds).doesNotHaveDuplicates();
         assertThat(pagedIds).isSorted();
-        assertThat(pagedIds).isEqualTo(firstTwentyIds);
+        assertThat(pagedIds).isEqualTo(allTwentyFiveIds);
     }
 
     @Test

--- a/backend/core/src/main/java/com/ritense/valtimo/service/OperatonTaskService.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/service/OperatonTaskService.java
@@ -96,6 +96,7 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Root;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -839,7 +840,7 @@ public class OperatonTaskService {
     }
 
     private List<Order> getOrderBy(CriteriaBuilder cb, Root<OperatonTask> root, Sort sort) {
-        return sort.stream()
+        var orders = sort.stream()
             .map(order -> {
                 String sortProperty;
                 if (order.getProperty().equals("created")) {
@@ -854,7 +855,11 @@ public class OperatonTaskService {
                 return order.isAscending() ? cb.asc(expression) : cb.desc(expression);
             })
             .map(Order.class::cast)
-            .toList();
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        // Paging is only reproducible when the ORDER BY ends on a unique column, so ties never reshuffle
+        orders.add(cb.asc(root.get("id")));
+        return orders;
     }
 
     private AuthorizationSpecification<OperatonTask> getAuthorizationSpecification(Action<OperatonTask> action) {

--- a/backend/core/src/main/java/com/ritense/valtimo/service/OperatonTaskService.java
+++ b/backend/core/src/main/java/com/ritense/valtimo/service/OperatonTaskService.java
@@ -858,7 +858,7 @@ public class OperatonTaskService {
             .collect(Collectors.toCollection(ArrayList::new));
 
         // Paging is only reproducible when the ORDER BY ends on a unique column, so ties never reshuffle
-        orders.add(cb.asc(root.get("id")));
+        orders.add(cb.asc(root.get(ID)));
         return orders;
     }
 

--- a/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
@@ -241,8 +241,12 @@ class OperatonTaskServiceIntTest extends BaseIntegrationTest {
         var firstPageIds = findTaskIds(PageRequest.of(0, 10, Sort.Direction.DESC, "name"));
         var secondPageIds = findTaskIds(PageRequest.of(1, 10, Sort.Direction.DESC, "name"));
 
+        assertThat(firstPageIds).hasSize(10);
+        assertThat(secondPageIds).hasSize(10);
         assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds);
-        assertThat(Stream.concat(firstPageIds.stream(), secondPageIds.stream())).isSorted();
+        var pagedIds = Stream.concat(firstPageIds.stream(), secondPageIds.stream()).collect(Collectors.toList());
+        assertThat(pagedIds).doesNotHaveDuplicates();
+        assertThat(pagedIds).isSorted();
     }
 
     private List<String> findTaskIds(PageRequest pageRequest) {

--- a/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
@@ -41,6 +41,7 @@ import com.ritense.valtimo.contract.case_.CaseDefinitionId;
 import com.ritense.valtimo.operaton.authorization.OperatonTaskActionProvider;
 import com.ritense.valtimo.operaton.domain.OperatonTask;
 import com.ritense.valtimo.operaton.domain.ProcessInstanceWithDefinition;
+import com.ritense.valtimo.operaton.dto.TaskExtended;
 import java.sql.Date;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -49,6 +50,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.operaton.bpm.engine.TaskService;
@@ -218,6 +221,35 @@ class OperatonTaskServiceIntTest extends BaseIntegrationTest {
         );
 
         assertThat(pagedTasks.getTotalElements()).isEqualTo(10);
+    }
+
+    @Test
+    @WithMockUser(username = "user@ritense.com", authorities = "IDENTITY_LINK_ROLE")
+    void shouldReturnDisjunctPagesWhenAllTasksShareTheSameName() {
+        AuthorizationContext.runWithoutAuthorization(() -> {
+            for (int i = 0; i < 25; i++) {
+                operatonProcessService.startProcess(
+                    "identity-link-mapper-test-process",
+                    businessKey,
+                    caseDefinitionId,
+                    Map.of()
+                );
+            }
+            return null;
+        });
+
+        var firstPageIds = findTaskIds(PageRequest.of(0, 10, Sort.Direction.DESC, "name"));
+        var secondPageIds = findTaskIds(PageRequest.of(1, 10, Sort.Direction.DESC, "name"));
+
+        assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds);
+        assertThat(Stream.concat(firstPageIds.stream(), secondPageIds.stream())).isSorted();
+    }
+
+    private List<String> findTaskIds(PageRequest pageRequest) {
+        return operatonTaskService.findTasksFiltered(OperatonTaskService.TaskFilter.ALL, pageRequest)
+            .getContent().stream()
+            .map(TaskExtended::getId)
+            .collect(Collectors.toList());
     }
 
     @Test

--- a/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
@@ -240,6 +240,7 @@ class OperatonTaskServiceIntTest extends BaseIntegrationTest {
 
         var firstPageIds = findTaskIds(PageRequest.of(0, 10, Sort.Direction.DESC, "name"));
         var secondPageIds = findTaskIds(PageRequest.of(1, 10, Sort.Direction.DESC, "name"));
+        var firstTwentyIds = findTaskIds(PageRequest.of(0, 20, Sort.Direction.DESC, "name"));
 
         assertThat(firstPageIds).hasSize(10);
         assertThat(secondPageIds).hasSize(10);
@@ -247,6 +248,7 @@ class OperatonTaskServiceIntTest extends BaseIntegrationTest {
         var pagedIds = Stream.concat(firstPageIds.stream(), secondPageIds.stream()).collect(Collectors.toList());
         assertThat(pagedIds).doesNotHaveDuplicates();
         assertThat(pagedIds).isSorted();
+        assertThat(pagedIds).isEqualTo(firstTwentyIds);
     }
 
     private List<String> findTaskIds(PageRequest pageRequest) {

--- a/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
+++ b/backend/core/src/test/java/com/ritense/valtimo/service/OperatonTaskServiceIntTest.java
@@ -240,15 +240,21 @@ class OperatonTaskServiceIntTest extends BaseIntegrationTest {
 
         var firstPageIds = findTaskIds(PageRequest.of(0, 10, Sort.Direction.DESC, "name"));
         var secondPageIds = findTaskIds(PageRequest.of(1, 10, Sort.Direction.DESC, "name"));
-        var firstTwentyIds = findTaskIds(PageRequest.of(0, 20, Sort.Direction.DESC, "name"));
+        var thirdPageIds = findTaskIds(PageRequest.of(2, 10, Sort.Direction.DESC, "name"));
+        // Sized past the 25 tasks started here, so the comparison holds whether or not other tests
+        // in this class left tasks behind — findTasksFiltered(ALL) is not scoped to this test
+        var allIds = findTaskIds(PageRequest.of(0, 30, Sort.Direction.DESC, "name"));
 
         assertThat(firstPageIds).hasSize(10);
         assertThat(secondPageIds).hasSize(10);
+        assertThat(thirdPageIds).hasSizeGreaterThanOrEqualTo(5);
         assertThat(firstPageIds).doesNotContainAnyElementsOf(secondPageIds);
-        var pagedIds = Stream.concat(firstPageIds.stream(), secondPageIds.stream()).collect(Collectors.toList());
+        var pagedIds = Stream.of(firstPageIds, secondPageIds, thirdPageIds)
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
         assertThat(pagedIds).doesNotHaveDuplicates();
         assertThat(pagedIds).isSorted();
-        assertThat(pagedIds).isEqualTo(firstTwentyIds);
+        assertThat(pagedIds).isEqualTo(allIds);
     }
 
     private List<String> findTaskIds(PageRequest pageRequest) {

--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
@@ -621,7 +621,7 @@ class CaseTaskListSearchService(
         sort: Sort,
         sortTypeMap: Map<String, Class<*>>
     ): List<Order> {
-        return sort.stream()
+        val orders = sort.stream()
             .map { order: Sort.Order ->
                 val expression: Expression<*>
                 val property = order.property
@@ -689,6 +689,9 @@ class CaseTaskListSearchService(
                 if (order.direction.isAscending) cb.asc(expression) else cb.desc(expression)
             }
             .collect(Collectors.toList())
+
+        // Paging is only reproducible when the ORDER BY ends on a unique column, so ties never reshuffle
+        return orders + cb.asc(taskRoot.get<String>("id"))
     }
 
     private fun buildSortTypeMap(caseDefinitionName: String): Map<String, Class<*>> {

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
@@ -401,9 +401,13 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
         val sort = Sort.by(Sort.Direction.DESC, "doc:street")
         val firstPageTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(0, 10, sort))
         val secondPageTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(1, 10, sort))
+        val firstTwentyTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(0, 20, sort))
 
+        assertThat(firstPageTaskIds).hasSize(10)
+        assertThat(secondPageTaskIds).hasSize(10)
         assertThat(firstPageTaskIds).doesNotContainAnyElementsOf(secondPageTaskIds)
         assertThat(firstPageTaskIds + secondPageTaskIds).isSorted()
+        assertThat(firstPageTaskIds + secondPageTaskIds).isEqualTo(firstTwentyTaskIds)
     }
 
     private fun searchTaskIds(caseDefinitionName: String, pageable: PageRequest): List<String> =

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
@@ -392,6 +392,24 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
         assertThat(searchResult.numberOfElements).isEqualTo(10)
     }
 
+    @Test
+    @WithMockUser(username = "user@ritense.com", authorities = [AuthoritiesConstants.USER])
+    fun shouldReturnDisjunctPagesWhenAllTasksShareTheSortedValue() {
+        val taskDefinition = definition("task")
+        repeat(12) { createDocumentAndTwoProcesses("Funenpark", taskDefinition.id().name()) }
+
+        val sort = Sort.by(Sort.Direction.DESC, "doc:street")
+        val firstPageTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(0, 10, sort))
+        val secondPageTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(1, 10, sort))
+
+        assertThat(firstPageTaskIds).doesNotContainAnyElementsOf(secondPageTaskIds)
+        assertThat(firstPageTaskIds + secondPageTaskIds).isSorted()
+    }
+
+    private fun searchTaskIds(caseDefinitionName: String, pageable: PageRequest): List<String> =
+        caseTaskListSearchService.search(caseDefinitionName, AdvancedSearchRequest(), pageable)
+            .content.map { it.taskId }
+
     private fun createTeamAndAssignToTask(taskId: String, teamKey: String, teamTitle: String) {
         if (!teamRepository.existsById(teamKey)) {
             teamRepository.save(com.ritense.team.domain.Team(key = teamKey, title = teamTitle))

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
@@ -401,13 +401,18 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
         val sort = Sort.by(Sort.Direction.DESC, "doc:street")
         val firstPageTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(0, 10, sort))
         val secondPageTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(1, 10, sort))
-        val firstTwentyTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(0, 20, sort))
+        val thirdPageTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(2, 10, sort))
+        val allTaskIds = searchTaskIds(taskDefinition.id().name(), PageRequest.of(0, 24, sort))
 
         assertThat(firstPageTaskIds).hasSize(10)
         assertThat(secondPageTaskIds).hasSize(10)
+        assertThat(thirdPageTaskIds).hasSize(4)
         assertThat(firstPageTaskIds).doesNotContainAnyElementsOf(secondPageTaskIds)
-        assertThat(firstPageTaskIds + secondPageTaskIds).isSorted()
-        assertThat(firstPageTaskIds + secondPageTaskIds).isEqualTo(firstTwentyTaskIds)
+        val pagedTaskIds = firstPageTaskIds + secondPageTaskIds + thirdPageTaskIds
+        assertThat(pagedTaskIds).hasSize(24)
+        assertThat(pagedTaskIds).doesNotHaveDuplicates()
+        assertThat(pagedTaskIds).isSorted()
+        assertThat(pagedTaskIds).isEqualTo(allTaskIds)
     }
 
     private fun searchTaskIds(caseDefinitionName: String, pageable: PageRequest): List<String> =

--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -24,6 +24,7 @@ New enhancement explanation.
 
 | Area | Fix |
 |------|-----|
+| Case and task lists | Paging through a list sorted on a column that repeats values, such as the assignee, no longer shows the same case or task on two pages while leaving others out |
 | Case definitions | The version picker lists every version of a case again, instead of only the active one, and its pagination works |
 | Case migration | The source and target version dropdowns offer every version of the selected case again, instead of only one |
 | Plugins | The verzoek plugin offers every case version again when picking one, instead of only the active one |


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/741

## Bug

Paging through a case list or a task list sorted on a column where many rows share the same
value, such as the assignee, showed some cases and tasks twice on different pages while
leaving others out entirely.

## Fix

Every page is now a slice of one consistent order, so each case and task appears exactly once
while paging.
