### PR TITLE
Stop all other processes of a case from a service task

### DIFF
--- a/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/ProcessDocumentsService.kt
+++ b/backend/process-document/src/main/kotlin/com/ritense/processdocument/service/ProcessDocumentsService.kt
@@ -30,6 +30,7 @@ import com.ritense.valtimo.contract.annotation.ProcessBeanMethod
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.operaton.service.OperatonRuntimeService
 import com.ritense.valtimo.service.OperatonProcessService
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.operaton.bpm.engine.RepositoryService
 import org.operaton.bpm.engine.delegate.DelegateExecution
 import org.springframework.stereotype.Service
@@ -53,20 +54,34 @@ class ProcessDocumentsService(
     fun deleteAllProcessInstancesForThisDocument(execution: DelegateExecution, reason: String) {
         val documentId = JsonSchemaDocumentId.existingId(execution.getJsonSchemaDocumentId())
         withLoggingContext(JsonSchemaDocument::class, documentId.toString()) {
-            val processInstanceIds = associationService.findProcessDocumentInstances(documentId)
-                .map { it.processDocumentInstanceId().processInstanceId().toString() }
-            operatonProcessService.findProcessInstancesByIds(processInstanceIds.toSet())
-                .filter { it.rootProcessInstanceId == null || it.rootProcessInstanceId == it.processInstanceId }
-                .mapNotNull { processInstance ->
-                    try {
-                        operatonProcessService.deleteProcessInstanceById(processInstance.id, reason)
-                        null
-                    } catch (exception: Exception) {
-                        exception
-                    }
+            deleteRootProcessInstancesForDocument(documentId, reason, keepRootProcessInstanceId = null)
+        }
+    }
+
+    @ProcessBeanMethod(
+        description = "Deletes all process instances associated with the current document, except the calling one",
+        example = "\${processService.deleteAllOtherProcessInstancesForThisDocument(execution, 'Case cancelled')}"
+    )
+    fun deleteAllOtherProcessInstancesForThisDocument(execution: DelegateExecution, reason: String) {
+        val documentId = JsonSchemaDocumentId.existingId(execution.getJsonSchemaDocumentId())
+        withLoggingContext(JsonSchemaDocument::class, documentId.toString()) {
+            val callingProcessInstance = operatonProcessService
+                .findProcessInstanceById(execution.processInstanceId)
+                .orElse(null)
+            if (callingProcessInstance == null) {
+                logger.warn {
+                    "Deleted no process instances. " +
+                        "Calling process instance '${execution.processInstanceId}' could not be found."
                 }
-                .toList()
-                .forEach { throw it }
+            } else {
+                deleteRootProcessInstancesForDocument(
+                    documentId,
+                    reason,
+                    keepRootProcessInstanceId = callingProcessInstance.rootProcessInstanceId
+                        ?.takeIf { it.isNotBlank() }
+                        ?: execution.processInstanceId
+                )
+            }
         }
     }
 
@@ -156,6 +171,29 @@ class ProcessDocumentsService(
         }.distinct()
     }
 
+    private fun deleteRootProcessInstancesForDocument(
+        documentId: JsonSchemaDocumentId,
+        reason: String,
+        keepRootProcessInstanceId: String?
+    ) {
+        val processInstanceIds = associationService.findProcessDocumentInstances(documentId)
+            .map { it.processDocumentInstanceId().processInstanceId().toString() }
+        operatonProcessService.findProcessInstancesByIds(processInstanceIds.toSet())
+            .filter { it.rootProcessInstanceId == null || it.rootProcessInstanceId == it.processInstanceId }
+            .filter { it.id != keepRootProcessInstanceId }
+            .mapNotNull { processInstance ->
+                try {
+                    operatonProcessService.deleteProcessInstanceById(processInstance.id, reason)
+                    null
+                } catch (exception: Exception) {
+                    logger.error(exception) { "Failed to delete process instance '${processInstance.id}'" }
+                    exception
+                }
+            }
+            .firstOrNull()
+            ?.let { throw it }
+    }
+
     private fun associateDocumentToProcess(
         processInstanceId: String?,
         processName: String,
@@ -171,5 +209,9 @@ class ProcessDocumentsService(
                     )
                 }) { throw DocumentNotFoundException("No Document found with id $businessKey") }
         }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
     }
 }

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/ProcessDocumentsServiceIntTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/ProcessDocumentsServiceIntTest.kt
@@ -39,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @Transactional
 class ProcessDocumentsServiceIntTest : BaseIntegrationTest() {
@@ -99,6 +100,44 @@ class ProcessDocumentsServiceIntTest : BaseIntegrationTest() {
         }
 
         assertEquals(0, result.errors().size)
+    }
+
+    @Test
+    @Throws(JsonProcessingException::class)
+    fun `should delete other processes for a document and continue the calling process`() {
+        val request = NewDocumentAndStartProcessRequest(
+            "delete-other-processes",
+            NewDocumentRequest(
+                "house",
+                "house",
+                "1.0.0",
+                objectMapper.readTree(documentJson)
+            )
+        )
+
+        val result = runWithoutAuthorization {
+            processDocumentService.newDocumentAndStartProcess(request)
+        }
+
+        assertEquals(0, result.errors().size)
+        val callingProcessInstanceId = result.resultingProcessInstanceId().orElseThrow().toString()
+        val otherProcessInstanceIds = processDocumentInstanceRepository
+            .findAllByProcessDocumentInstanceIdDocumentId(
+                JsonSchemaDocumentId.existingId(result.resultingDocument().orElseThrow().id().id)
+            )
+            .map { it.processDocumentInstanceId().processInstanceId().toString() }
+            .filter { it != callingProcessInstanceId }
+        assertEquals(1, otherProcessInstanceIds.size)
+
+        runWithoutAuthorization {
+            taskService.complete(taskService.findTask(byName("trigger delete other processes")).id)
+        }
+
+        runWithoutAuthorization {
+            assertTrue(operatonProcessService.findProcessInstanceById(callingProcessInstanceId).isPresent)
+            assertTrue(operatonProcessService.findProcessInstanceById(otherProcessInstanceIds.first()).isEmpty)
+        }
+        assertNotNull(runWithoutAuthorization { taskService.findTask(byName("delete other processes user task")) })
     }
 
     @Test

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/ProcessDocumentsServiceTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/ProcessDocumentsServiceTest.kt
@@ -16,16 +16,22 @@
 
 package com.ritense.processdocument.service
 
+import com.ritense.processdocument.domain.ProcessDocumentInstance
+import com.ritense.processdocument.domain.ProcessDocumentInstanceId
+import com.ritense.processdocument.domain.impl.OperatonProcessInstanceId
 import com.ritense.valtimo.service.OperatonProcessService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.operaton.bpm.engine.delegate.DelegateExecution
+import org.operaton.bpm.engine.runtime.ProcessInstance
 import java.util.Optional
 
 internal class ProcessDocumentsServiceTest {
@@ -48,6 +54,36 @@ internal class ProcessDocumentsServiceTest {
     }
 
     @Test
+    fun `should keep the root of the calling execution rather than its own process instance`() {
+        // Every mock is built before any stubbing starts: creating a mock inside a whenever() chain leaves
+        // Mockito with an unfinished stubbing.
+        val execution = mock<DelegateExecution>()
+        val callingExecutionInstance = processInstance(SUB_PROCESS_INSTANCE_ID, CALLING_ROOT_ID)
+        val roots = listOf(
+            processInstance(CALLING_ROOT_ID, CALLING_ROOT_ID),
+            processInstance(OTHER_ROOT_ID, OTHER_ROOT_ID)
+        )
+        val associations = listOf(
+            processDocumentInstance(CALLING_ROOT_ID),
+            processDocumentInstance(OTHER_ROOT_ID)
+        )
+
+        whenever(execution.businessKey).thenReturn(DOCUMENT_ID)
+        whenever(execution.processInstanceId).thenReturn(SUB_PROCESS_INSTANCE_ID)
+        whenever(operatonProcessService.findProcessInstanceById(SUB_PROCESS_INSTANCE_ID))
+            .thenReturn(Optional.of(callingExecutionInstance))
+        whenever(associationService.findProcessDocumentInstances(any())).thenReturn(associations)
+        whenever(operatonProcessService.findProcessInstancesByIds(setOf(CALLING_ROOT_ID, OTHER_ROOT_ID)))
+            .thenReturn(roots)
+
+        processDocumentsService.deleteAllOtherProcessInstancesForThisDocument(execution, "Case cancelled")
+
+        verify(operatonProcessService).deleteProcessInstanceById(OTHER_ROOT_ID, "Case cancelled")
+        verify(operatonProcessService, never()).deleteProcessInstanceById(eq(CALLING_ROOT_ID), any())
+        verify(operatonProcessService, never()).deleteProcessInstanceById(eq(SUB_PROCESS_INSTANCE_ID), any())
+    }
+
+    @Test
     fun `should delete nothing when the calling process instance cannot be found`() {
         val execution = mock<DelegateExecution>()
         whenever(execution.businessKey).thenReturn(DOCUMENT_ID)
@@ -60,8 +96,25 @@ internal class ProcessDocumentsServiceTest {
         verifyNoInteractions(associationService)
     }
 
+    private fun processInstance(processInstanceId: String, rootProcessInstanceId: String?): ProcessInstance =
+        mock {
+            on { this.id } doReturn processInstanceId
+            on { this.processInstanceId } doReturn processInstanceId
+            on { this.rootProcessInstanceId } doReturn rootProcessInstanceId
+        }
+
+    private fun processDocumentInstance(processInstanceId: String): ProcessDocumentInstance {
+        val id = mock<ProcessDocumentInstanceId> {
+            on { processInstanceId() } doReturn OperatonProcessInstanceId(processInstanceId)
+        }
+        return mock { on { processDocumentInstanceId() } doReturn id }
+    }
+
     companion object {
         private const val DOCUMENT_ID = "11111111-1111-1111-1111-111111111111"
         private const val PROCESS_INSTANCE_ID = "00000000-0000-0000-0000-000000000000"
+        private const val CALLING_ROOT_ID = "22222222-2222-2222-2222-222222222222"
+        private const val SUB_PROCESS_INSTANCE_ID = "33333333-3333-3333-3333-333333333333"
+        private const val OTHER_ROOT_ID = "44444444-4444-4444-4444-444444444444"
     }
 }

--- a/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/ProcessDocumentsServiceTest.kt
+++ b/backend/process-document/src/test/kotlin/com/ritense/processdocument/service/ProcessDocumentsServiceTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processdocument.service
+
+import com.ritense.valtimo.service.OperatonProcessService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.operaton.bpm.engine.delegate.DelegateExecution
+import java.util.Optional
+
+internal class ProcessDocumentsServiceTest {
+
+    lateinit var operatonProcessService: OperatonProcessService
+    lateinit var associationService: ProcessDocumentAssociationService
+    lateinit var processDocumentsService: ProcessDocumentsService
+
+    @BeforeEach
+    fun beforeEach() {
+        operatonProcessService = mock()
+        associationService = mock()
+        processDocumentsService = ProcessDocumentsService(
+            mock(),
+            operatonProcessService,
+            associationService,
+            mock(),
+            mock(),
+        )
+    }
+
+    @Test
+    fun `should delete nothing when the calling process instance cannot be found`() {
+        val execution = mock<DelegateExecution>()
+        whenever(execution.businessKey).thenReturn(DOCUMENT_ID)
+        whenever(execution.processInstanceId).thenReturn(PROCESS_INSTANCE_ID)
+        whenever(operatonProcessService.findProcessInstanceById(PROCESS_INSTANCE_ID)).thenReturn(Optional.empty())
+
+        processDocumentsService.deleteAllOtherProcessInstancesForThisDocument(execution, "Case cancelled")
+
+        verify(operatonProcessService, never()).deleteProcessInstanceById(any(), any())
+        verifyNoInteractions(associationService)
+    }
+
+    companion object {
+        private const val DOCUMENT_ID = "11111111-1111-1111-1111-111111111111"
+        private const val PROCESS_INSTANCE_ID = "00000000-0000-0000-0000-000000000000"
+    }
+}

--- a/backend/process-document/src/test/resources/config/case/house/1-0-0/bpmn/delete-other-processes.bpmn
+++ b/backend/process-document/src/test/resources/config/case/house/1-0-0/bpmn/delete-other-processes.bpmn
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0oth3rp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="delete-other-processes" name="delete other processes" isExecutable="true">
+    <bpmn:startEvent id="start_event_id" name="start_event_name">
+      <bpmn:outgoing>Flow_1bxegcf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1bxegcf" sourceRef="start_event_id" targetRef="StartChildProcess" />
+    <bpmn:intermediateThrowEvent id="StartChildProcess" name="Start child process">
+      <bpmn:incoming>Flow_1bxegcf</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ot55vv</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0oth3rp" camunda:expression="${correlationService.sendStartMessage(&#34;START_CHILD_PROCESS&#34;,execution.businessKey)}" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0ot55vv" sourceRef="StartChildProcess" targetRef="TriggerTask" />
+    <bpmn:userTask id="TriggerTask" name="trigger delete other processes" camunda:candidateGroups="ROLE_USER">
+      <bpmn:incoming>Flow_0ot55vv</bpmn:incoming>
+      <bpmn:outgoing>Flow_1uhzsxo</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1uhzsxo" sourceRef="TriggerTask" targetRef="delete-other-processes-activity" />
+    <bpmn:serviceTask id="delete-other-processes-activity" name="Delete other processes" camunda:expression="${processService.deleteAllOtherProcessInstancesForThisDocument(execution,&#34;Test deletion process&#34;)}">
+      <bpmn:incoming>Flow_1uhzsxo</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vsuf63</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0vsuf63" sourceRef="delete-other-processes-activity" targetRef="UserTask" />
+    <bpmn:userTask id="UserTask" name="delete other processes user task" camunda:candidateGroups="ROLE_USER">
+      <bpmn:incoming>Flow_0vsuf63</bpmn:incoming>
+      <bpmn:outgoing>Flow_0q496wa</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0q496wa" sourceRef="UserTask" targetRef="Event_1jj68wa" />
+    <bpmn:endEvent id="Event_1jj68wa">
+      <bpmn:incoming>Flow_0q496wa</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="delete-other-processes">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start_event_id">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="153" y="142" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dxtltt_di" bpmnElement="StartChildProcess">
+        <dc:Bounds x="272" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="266" y="142" width="49" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1trgg3r_di" bpmnElement="TriggerTask">
+        <dc:Bounds x="360" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xck9ge_di" bpmnElement="delete-other-processes-activity">
+        <dc:Bounds x="510" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0qaiqaf_di" bpmnElement="UserTask">
+        <dc:Bounds x="660" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1jj68wa_di" bpmnElement="Event_1jj68wa">
+        <dc:Bounds x="812" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1bxegcf_di" bpmnElement="Flow_1bxegcf">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="272" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ot55vv_di" bpmnElement="Flow_0ot55vv">
+        <di:waypoint x="308" y="117" />
+        <di:waypoint x="360" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uhzsxo_di" bpmnElement="Flow_1uhzsxo">
+        <di:waypoint x="460" y="117" />
+        <di:waypoint x="510" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vsuf63_di" bpmnElement="Flow_0vsuf63">
+        <di:waypoint x="610" y="117" />
+        <di:waypoint x="660" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q496wa_di" bpmnElement="Flow_0q496wa">
+        <di:waypoint x="760" y="117" />
+        <di:waypoint x="812" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/backend/process-document/src/test/resources/config/case/house/1-0-0/process-document-link/house.process-document-link.json
+++ b/backend/process-document/src/test/resources/config/case/house/1-0-0/process-document-link/house.process-document-link.json
@@ -43,5 +43,10 @@
         "processDefinitionKey" : "delete-processes",
         "canInitializeDocument" : true,
         "startableByUser" : true
+    },
+    {
+        "processDefinitionKey" : "delete-other-processes",
+        "canInitializeDocument" : true,
+        "startableByUser" : true
     }
 ]

--- a/documentation/release-notes/13.x.x/13.45.0/README.md
+++ b/documentation/release-notes/13.x.x/13.45.0/README.md
@@ -33,6 +33,10 @@ The setting that could block changes to system processes no longer has any effec
 
 Admin > Other > Process migration has the standard Valtimo look and feel, with clearer labels for the source and target process, the versions, and the activities to map.
 
+### Stop the other processes of a case and carry on
+
+A process can now stop all other running processes of its case and then continue its own flow, so a rejection can clear the remaining work and still set a status or send a letter. It sits in the expression dropdown in the BPMN modeler next to the existing option, which stops every process of the case including the one that asks.
+
 ---
 
 ## Bugfixes


### PR DESCRIPTION
https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/831

## Bug

A process could stop all running processes of its case, but that included the process doing the
asking — so a rejection branch could not clear the remaining work and then still set a status or
send a letter.

## Fix

A process can now stop only the *other* running processes of its case and carry on with its own
flow. Both options appear in the expression dropdown in the BPMN modeller.
