### PR TITLE
Fix: repeated clicks on Save upload the same document more than once

### DIFF
--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -27,6 +27,7 @@ New enhancement explanation.
 | Case definitions | The version picker lists every version of a case again, instead of only the active one, and its pagination works              |
 | Case migration   | The source and target version dropdowns offer every version of the selected case again, instead of only one                   |
 | Cases            | A case can be deleted when the zaak it is linked to has already been removed in the Zaken API                                 |
+| Documents        | A document is added to a case once, however many times Save is clicked in the metadata window                                 |
 | Plugins          | The verzoek plugin offers every case version again when picking one, instead of only the active one                           |
 | Case definitions | Versions are ordered by version number rather than alphabetically, so 1.0.10 comes after 1.0.9                                |
 | Plugins          | Creating a zaakdossier via the verzoek plugin with an empty initiator type no longer fails when creating the initiator zaakrol |

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-documents/documenten-api-documents.component.html
@@ -102,6 +102,7 @@
     [open]="showUploadModal$ | async"
     [supportsTrefwoorden]="obs?.supportedDocumentenApiFeatures?.supportsTrefwoorden"
     [uploadError]="uploadError()"
+    [uploading]="obs.uploading"
     (metadata)="metadataSet($event)"
     (modalClose)="closeMetadataModal()"
     (uploadErrorDismiss)="uploadError.set(null)"

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.html
@@ -60,7 +60,7 @@
   </div>
 
   <div role="footer" class="metadata-modal-footer">
-    <button cdsButton="ghost" (click)="closeModal()" [disabled]="obs.disabled">
+    <button cdsButton="ghost" (click)="closeModal()" [disabled]="obs.disabled || uploading">
       {{ 'document.cancel' | translate }}
     </button>
 

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.html
@@ -67,7 +67,7 @@
     <button
       cdsButton="primary"
       type="submit"
-      [disabled]="obs.disabled || !documentenApiMetadataForm.valid || obs.editDisabled"
+      [disabled]="obs.disabled || uploading || !documentenApiMetadataForm.valid || obs.editDisabled"
       (click)="save()"
     >
       {{ 'document.save' | translate }}

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.spec.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {FormBuilder} from '@angular/forms';
+import {of} from 'rxjs';
+import {DocumentenApiMetadata} from '../../models';
+import {DocumentenApiMetadataModalComponent} from './documenten-api-metadata-modal.component';
+
+describe('DocumentenApiMetadataModalComponent', () => {
+  let component: DocumentenApiMetadataModalComponent;
+  let emitted: Array<DocumentenApiMetadata>;
+
+  beforeEach(() => {
+    component = new DocumentenApiMetadataModalComponent(
+      {params: of({})} as any,
+      {} as any,
+      {} as any,
+      new FormBuilder(),
+      {loadUserProfile: () => Promise.resolve({email: 'ambtenaar@example.com'})} as any,
+      {closeModal: () => {}} as any,
+      {stream: () => of('')} as any,
+      {caseDefinitionKey$: of('some-case')} as any,
+      {} as any,
+      {documentId$: of(null)} as any
+    );
+
+    component.documentenApiMetadataForm.patchValue({
+      auteur: 'ambtenaar@example.com',
+      creatiedatum: '2026-09-06',
+      informatieobjecttype: 'http://localhost/catalogi/api/v1/informatieobjecttypen/1',
+      taal: 'nld',
+      titel: 'Paspoort',
+    });
+
+    emitted = [];
+    component.metadata.subscribe(metadata => emitted.push(metadata));
+  });
+
+  it('emits the metadata when the form is submitted', () => {
+    expect(component.documentenApiMetadataForm.valid).toBeTrue();
+
+    component.save();
+
+    expect(emitted.length).toBe(1);
+  });
+
+  it('does not emit the metadata again while an upload is already in flight', () => {
+    component.save();
+
+    component.uploading = true;
+    component.save();
+    component.save();
+
+    expect(emitted.length).toBe(1);
+  });
+});

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/components/documenten-api-metadata-modal/documenten-api-metadata-modal.component.ts
@@ -183,6 +183,7 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
   }
   @Input() isEditMode: boolean;
   @Input() uploadError: string | null = null;
+  @Input() uploading = false;
 
   public readonly open$ = new BehaviorSubject<boolean>(false);
 
@@ -570,6 +571,8 @@ export class DocumentenApiMetadataModalComponent implements OnInit, OnDestroy {
   }
 
   public save(): void {
+    if (this.uploading) return;
+
     this.formatDate('creatiedatum');
     this.formatDate('verzenddatum');
     this.formatDate('ontvangstdatum');

--- a/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.html
+++ b/frontend/projects/valtimo/zgw/src/lib/modules/documenten-api/formio/documenten-api-uploader/documenten-api-uploader.component.html
@@ -88,5 +88,6 @@
   [open]="showModal()"
   [supportsTrefwoorden]="(supportedDocumentenApiFeatures$ | async)?.supportsTrefwoorden"
   [uploadError]="uploadError()"
+  [uploading]="uploading$ | async"
   (uploadErrorDismiss)="uploadError.set(null)"
 ></valtimo-documenten-api-metadata-modal>


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/865

## Bug

On a case's Documents tab, Save in the file metadata window stayed active while the upload was
still running. Clicking it again filed the same document again, so the case ended up with one copy
per click.

## Fix

Save is now switched off as soon as it is clicked and stays off until the upload finishes, so a
document is added to the case once however many times Save is clicked.
